### PR TITLE
update to base v0.11

### DIFF
--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -9,11 +9,11 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "base"                    {>= "v0.10.0"}
+  "base"                    {>= "v0.11.0"}
   "jbuilder"                {build & >= "1.0+beta18.1"}
-  "ocaml-compiler-libs"     {>= "v0.10.0"}
+  "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "1.0"}
   "ppx_derivers"            {>= "1.0"}
-  "stdio"                   {>= "v0.10.0"}
+  "stdio"                   {>= "v0.11.0"}
 ]
 available: [ ocaml-version >= "4.04.1" ]

--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -298,13 +298,13 @@ let rev_concat = function
 ;;
 
 let sort_attr_group_inline l =
-  List.sort l ~cmp:(fun a b ->
+  List.sort l ~compare:(fun a b ->
     String.compare
       (Rule.Attr_group_inline.attr_name a)
       (Rule.Attr_group_inline.attr_name b))
 
 let sort_attr_inline l =
-  List.sort l ~cmp:(fun a b ->
+  List.sort l ~compare:(fun a b ->
     String.compare
       (Rule.Attr_inline.attr_name a)
       (Rule.Attr_inline.attr_name b))

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -328,7 +328,7 @@ module Deriver = struct
           None)
     in
     (* Set of actual deriver names *)
-    let seen = Hash_set.create (module String) () in
+    let seen = Hash_set.create (module String) in
     List.map derivers_and_args ~f:(fun (name, args) ->
       let named_generators = resolve field name in
       List.iter named_generators ~f:(fun (actual_deriver_name, gen) ->

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -317,7 +317,7 @@ let get_whole_ast_passes ~hook ~expect_mismatch_handler =
           | None -> None
           | Some x -> Some (ct.name, x))
         (* Sort them to ensure deterministic ordering *)
-        |> List.sort ~cmp:(fun (a, _) (b, _) -> String.compare a b)
+        |> List.sort ~compare:(fun (a, _) (b, _) -> String.compare a b)
         |> List.map ~f:snd
       in
 
@@ -865,7 +865,7 @@ let process_file (kind : Kind.t) fn ~input_name ~output_mode ~embed_errors ~outp
       Out_channel.write_all fn
         ~data:(
           List.map metadata ~f:(fun (s, sexp) ->
-            Sexp.to_string_hum (List [Atom s; sexp]) ^ "\n")
+            Sexp.to_string_hum (Sexp.List [Atom s; sexp]) ^ "\n")
           |> String.concat ~sep:""));
 
     let input_contents = lazy (load_source_file fn) in

--- a/src/name.ml
+++ b/src/name.ml
@@ -134,7 +134,7 @@ module Whitelisted = struct
 end
 
 module Reserved_namespaces = struct
-  let tbl : (string, unit) Hashtbl.t = Hashtbl.create (module String) ()
+  let tbl : (string, unit) Hashtbl.t = Hashtbl.create (module String)
 
   let reserve ns = Hashtbl.add_exn tbl ~key:ns ~data:()
 
@@ -257,7 +257,7 @@ module Registrar = struct
           Format.fprintf ppf "@ but@ is@ used@ here@ in@ the@ context@ of@ %s@ %a"
             a_or_an pp_text s
       in
-      match List.sort ~cmp:(fun x y -> - (String.compare x y)) other_contexts with
+      match List.sort ~compare:(fun x y -> - (String.compare x y)) other_contexts with
       | [] -> None
       | [c] ->
         Some

--- a/src/reconcile.ml
+++ b/src/reconcile.ml
@@ -101,7 +101,7 @@ module Replacements = struct
            It is too complicated to reconcile it with the source";
       assert (repl.start.pos_cnum <= repl.stop.pos_cnum));
     let repls =
-      List.sort repls ~cmp:(fun  a b ->
+      List.sort repls ~compare:(fun  a b ->
         let d = compare a.start.pos_cnum b.stop.pos_cnum in
         if d = 0 then
           (* Put the largest first, so that the following [filter] functions always picks up

--- a/test/driver/test.mlt
+++ b/test/driver/test.mlt
@@ -77,7 +77,7 @@ let lint = object
     match td.ptype_kind with
     | Ptype_record lds ->
       if Poly.(<>)
-           (List.sort lds ~cmp:(fun a b -> String.compare a.pld_name.txt b.pld_name.txt))
+           (List.sort lds ~compare:(fun a b -> String.compare a.pld_name.txt b.pld_name.txt))
            lds
       then
         Driver.Lint_error.of_string td.ptype_loc


### PR DESCRIPTION
I also updated the dep on stdio and ocaml-compiler-libs even though these stayed compatible. Seems easier to keep these numbers synchronized.

This should be merged once https://github.com/ocaml/opam-repository/pull/11591 is.