### PR TITLE
Prevent cookies set from the command line from disappearing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 - Make sure to import command line arguments registered with
   ocaml-migrate-parsetree
 
+- Fix an issue where cookies set from the command line sometimes
+  disappeared
+
 0.1.0
 -----
 

--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -12,7 +12,7 @@ depends: [
   "base"                    {>= "v0.11.0"}
   "jbuilder"                {build & >= "1.0+beta18.1"}
   "ocaml-compiler-libs"     {>= "v0.11.0"}
-  "ocaml-migrate-parsetree" {>= "1.0.8"}
+  "ocaml-migrate-parsetree" {>= "1.0.9"}
   "ppx_derivers"            {>= "1.0"}
   "stdio"                   {>= "v0.11.0"}
 ]

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -1051,8 +1051,8 @@ let set_cookie s =
       ; pos_cnum  = 0
       };
     let expr = Parse.expression lexbuf in
-    Ocaml_common.Ast_mapper.set_cookie name
-      (Ppxlib_ast.Selected_ast.to_ocaml Expression expr)
+    Migrate_parsetree.Driver.set_global_cookie name
+      (module Ppx_ast.Selected_ast) expr
 
 let as_pp () =
   set_output_mode Dump_ast;


### PR DESCRIPTION
Similar fix to https://github.com/ocaml-ppx/ocaml-migrate-parsetree/pull/41