### PR TITLE
Remove references to type_conv (continued)

### DIFF
--- a/ast/jbuild
+++ b/ast/jbuild
@@ -18,7 +18,7 @@
             ppxlib_ast
             syntaxerr
             warn))
-  (lint (pps (ppxlib_traverse -type-conv-keep-w32=impl)))
+  (lint (pps (ppxlib_traverse -deriving-keep-w32=impl)))
   (preprocess no_preprocessing)))
 
 (ocamllex  (lexer))

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -30,7 +30,7 @@ let () =
   Driver.add_arg "-deriving-keep-w32"
     keep_w32_spec
     ~doc:" Do not try to disable warning 32 for the generated code";
-  Driver.add_arg "-deriving-w32"
+  Driver.add_arg "-deriving-disable-w32-method"
     conv_w32_spec
     ~doc:" How to disable warning 32 for the generated code";
   Driver.add_arg "-type-conv-keep-w32"
@@ -38,7 +38,7 @@ let () =
     ~doc:" Deprecated, use -deriving-keep-w32";
   Driver.add_arg "-type-conv-w32"
     conv_w32_spec
-    ~doc:" Deprecated, use -deriving-w32"
+    ~doc:" Deprecated, use -deriving-disable-w32-method"
 
 let keep_w32_impl () = !keep_w32_impl || Driver.pretty ()
 let keep_w32_intf () = !keep_w32_intf || Driver.pretty ()

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -674,43 +674,5 @@ let () =
            ; Context_free.Rule.attr_sig_exception_expect
                Attr.Expect.ec
                expand_sig_exception
-
-           (* equivalent but deprecated attributes *)
-           ; Context_free.Rule.attr_str_type_decl
-               Attr.td_depr
-               expand_str_type_decls
-           ; Context_free.Rule.attr_sig_type_decl
-               Attr.td_depr
-               expand_sig_type_decls
-           ; Context_free.Rule.attr_str_type_ext
-               Attr.te_depr
-               expand_str_type_ext
-           ; Context_free.Rule.attr_sig_type_ext
-               Attr.te_depr
-               expand_sig_type_ext
-           ; Context_free.Rule.attr_str_exception
-               Attr.ec_depr
-               expand_str_exception
-           ; Context_free.Rule.attr_sig_exception
-               Attr.ec_depr
-               expand_sig_exception
-           ; Context_free.Rule.attr_str_type_decl_expect
-               Attr.Expect.td_depr
-               expand_str_type_decls
-           ; Context_free.Rule.attr_sig_type_decl_expect
-               Attr.Expect.td_depr
-               expand_sig_type_decls
-           ; Context_free.Rule.attr_str_type_ext_expect
-               Attr.Expect.te_depr
-               expand_str_type_ext
-           ; Context_free.Rule.attr_sig_type_ext_expect
-               Attr.Expect.te_depr
-               expand_sig_type_ext
-           ; Context_free.Rule.attr_str_exception_expect
-               Attr.Expect.ec_depr
-               expand_str_exception
-           ; Context_free.Rule.attr_sig_exception_expect
-               Attr.Expect.ec_depr
-               expand_sig_exception
            ]
 ;;

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -8,25 +8,37 @@ let do_insert_unused_warning_attribute = ref false
 let keep_w32_impl = ref false
 let keep_w32_intf = ref false
 let () =
-  Driver.add_arg "-type-conv-keep-w32"
-    (Symbol
-       (["impl"; "intf"; "both"],
-        (function
-          | "impl" -> keep_w32_impl := true
-          | "intf" -> keep_w32_intf := true
-          | "both" ->
-            keep_w32_impl := true;
-            keep_w32_intf := true
-          | _ -> assert false)))
+  let keep_w32_spec =
+    Caml.Arg.Symbol
+      (["impl"; "intf"; "both"],
+       (function
+         | "impl" -> keep_w32_impl := true
+         | "intf" -> keep_w32_intf := true
+         | "both" ->
+           keep_w32_impl := true;
+           keep_w32_intf := true
+         | _ -> assert false))
+  in
+  let conv_w32_spec =
+    Caml.Arg.Symbol
+      (["code"; "attribute"],
+       (function
+         | "code"      -> do_insert_unused_warning_attribute := false
+         | "attribute" -> do_insert_unused_warning_attribute := true
+         | _           -> assert false))
+  in
+  Driver.add_arg "-deriving-keep-w32"
+    keep_w32_spec
     ~doc:" Do not try to disable warning 32 for the generated code";
+  Driver.add_arg "-deriving-w32"
+    conv_w32_spec
+    ~doc:" How to disable warning 32 for the generated code";
+  Driver.add_arg "-type-conv-keep-w32"
+    keep_w32_spec
+    ~doc:" Deprecated, use -deriving-keep-w32";
   Driver.add_arg "-type-conv-w32"
-    (Symbol
-       (["code"; "attribute"],
-        (function
-          | "code"      -> do_insert_unused_warning_attribute := false
-          | "attribute" -> do_insert_unused_warning_attribute := true
-          | _           -> assert false)))
-    ~doc:" How to disable warning 32 for the generated code"
+    conv_w32_spec
+    ~doc:" Deprecated, use -deriving-w32"
 
 let keep_w32_impl () = !keep_w32_impl || Driver.pretty ()
 let keep_w32_intf () = !keep_w32_intf || Driver.pretty ()

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -494,18 +494,18 @@ module Attr = struct
   let td = mk_deriving_attr ~prefix:"ppxlib." ~suffix Type_declaration
   let te = mk_deriving_attr ~prefix:"ppxlib." ~suffix Type_extension
   let ec = mk_deriving_attr ~prefix:"ppxlib." ~suffix Extension_constructor
-  let td_depr = mk_deriving_attr ~prefix:"type_conv." ~suffix Type_declaration
-  let te_depr = mk_deriving_attr ~prefix:"type_conv." ~suffix Type_extension
-  let ec_depr = mk_deriving_attr ~prefix:"type_conv." ~suffix Extension_constructor
+  let _td_depr = mk_deriving_attr ~prefix:"type_conv." ~suffix Type_declaration
+  let _te_depr = mk_deriving_attr ~prefix:"type_conv." ~suffix Type_extension
+  let _ec_depr = mk_deriving_attr ~prefix:"type_conv." ~suffix Extension_constructor
 
   module Expect = struct
     let suffix = "_inline"
     let td = mk_deriving_attr ~prefix:"ppxlib." ~suffix Type_declaration
     let te = mk_deriving_attr ~prefix:"ppxlib." ~suffix Type_extension
     let ec = mk_deriving_attr ~prefix:"ppxlib." ~suffix Extension_constructor
-    let td_depr = mk_deriving_attr ~prefix:"type_conv." ~suffix Type_declaration
-    let te_depr = mk_deriving_attr ~prefix:"type_conv." ~suffix Type_extension
-    let ec_depr = mk_deriving_attr ~prefix:"type_conv." ~suffix Extension_constructor
+    let _td_depr = mk_deriving_attr ~prefix:"type_conv." ~suffix Type_declaration
+    let _te_depr = mk_deriving_attr ~prefix:"type_conv." ~suffix Type_extension
+    let _ec_depr = mk_deriving_attr ~prefix:"type_conv." ~suffix Extension_constructor
   end
 end
 

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -634,8 +634,8 @@ let expand_sig_type_ext ~loc ~path te generators =
   disable_unused_warning_sig ~loc generated
 
 let () =
-  Driver.register_transformation "type_conv"
-    ~aliases:["deriving"]
+  Driver.register_transformation "deriving"
+    ~aliases:["type_conv"]
     ~rules:[ Context_free.Rule.attr_str_type_decl
                Attr.td
                expand_str_type_decls

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -494,18 +494,12 @@ module Attr = struct
   let td = mk_deriving_attr ~prefix:"ppxlib." ~suffix Type_declaration
   let te = mk_deriving_attr ~prefix:"ppxlib." ~suffix Type_extension
   let ec = mk_deriving_attr ~prefix:"ppxlib." ~suffix Extension_constructor
-  let _td_depr = mk_deriving_attr ~prefix:"type_conv." ~suffix Type_declaration
-  let _te_depr = mk_deriving_attr ~prefix:"type_conv." ~suffix Type_extension
-  let _ec_depr = mk_deriving_attr ~prefix:"type_conv." ~suffix Extension_constructor
 
   module Expect = struct
     let suffix = "_inline"
     let td = mk_deriving_attr ~prefix:"ppxlib." ~suffix Type_declaration
     let te = mk_deriving_attr ~prefix:"ppxlib." ~suffix Type_extension
     let ec = mk_deriving_attr ~prefix:"ppxlib." ~suffix Extension_constructor
-    let _td_depr = mk_deriving_attr ~prefix:"type_conv." ~suffix Type_declaration
-    let _te_depr = mk_deriving_attr ~prefix:"type_conv." ~suffix Type_extension
-    let _ec_depr = mk_deriving_attr ~prefix:"type_conv." ~suffix Extension_constructor
   end
 end
 

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -60,6 +60,7 @@ end
 module Transform = struct
   type t =
     { name            : string
+    ; aliases         : string list
     ; impl            : (Parsetree.structure -> Parsetree.structure) option
     ; intf            : (Parsetree.signature -> Parsetree.signature) option
     ; lint_impl       : (Parsetree.structure -> Lint_error.t list) option
@@ -72,6 +73,9 @@ module Transform = struct
     ; registered_at   : Caller_id.t
     }
 
+  let has_name t name =
+    (String.equal name t.name) || (List.exists ~f:(String.equal name) t.aliases)
+
   let all : t list ref = ref []
 
   let print_caller_id oc (caller_id : Caller_id.t) =
@@ -81,12 +85,13 @@ module Transform = struct
   ;;
 
   let register ?(extensions=[]) ?(rules=[]) ?enclose_impl ?enclose_intf
-        ?impl ?intf ?lint_impl ?lint_intf ?preprocess_impl ?preprocess_intf name =
+        ?impl ?intf ?lint_impl ?lint_intf ?preprocess_impl ?preprocess_intf
+        ?(aliases=[]) name =
     let rules =
       List.map extensions ~f:Context_free.Rule.extension @ rules
     in
     let caller_id = Caller_id.get ~skip:[Caml.__FILE__] in
-    begin match List.filter !all ~f:(fun ct -> String.equal ct.name name) with
+    begin match List.filter !all ~f:(fun ct -> has_name ct name) with
     | [] -> ()
     | ct :: _ ->
       eprintf "Warning: code transformation %s registered twice.\n" name;
@@ -95,6 +100,7 @@ module Transform = struct
     end;
     let ct =
       { name
+      ; aliases
       ; rules
       ; enclose_impl
       ; enclose_intf
@@ -200,6 +206,7 @@ module Transform = struct
   let builtin_of_context_free_rewriters ~hook ~rules ~enclose_impl ~enclose_intf =
     merge_into_generic_mappers ~hook
       { name = "<builtin:context-free>"
+      ; aliases = []
       ; impl = None
       ; intf = None
       ; lint_impl = None
@@ -218,6 +225,7 @@ module Transform = struct
           if Option.is_some t.lint_impl || Option.is_some t.lint_intf then
             Some
               { name = Printf.sprintf "<lint:%s>" t.name
+              ; aliases = []
               ; impl = None
               ; intf = None
               ; lint_impl = t.lint_impl
@@ -237,6 +245,7 @@ module Transform = struct
           then
             Some
               { name = Printf.sprintf "<preprocess:%s>" t.name
+              ; aliases = []
               ; impl = t.preprocess_impl
               ; intf = t.preprocess_intf
               ; lint_impl = None
@@ -262,14 +271,14 @@ end
 
 let register_transformation = Transform.register
 
-let register_code_transformation ~name ~impl ~intf =
-  register_transformation name ~impl ~intf
+let register_code_transformation ~name ?(aliases=[]) ~impl ~intf =
+  register_transformation name ~impl ~intf ~aliases
 ;;
 
-let register_transformation_using_ocaml_current_ast  ?impl ?intf name =
+let register_transformation_using_ocaml_current_ast ?impl ?intf ?aliases name =
   let impl = Option.map impl ~f:(Ppxlib_ast.Selected_ast.of_ocaml_mapper Structure) in
   let intf = Option.map intf ~f:(Ppxlib_ast.Selected_ast.of_ocaml_mapper Signature) in
-  register_transformation ?impl ?intf name
+  register_transformation ?impl ?intf ?aliases name
 
 let debug_dropped_attribute name ~old_dropped ~new_dropped =
   let print_diff what a b =
@@ -296,7 +305,7 @@ let get_whole_ast_passes ~hook ~expect_mismatch_handler =
     | Some names ->
       List.map names ~f:(fun name ->
         List.find_exn !Transform.all ~f:(fun (ct : Transform.t) ->
-          String.equal ct.name name))
+          Transform.has_name ct name))
   in
   let (`Linters linters, `Preprocess preprocess, `Rest cts) =
     Transform.partition_transformations cts in
@@ -973,7 +982,7 @@ let parse_apply_list s =
   let names = if String.equal s "" then [] else String.split s ~on:',' in
   List.iter names ~f:(fun name ->
     if not (List.exists !Transform.all ~f:(fun (ct : Transform.t) ->
-      String.equal ct.name name)) then
+      Transform.has_name ct name)) then
       raise (Caml.Arg.Bad (Printf.sprintf "code transformation '%s' does not exist" name)));
   names
 

--- a/src/driver.mli
+++ b/src/driver.mli
@@ -95,6 +95,7 @@ val register_transformation
   -> ?lint_intf        : (signature -> Lint_error.t list)
   -> ?preprocess_impl  : (structure -> structure)
   -> ?preprocess_intf  : (signature -> signature)
+  -> ?aliases          : string list
   -> string
   -> unit
 
@@ -110,6 +111,7 @@ val register_transformation_using_ocaml_current_ast
               Migrate_parsetree.OCaml_current.Ast.Parsetree.structure)
   -> ?intf : (Migrate_parsetree.OCaml_current.Ast.Parsetree.signature ->
               Migrate_parsetree.OCaml_current.Ast.Parsetree.signature)
+  -> ?aliases : string list
   -> string
   -> unit
 
@@ -125,6 +127,7 @@ val register_transformation_using_ocaml_current_ast
 *)
 val register_code_transformation
   :  name:string
+  -> ?aliases:string list
   -> impl:(structure -> structure)
   -> intf:(signature -> signature)
   -> unit

--- a/test/traverse/jbuild
+++ b/test/traverse/jbuild
@@ -1,6 +1,6 @@
 (library
  ((name ppxlib_traverse_test)
   (flags (:standard -safe-string))
-  (preprocess (pps (ppx_inline_test ppxlib_traverse -type-conv-keep-w32=impl ppxlib.runner)))))
+  (preprocess (pps (ppx_inline_test ppxlib_traverse -deriving-keep-w32=impl ppxlib.runner)))))
 
 (jbuild_version 1)

--- a/test/type-conv/jbuild
+++ b/test/type-conv/jbuild
@@ -6,6 +6,6 @@
                     ppx_sexp_conv
                     ppx_compare
                     ppx_bin_prot
-                    -type-conv-keep-w32=both ppxlib.runner)))))
+                    -deriving-keep-w32=both ppxlib.runner)))))
 
 (jbuild_version 1)


### PR DESCRIPTION
(Basically a follow-up to https://github.com/ocaml-ppx/ppxlib/pull/7.)

We might want to factor out some parts dealing with attributes/transforms,
but I am not sure it is worth the trouble.