### PR TITLE
Use "relative" line numbers in expect tests

### DIFF
--- a/test/base/test_name.ml
+++ b/test/base/test_name.ml
@@ -17,7 +17,7 @@ let dot_suffixes name =
     (Sexp.to_string_hum
        (List.sexp_of_t String.sexp_of_t (N.dot_suffixes name)))
 [%%expect{|
-val dot_suffixes : Ppxlib__.Import.string -> string = <fun>
+val dot_suffixes : string -> string = <fun>
 |}]
 
 let _ = dot_suffixes "foo.bar.baz"
@@ -37,7 +37,7 @@ let split_path name =
       (Sexp.to_string_hum
          (List [sexp_of_string a; Option.sexp_of_t sexp_of_string b]))
 [%%expect{|
-val split_path : Ppxlib__.Import.string -> string = <fun>
+val split_path : string -> string = <fun>
 |}]
 
 let _ = split_path "a.b.c"

--- a/test/deriving/test.ml
+++ b/test/deriving/test.ml
@@ -25,13 +25,13 @@ val bar : Deriving.t = <abstr>
 
 type t = int [@@deriving bar]
 [%%expect{|
-File "test/deriving/test.ml", line 26, characters 25-28:
+File "test/deriving/test.ml", line 2, characters 25-28:
 Error: Deriver foo is needed for bar, you need to add it before in the list
 |}]
 
 type t = int [@@deriving bar, foo]
 [%%expect{|
-File "test/deriving/test.ml", line 32, characters 25-33:
+File "test/deriving/test.ml", line 2, characters 25-33:
 Error: Deriver foo is needed for bar, you need to add it before in the list
 |}]
 

--- a/test/deriving/test.ml
+++ b/test/deriving/test.ml
@@ -11,7 +11,7 @@ let foo =
     ~str_type_decl:(Deriving.Generator.make_noarg
                       (fun ~loc ~path:_ _ -> [%str let x = 42]))
 [%%expect{|
-val foo : Ppxlib.Deriving.t = <abstr>
+val foo : Deriving.t = <abstr>
 |}]
 
 let bar =
@@ -20,7 +20,7 @@ let bar =
                       ~deps:[foo]
                       (fun ~loc ~path:_ _ -> [%str let () = Printf.printf "x = %d\n" x]))
 [%%expect{|
-val bar : Ppxlib.Deriving.t = <abstr>
+val bar : Deriving.t = <abstr>
 |}]
 
 type t = int [@@deriving bar]

--- a/test/driver/attributes/test.ml
+++ b/test/driver/attributes/test.ml
@@ -14,7 +14,7 @@ Error: Attribute `foo' was not used
 
 let f x = 1 [@@deprecatd "..."]
 [%%expect{|
-File "test/driver/attributes/test.ml", line 15, characters 15-24:
+File "test/driver/attributes/test.ml", line 2, characters 15-24:
 Error: Attribute `deprecatd' was not used.
 Hint: Did you mean deprecated?
 |}]
@@ -30,7 +30,7 @@ val attr : (type_declaration, unit) Attribute.t = <abstr>
 
 type t = int [@blah]
 [%%expect{|
-File "test/driver/attributes/test.ml", line 31, characters 15-19:
+File "test/driver/attributes/test.ml", line 2, characters 15-19:
 Error: Attribute `blah' was not used.
 Hint: `blah' is available for type declarations but is used here in the
 context of a core type.
@@ -48,7 +48,7 @@ val attr : (expression, unit) Attribute.t = <abstr>
 
 type t = int [@blah]
 [%%expect{|
-File "test/driver/attributes/test.ml", line 49, characters 15-19:
+File "test/driver/attributes/test.ml", line 2, characters 15-19:
 Error: Attribute `blah' was not used.
 Hint: `blah' is available for expressions and type declarations but is used
 here in the context of a core type.
@@ -75,6 +75,6 @@ let () =
 
 let x = (42 [@foo])
 [%%expect{|
-File "test/driver/attributes/test.ml", line 76, characters 14-17:
+File "test/driver/attributes/test.ml", line 5, characters 14-17:
 Error: Attribute `foo' was silently dropped
 |}]

--- a/test/driver/attributes/test.ml
+++ b/test/driver/attributes/test.ml
@@ -25,13 +25,12 @@ let attr : _ Attribute.t =
     Ast_pattern.(__)
     ignore
 [%%expect{|
-val attr : (Ppxlib__.Import.type_declaration, Base.unit) Ppxlib.Attribute.t =
-  <abstr>
+val attr : (type_declaration, unit) Attribute.t = <abstr>
 |}]
 
 type t = int [@blah]
 [%%expect{|
-File "test/driver/attributes/test.ml", line 32, characters 15-19:
+File "test/driver/attributes/test.ml", line 31, characters 15-19:
 Error: Attribute `blah' was not used.
 Hint: `blah' is available for type declarations but is used here in the
 context of a core type.
@@ -44,13 +43,12 @@ let attr : _ Attribute.t =
     Ast_pattern.(__)
     ignore
 [%%expect{|
-val attr : (Ppxlib__.Import.expression, Base.unit) Ppxlib.Attribute.t =
-  <abstr>
+val attr : (expression, unit) Attribute.t = <abstr>
 |}]
 
 type t = int [@blah]
 [%%expect{|
-File "test/driver/attributes/test.ml", line 51, characters 15-19:
+File "test/driver/attributes/test.ml", line 49, characters 15-19:
 Error: Attribute `blah' was not used.
 Hint: `blah' is available for expressions and type declarations but is used
 here in the context of a core type.
@@ -69,7 +67,7 @@ let faulty_transformation = object
     | _ -> super#expression e
 end
 [%%expect{|
-val faulty_transformation : Ppxlib.Ast_traverse.map = <obj>
+val faulty_transformation : Ast_traverse.map = <obj>
 |}]
 
 let () =
@@ -77,6 +75,6 @@ let () =
 
 let x = (42 [@foo])
 [%%expect{|
-File "test/driver/attributes/test.ml", line 78, characters 14-17:
+File "test/driver/attributes/test.ml", line 76, characters 14-17:
 Error: Attribute `foo' was silently dropped
 |}]

--- a/test/driver/non-compressible-suffix/test.ml
+++ b/test/driver/non-compressible-suffix/test.ml
@@ -34,6 +34,6 @@ Driver.register_transformation "blah"
 
 [%bar];;
 [%%expect{|
-File "test/driver/non-compressible-suffix/test.ml", line 35, characters 2-5:
+File "test/driver/non-compressible-suffix/test.ml", line 2, characters 2-5:
 Error: Uninterpreted extension 'bar'.
 |}]

--- a/test/driver/non-compressible-suffix/test.ml
+++ b/test/driver/non-compressible-suffix/test.ml
@@ -19,7 +19,7 @@ Driver.register_transformation "blah"
          ]
 ;;
 [%%expect{|
-- : Ppxlib__.Import.unit = ()
+- : unit = ()
 |}]
 
 [%foo];;

--- a/test/driver/transformations/test.ml
+++ b/test/driver/transformations/test.ml
@@ -37,7 +37,7 @@ type t =
   ; a : int
   }
 [%%expect{|
-File "test/driver/transformations/test.ml", line 35, characters 0-36:
+File "test/driver/transformations/test.ml", line 2, characters 0-36:
 Warning 22: Fields are not sorted!
 type t = { b : int; a : int; }
 |}]

--- a/test/driver/transformations/test.ml
+++ b/test/driver/transformations/test.ml
@@ -29,8 +29,7 @@ end
 let () =
   Driver.register_transformation "lint" ~lint_impl:(fun st -> lint#structure st [])
 [%%expect{|
-val lint : Ppxlib.Driver.Lint_error.t Base.list Ppxlib.Ast_traverse.fold =
-  <obj>
+val lint : Driver.Lint_error.t list Ast_traverse.fold = <obj>
 |}]
 
 type t =
@@ -38,9 +37,9 @@ type t =
   ; a : int
   }
 [%%expect{|
-File "test/driver/transformations/test.ml", line 36, characters 0-36:
+File "test/driver/transformations/test.ml", line 35, characters 0-36:
 Warning 22: Fields are not sorted!
-type t = { b : Base.int; a : Base.int; }
+type t = { b : int; a : int; }
 |}]
 
 

--- a/test/expect/expect_test.mll
+++ b/test/expect/expect_test.mll
@@ -98,7 +98,7 @@ let main () =
     List.iter chunks ~f:(fun (pos, s) ->
       Format.fprintf ppf "%s[%%%%expect{|@." s;
       let lexbuf = Lexing.from_string s in
-      lexbuf.lex_curr_p <- pos;
+      lexbuf.lex_curr_p <- { pos with pos_lnum = 1; };
       let phrases = !Toploop.parse_use_file lexbuf in
       List.iter phrases ~f:(fun phr ->
         try


### PR DESCRIPTION
The line numbers are now "relative" to the end of the previous
`%%expect` block (if any, to the beginning of the file otherwise).

It makes tests less fragile; *e.g* adding a test before another
one does no more trigger a renumbering.