### PR TITLE
Add missing -corrected-suffix option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+0.3.0
+-----
+
+- Allow to set the suffix of corrected files
+
 0.2.0
 -----
 

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -23,6 +23,7 @@ let diff_command = ref Options.diff_command
 let pretty = ref false
 let styler = ref None
 let output_metadata_filename = ref None
+let corrected_suffix = ref ".ppx-corrected"
 
 module Lint_error = struct
   type t = Location.t * string
@@ -872,7 +873,7 @@ let process_file (kind : Kind.t) fn ~input_name ~output_mode ~embed_errors ~outp
           |> String.concat ~sep:""));
 
     let input_contents = lazy (load_source_file fn) in
-    let corrected = fn ^ ".ppx-corrected" in
+    let corrected = fn ^ !corrected_suffix in
     let mismatches_found =
       match !corrections with
       | [] ->
@@ -1126,6 +1127,8 @@ let standalone_args =
     " Same as -cookie"
   ; "-output-metadata", Arg.String (fun s -> output_metadata_filename := Some s),
     "FILE Where to store the output metadata"
+  ; "-corrected-suffix", Arg.Set_string corrected_suffix,
+    "SUFFIX Suffix to happend to corrected files"
   ]
 ;;
 


### PR DESCRIPTION
This change was already merged in ppx_driver but it seems to have been lost during the migration to github