### PR TITLE
Restore compatibility with OCaml 4.04.x

### DIFF
--- a/ast/lexer.mll
+++ b/ast/lexer.mll
@@ -99,24 +99,25 @@ let keyword_table =
 ]
 
 module Buffer = struct (* Imported for compatibility with 4.04.x *)
-  include Buffer
+  [@@@warning "-32"]
   let add_utf_8_uchar b u = match Uchar.to_int u with
     | u when u < 0 -> assert false
     | u when u <= 0x007F ->
-      add_char b (Char.unsafe_chr u)
+      Buffer.add_char b (Char.unsafe_chr u)
     | u when u <= 0x07FF ->
-      add_char b (Char.unsafe_chr (0xC0 lor (u lsr 6)));
-      add_char b (Char.unsafe_chr (0x80 lor (u land 0x3F)));
+      Buffer.add_char b (Char.unsafe_chr (0xC0 lor (u lsr 6)));
+      Buffer.add_char b (Char.unsafe_chr (0x80 lor (u land 0x3F)));
     | u when u <= 0xFFFF ->
-      add_char b (Char.unsafe_chr (0xE0 lor (u lsr 12)));
-      add_char b (Char.unsafe_chr (0x80 lor ((u lsr 6) land 0x3F)));
-      add_char b (Char.unsafe_chr (0x80 lor (u land 0x3F)));
+      Buffer.add_char b (Char.unsafe_chr (0xE0 lor (u lsr 12)));
+      Buffer.add_char b (Char.unsafe_chr (0x80 lor ((u lsr 6) land 0x3F)));
+      Buffer.add_char b (Char.unsafe_chr (0x80 lor (u land 0x3F)));
     | u when u <= 0x10FFFF ->
-      add_char b (Char.unsafe_chr (0xF0 lor (u lsr 18)));
-      add_char b (Char.unsafe_chr (0x80 lor ((u lsr 12) land 0x3F)));
-      add_char b (Char.unsafe_chr (0x80 lor ((u lsr 6) land 0x3F)));
-      add_char b (Char.unsafe_chr (0x80 lor (u land 0x3F)));
+      Buffer.add_char b (Char.unsafe_chr (0xF0 lor (u lsr 18)));
+      Buffer.add_char b (Char.unsafe_chr (0x80 lor ((u lsr 12) land 0x3F)));
+      Buffer.add_char b (Char.unsafe_chr (0x80 lor ((u lsr 6) land 0x3F)));
+      Buffer.add_char b (Char.unsafe_chr (0x80 lor (u land 0x3F)));
     | _ -> assert false
+  include Buffer
 end
 
 (* To buffer string literals *)

--- a/ast/lexer.mll
+++ b/ast/lexer.mll
@@ -98,6 +98,27 @@ let keyword_table =
     "asr", INFIXOP4("asr")
 ]
 
+module Buffer = struct (* Imported for compatibility with 4.04.x *)
+  include Buffer
+  let add_utf_8_uchar b u = match Uchar.to_int u with
+    | u when u < 0 -> assert false
+    | u when u <= 0x007F ->
+      add_char b (Char.unsafe_chr u)
+    | u when u <= 0x07FF ->
+      add_char b (Char.unsafe_chr (0xC0 lor (u lsr 6)));
+      add_char b (Char.unsafe_chr (0x80 lor (u land 0x3F)));
+    | u when u <= 0xFFFF ->
+      add_char b (Char.unsafe_chr (0xE0 lor (u lsr 12)));
+      add_char b (Char.unsafe_chr (0x80 lor ((u lsr 6) land 0x3F)));
+      add_char b (Char.unsafe_chr (0x80 lor (u land 0x3F)));
+    | u when u <= 0x10FFFF ->
+      add_char b (Char.unsafe_chr (0xF0 lor (u lsr 18)));
+      add_char b (Char.unsafe_chr (0x80 lor ((u lsr 12) land 0x3F)));
+      add_char b (Char.unsafe_chr (0x80 lor ((u lsr 6) land 0x3F)));
+      add_char b (Char.unsafe_chr (0x80 lor (u land 0x3F)));
+    | _ -> assert false
+end
+
 (* To buffer string literals *)
 
 let string_buffer = Buffer.create 256


### PR DESCRIPTION
In order to restore compatibility with OCaml 4.04.x, this PR
imports a copy of `Buffer.add_utf_8_uchar`. It cannot be a
mere copy/paste because the original implementation is
based on the non-exported type definition of `Buffer.t`.

With this PR, ppxlib can be compiled with 4.04.x. However,
it is noteworthy that tests do not pass because the set of
enabled warnings was different back then (fixable), and
because the heuristic of `-short-path` was different (fixable
by explicitly opening some modules?).