### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @diml @xclerc


### PR DESCRIPTION
This PR adds a `CODEOWNERS` file in order to automatically
add reviewers when a PR is created.