### PR TITLE
Tweak expect tests output

### DIFF
--- a/test/deriving/test.ml
+++ b/test/deriving/test.ml
@@ -25,13 +25,13 @@ val bar : Deriving.t = <abstr>
 
 type t = int [@@deriving bar]
 [%%expect{|
-File "test/deriving/test.ml", line 2, characters 25-28:
+Line _, characters 25-28:
 Error: Deriver foo is needed for bar, you need to add it before in the list
 |}]
 
 type t = int [@@deriving bar, foo]
 [%%expect{|
-File "test/deriving/test.ml", line 2, characters 25-33:
+Line _, characters 25-33:
 Error: Deriver foo is needed for bar, you need to add it before in the list
 |}]
 

--- a/test/driver/attributes/test.ml
+++ b/test/driver/attributes/test.ml
@@ -8,13 +8,13 @@ let () = Driver.enable_checks ()
 
 let x = 1 [@@foo]
 [%%expect{|
-File "test/driver/attributes/test.ml", line 9, characters 13-16:
+Line _, characters 13-16:
 Error: Attribute `foo' was not used
 |}]
 
 let f x = 1 [@@deprecatd "..."]
 [%%expect{|
-File "test/driver/attributes/test.ml", line 2, characters 15-24:
+Line _, characters 15-24:
 Error: Attribute `deprecatd' was not used.
 Hint: Did you mean deprecated?
 |}]
@@ -30,7 +30,7 @@ val attr : (type_declaration, unit) Attribute.t = <abstr>
 
 type t = int [@blah]
 [%%expect{|
-File "test/driver/attributes/test.ml", line 2, characters 15-19:
+Line _, characters 15-19:
 Error: Attribute `blah' was not used.
 Hint: `blah' is available for type declarations but is used here in the
 context of a core type.
@@ -48,7 +48,7 @@ val attr : (expression, unit) Attribute.t = <abstr>
 
 type t = int [@blah]
 [%%expect{|
-File "test/driver/attributes/test.ml", line 2, characters 15-19:
+Line _, characters 15-19:
 Error: Attribute `blah' was not used.
 Hint: `blah' is available for expressions and type declarations but is used
 here in the context of a core type.
@@ -75,6 +75,6 @@ let () =
 
 let x = (42 [@foo])
 [%%expect{|
-File "test/driver/attributes/test.ml", line 5, characters 14-17:
+Line _, characters 14-17:
 Error: Attribute `foo' was silently dropped
 |}]

--- a/test/driver/non-compressible-suffix/test.ml
+++ b/test/driver/non-compressible-suffix/test.ml
@@ -34,6 +34,6 @@ Driver.register_transformation "blah"
 
 [%bar];;
 [%%expect{|
-File "test/driver/non-compressible-suffix/test.ml", line 2, characters 2-5:
+Line _, characters 2-5:
 Error: Uninterpreted extension 'bar'.
 |}]

--- a/test/driver/transformations/test.ml
+++ b/test/driver/transformations/test.ml
@@ -37,9 +37,8 @@ type t =
   ; a : int
   }
 [%%expect{|
-File "test/driver/transformations/test.ml", line 2, characters 0-36:
-Warning 22: Fields are not sorted!
-type t = { b : int; a : int; }
+Line _, characters 0-3:
+Error (warning 22): Fields are not sorted!
 |}]
 
 

--- a/test/driver/transformations/test.ml
+++ b/test/driver/transformations/test.ml
@@ -37,8 +37,8 @@ type t =
   ; a : int
   }
 [%%expect{|
-Line _, characters 0-3:
-Error (warning 22): Fields are not sorted!
+Line _, characters 0-36:
+Error (Warning 22): Fields are not sorted!
 |}]
 
 

--- a/test/expect/expect_test.mll
+++ b/test/expect/expect_test.mll
@@ -96,6 +96,11 @@ let main () =
     let ppf = Format.formatter_of_buffer buf in
     Location.formatter_for_warnings := ppf;
     Warnings.parse_options true "+a";
+    Location.printer := (fun ppf loc ->
+      Format.fprintf ppf "Line _, characters %d-%d:\n"
+        (loc.loc_start.pos_cnum - loc.loc_start.pos_bol)
+        (loc.loc_end.pos_cnum - loc.loc_end.pos_bol)
+    );
     List.iter chunks ~f:(fun (pos, s) ->
       Format.fprintf ppf "%s[%%%%expect{|@." s;
       let lexbuf = Lexing.from_string s in

--- a/test/expect/expect_test.mll
+++ b/test/expect/expect_test.mll
@@ -81,6 +81,7 @@ let main () =
   run_expect_test Sys.argv.(1) ~f:(fun file_contents lexbuf ->
     let chunks = code file_contents lexbuf.lex_curr_p lexbuf in
 
+    Warnings.parse_options false "@a-4-29-40-41-42-44-45-48-58";
     Clflags.real_paths := false;
     Toploop.initialize_toplevel_env ();
     List.iter
@@ -95,7 +96,6 @@ let main () =
     let buf = Buffer.create (String.length file_contents + 1024) in
     let ppf = Format.formatter_of_buffer buf in
     Location.formatter_for_warnings := ppf;
-    Warnings.parse_options true "+a";
     Location.printer := (fun ppf loc ->
       Format.fprintf ppf "Line _, characters %d-%d:\n"
         (loc.loc_start.pos_cnum - loc.loc_start.pos_bol)

--- a/test/expect/expect_test.mll
+++ b/test/expect/expect_test.mll
@@ -95,6 +95,7 @@ let main () =
     let buf = Buffer.create (String.length file_contents + 1024) in
     let ppf = Format.formatter_of_buffer buf in
     Location.formatter_for_warnings := ppf;
+    Warnings.parse_options true "+a";
     List.iter chunks ~f:(fun (pos, s) ->
       Format.fprintf ppf "%s[%%%%expect{|@." s;
       let lexbuf = Lexing.from_string s in


### PR DESCRIPTION
The information about the file is not very interesting (already given by
jbuilder/dune), and the information about the line can me misleading.

This PR also enable a set of warnings for expect tests.