### PR TITLE
Add Attribute.declare_with_name_loc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+next
+----
+
+- Add `Attribute.declare_with_name_loc` (#.., @diml)
+
 0.3.0
 -----
 

--- a/src/attribute.mli
+++ b/src/attribute.mli
@@ -123,7 +123,7 @@ val declare
   -> 'b
   -> ('a, 'c) t
 
-(** Same as [declare] but the callback receive the location of the name of the
+(** Same as [declare] but the callback receives the location of the name of the
     attribute. *)
 val declare_with_name_loc
   :  string

--- a/src/attribute.mli
+++ b/src/attribute.mli
@@ -123,6 +123,15 @@ val declare
   -> 'b
   -> ('a, 'c) t
 
+(** Same as [declare] but the callback receive the location of the name of the
+    attribute. *)
+val declare_with_name_loc
+  :  string
+  -> 'a Context.t
+  -> (payload, 'b, 'c) Ast_pattern.t
+  -> (name_loc:Location.t -> 'b)
+  -> ('a, 'c) t
+
 val name : _ t -> string
 val context : ('a, _) t -> 'a Context.t
 


### PR DESCRIPTION
This PR adds a function `Attribute.declare_with_name_loc`. It is the same as `Attribute.declare` except that the callback receives the location of the name of the attribute. I need this for a `ppx_expect` feature I'm working on.