### PR TITLE
Attempt to fix AppVeyor issues (end-of-line characters in diff)

### DIFF
--- a/test/driver/omp-integration/test/jbuild
+++ b/test/driver/omp-integration/test/jbuild
@@ -8,6 +8,7 @@
 
 (alias
  ((name runtest)
-  (action (diff --strip-trailing-cr test.expected test.output))))
+  (deps (test.expected test.output))
+  (action (run diff --strip-trailing-cr test.expected test.output))))
 
 (jbuild_version 1)

--- a/test/driver/omp-integration/test/jbuild
+++ b/test/driver/omp-integration/test/jbuild
@@ -8,6 +8,6 @@
 
 (alias
  ((name runtest)
-  (action (diff test.expected test.output))))
+  (action (diff --strip-trailing-cr test.expected test.output))))
 
 (jbuild_version 1)

--- a/test/driver/skip-hash-bang/jbuild
+++ b/test/driver/skip-hash-bang/jbuild
@@ -8,6 +8,7 @@
 
 (alias
  ((name runtest)
-  (action (diff test.expected test.output))))
+  (deps (test.expected test.output))
+  (action (run diff --strip-trailing-cr test.expected test.output))))
 
 (jbuild_version 1)


### PR DESCRIPTION
See whether passing the `--strip-trailing-cr` command-line
switch to `diff` fixes the AppVeyor issues.