### PR TITLE
Update AST to 4.07

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ It recognizes the following command-line switches:
 -debug-attribute-drop       Debug attribute dropping
 -print-transformations      Print linked-in code transformations, in the order they are applied
 -print-passes               Print the actual passes over the whole AST in the order they are applied
--ite-check                  Enforce that "complex" if branches are delimited (disabled if -pp is given)
+-ite-check                  No effect (kept for compatibility)
 -pp <command>               Pipe sources through preprocessor <command> (incompatible with -as-ppx)
 -reconcile                  (WIP) Pretty print the output using a mix of the input source and the generated code
 -reconcile-with-comments    (WIP) same as -reconcile but uses comments to enclose the generated code

--- a/ast/ast.ml
+++ b/ast/ast.ml
@@ -123,7 +123,7 @@ and constant = Parsetree.constant =
      Suffixes are rejected by the typechecker.
   *)
 
-(** {2 Extension points} *)
+(** {1 Extension points} *)
 
 and attribute = string loc * payload
 (* [@id ARG]
@@ -148,7 +148,7 @@ and payload = Parsetree.payload =
   | PTyp of core_type  (* : T *)
   | PPat of pattern * expression option  (* ? P  or  ? P when E *)
 
-(** {2 Core language} *)
+(** {1 Core language} *)
 
 (* Type expressions *)
 
@@ -493,7 +493,6 @@ and type_declaration = Parsetree.type_declaration =
 and type_kind = Parsetree.type_kind =
   | Ptype_abstract
   | Ptype_variant of constructor_declaration list
-  (* Invariant: non-empty list *)
   | Ptype_record of label_declaration list
   (* Invariant: non-empty list *)
   | Ptype_open
@@ -567,7 +566,7 @@ and extension_constructor_kind = Parsetree.extension_constructor_kind =
      | C = D
   *)
 
-(** {2 Class language} *)
+(** {1 Class language} *)
 
 (* Type expressions for the class language *)
 
@@ -593,7 +592,6 @@ and class_type_desc = Parsetree.class_type_desc =
   (* [%id] *)
   | Pcty_open of override_flag * longident_loc * class_type
   (* let open M in CT *)
-
 
 and class_signature = Parsetree.class_signature =
   {
@@ -734,7 +732,7 @@ and class_field_kind = Parsetree.class_field_kind =
 
 and class_declaration = class_expr class_infos
 
-(** {2 Module language} *)
+(** {1 Module language} *)
 
 (* Type expressions for the module language *)
 
@@ -945,7 +943,7 @@ and module_binding = Parsetree.module_binding =
   }
 (* X = ME *)
 
-(** {2 Toplevel} *)
+(** {1 Toplevel} *)
 
 (* Toplevel phrases *)
 

--- a/ast/docstrings.ml
+++ b/ast/docstrings.ml
@@ -244,6 +244,12 @@ let get_text pos =
       get_docstrings dsl
   with Not_found -> []
 
+let get_post_text pos =
+  try
+    let dsl = Hashtbl.find post_table pos in
+      get_docstrings dsl
+  with Not_found -> []
+
 (* Maps from positions to extra docstrings *)
 
 let pre_extra_table : (Lexing.position, docstring list) Hashtbl.t =
@@ -315,6 +321,9 @@ let symbol_text_lazy () =
 
 let rhs_text pos =
   get_text (Parsing.rhs_start_pos pos)
+
+let rhs_post_text pos =
+  get_post_text (Parsing.rhs_end_pos pos)
 
 let rhs_text_lazy pos =
   let pos = Parsing.rhs_start_pos pos in

--- a/ast/docstrings.mli
+++ b/ast/docstrings.mli
@@ -157,3 +157,6 @@ val rhs_pre_extra_text : int -> text
 
 (** Fetch additional text following the symbol at the given position *)
 val rhs_post_extra_text : int -> text
+
+(** Fetch text following the symbol at the given position *)
+val rhs_post_text : int -> text

--- a/ast/import.ml
+++ b/ast/import.ml
@@ -4,7 +4,7 @@
    It must be opened in all modules, especially the ones coming from the compiler.
 *)
 
-module Js    = Migrate_parsetree.OCaml_406
+module Js    = Migrate_parsetree.OCaml_407
 module Ocaml = Migrate_parsetree.Versions.OCaml_current
 
 module Select_ast(Ocaml : Migrate_parsetree.Versions.OCaml_version) = struct

--- a/ast/lexer.mll
+++ b/ast/lexer.mll
@@ -462,25 +462,12 @@ rule token = parse
         lexbuf.lex_curr_p <- { curpos with pos_cnum = curpos.pos_cnum - 1 };
         STAR
       }
-  | ("#" [' ' '\t']* (['0'-'9']+ as num) [' ' '\t']*
-        ("\"" ([^ '\010' '\013' '\"' ] * as name) "\"")?) as directive
-        [^ '\010' '\013'] * newline
-      {
-        match int_of_string num with
-        | exception _ ->
-            (* PR#7165 *)
-            let loc = Location.curr lexbuf in
-            let explanation = "line number out of range" in
-            let error = Invalid_directive (directive, Some explanation) in
-            raise (Error (error, loc))
-        | line_num ->
-           (* Documentation says that the line number should be
-              positive, but we have never guarded against this and it
-              might have useful hackish uses. *)
-            update_loc lexbuf name line_num true 0;
-            token lexbuf
+  | "#"
+      { let at_beginning_of_line pos = (pos.pos_cnum = pos.pos_bol) in
+        if not (at_beginning_of_line lexbuf.lex_start_p)
+        then HASH
+        else try directive lexbuf with Failure _ -> HASH
       }
-  | "#"  { HASH }
   | "&"  { AMPERSAND }
   | "&&" { AMPERAMPER }
   | "`"  { BACKQUOTE }
@@ -552,6 +539,25 @@ rule token = parse
                      Location.curr lexbuf))
       }
 
+and directive = parse
+  | ([' ' '\t']* (['0'-'9']+ as num) [' ' '\t']*
+        ("\"" ([^ '\010' '\013' '\"' ] * as name) "\"") as directive)
+        [^ '\010' '\013'] *
+      {
+        match int_of_string num with
+        | exception _ ->
+            (* PR#7165 *)
+            let loc = Location.curr lexbuf in
+            let explanation = "line number out of range" in
+            let error = Invalid_directive ("#" ^ directive, Some explanation) in
+            raise (Error (error, loc))
+        | line_num ->
+           (* Documentation says that the line number should be
+              positive, but we have never guarded against this and it
+              might have useful hackish uses. *)
+            update_loc lexbuf (Some name) (line_num - 1) true 0;
+            token lexbuf
+      }
 and comment = parse
     "(*"
       { comment_start_loc := (Location.curr lexbuf) :: !comment_start_loc;

--- a/ast/pprintast.ml
+++ b/ast/pprintast.ml
@@ -808,33 +808,11 @@ and class_type_field ctxt f x =
         item_attributes ctxt f x.pctf_attributes
 
 and class_signature ctxt f { pcsig_self = ct; pcsig_fields = l ;_} =
-  let class_type_field f x =
-    match x.pctf_desc with
-    | Pctf_inherit (ct) ->
-        pp f "@[<2>inherit@ %a@]%a" (class_type ctxt) ct
-          (item_attributes ctxt) x.pctf_attributes
-    | Pctf_val (s, mf, vf, ct) ->
-        pp f "@[<2>val @ %a%a%s@ :@ %a@]%a"
-          mutable_flag mf virtual_flag vf s.txt (core_type ctxt) ct
-          (item_attributes ctxt) x.pctf_attributes
-    | Pctf_method (s, pf, vf, ct) ->
-        pp f "@[<2>method %a %a%s :@;%a@]%a"
-          private_flag pf virtual_flag vf s.txt (core_type ctxt) ct
-          (item_attributes ctxt) x.pctf_attributes
-    | Pctf_constraint (ct1, ct2) ->
-        pp f "@[<2>constraint@ %a@ =@ %a@]%a"
-          (core_type ctxt) ct1 (core_type ctxt) ct2
-          (item_attributes ctxt) x.pctf_attributes
-    | Pctf_attribute a -> floating_attribute ctxt f a
-    | Pctf_extension e ->
-        item_extension ctxt f e;
-        item_attributes ctxt f x.pctf_attributes
-  in
   pp f "@[<hv0>@[<hv2>object@[<1>%a@]@ %a@]@ end@]"
     (fun f -> function
          {ptyp_desc=Ptyp_any; ptyp_attributes=[]; _} -> ()
        | ct -> pp f " (%a)" (core_type ctxt) ct) ct
-    (list class_type_field ~sep:"@;") l
+    (list (class_type_field ctxt) ~sep:"@;") l
 
 (* call [class_signature] called by [class_signature] *)
 and class_type ctxt f x =
@@ -985,22 +963,16 @@ and module_type ctxt f x =
       (attributes ctxt) x.pmty_attributes
   end else
     match x.pmty_desc with
-    | Pmty_ident li ->
-        pp f "%a" longident_loc li;
-    | Pmty_alias li ->
-        pp f "(module %a)" longident_loc li;
-    | Pmty_signature (s) ->
-        pp f "@[<hv0>@[<hv2>sig@ %a@]@ end@]" (* "@[<hov>sig@ %a@ end@]" *)
-          (list (signature_item ctxt)) s (* FIXME wrong indentation*)
     | Pmty_functor (_, None, mt2) ->
         pp f "@[<hov2>functor () ->@ %a@]" (module_type ctxt) mt2
     | Pmty_functor (s, Some mt1, mt2) ->
         if s.txt = "_" then
           pp f "@[<hov2>%a@ ->@ %a@]"
-            (module_type ctxt) mt1 (module_type ctxt) mt2
+            (module_type1 ctxt) mt1 (module_type ctxt) mt2
         else
           pp f "@[<hov2>functor@ (%s@ :@ %a)@ ->@ %a@]" s.txt
             (module_type ctxt) mt1 (module_type ctxt) mt2
+    | Pmty_with (mt, []) -> module_type ctxt f mt
     | Pmty_with (mt, l) ->
         let with_constraint f = function
           | Pwith_type (li, ({ptype_params= ls ;_} as td)) ->
@@ -1018,13 +990,24 @@ and module_type ctxt f x =
                 (type_declaration ctxt) td
           | Pwith_modsubst (li, li2) ->
              pp f "module %a :=@ %a" longident_loc li longident_loc li2 in
-        (match l with
-         | [] -> pp f "@[<hov2>%a@]" (module_type ctxt) mt
-         | _ -> pp f "@[<hov2>(%a@ with@ %a)@]"
-                  (module_type ctxt) mt (list with_constraint ~sep:"@ and@ ") l)
+        pp f "@[<hov2>%a@ with@ %a@]"
+          (module_type1 ctxt) mt (list with_constraint ~sep:"@ and@ ") l
+    | _ -> module_type1 ctxt f x
+
+and module_type1 ctxt f x =
+  if x.pmty_attributes <> [] then module_type ctxt f x
+  else match x.pmty_desc with
+    | Pmty_ident li ->
+        pp f "%a" longident_loc li;
+    | Pmty_alias li ->
+        pp f "(module %a)" longident_loc li;
+    | Pmty_signature (s) ->
+        pp f "@[<hv0>@[<hv2>sig@ %a@]@ end@]" (* "@[<hov>sig@ %a@ end@]" *)
+          (list (signature_item ctxt)) s (* FIXME wrong indentation*)
     | Pmty_typeof me ->
         pp f "@[<hov2>module@ type@ of@ %a@]" (module_expr ctxt) me
     | Pmty_extension e -> extension ctxt f e
+    | _ -> paren true (module_type ctxt) f x
 
 and signature ctxt f x =  list ~sep:"@\n" (signature_item ctxt) f x
 
@@ -1095,11 +1078,11 @@ and signature_item ctxt f x : unit =
         | pmd :: tl ->
             if not first then
               pp f "@ @[<hov2>and@ %s:@ %a@]%a" pmd.pmd_name.txt
-                (module_type ctxt) pmd.pmd_type
+                (module_type1 ctxt) pmd.pmd_type
                 (item_attributes ctxt) pmd.pmd_attributes
             else
               pp f "@[<hov2>module@ rec@ %s:@ %a@]%a" pmd.pmd_name.txt
-                (module_type ctxt) pmd.pmd_type
+                (module_type1 ctxt) pmd.pmd_type
                 (item_attributes ctxt) pmd.pmd_attributes;
             string_x_module_type_list f ~first:false tl
       in
@@ -1429,8 +1412,10 @@ and type_declaration ctxt f x =
     in
     match x.ptype_kind with
     | Ptype_variant xs ->
-        pp f "%t%t@\n%a" intro priv
-          (list ~sep:"@\n" constructor_declaration) xs
+      let variants fmt xs =
+        if xs = [] then pp fmt " |" else
+          pp fmt "@\n%a" (list ~sep:"@\n" constructor_declaration) xs
+      in pp f "%t%t%a" intro priv variants xs
     | Ptype_abstract -> ()
     | Ptype_record l ->
         pp f "%t%t@;%a" intro priv (record_declaration ctxt) l

--- a/ast/warn.ml
+++ b/ast/warn.ml
@@ -1,4 +1,4 @@
-open Import
+open! Import
 
 let default_print_warning _loc = ()
 

--- a/ast/warn.ml
+++ b/ast/warn.ml
@@ -1,8 +1,6 @@
 open Import
 
-let default_print_warning loc =
-  Location.print_error Format.err_formatter loc;
-  Format.fprintf Format.err_formatter "this [if] branch is not delimited\n%!"
+let default_print_warning _loc = ()
 
 let about_ite_branch_ref = ref default_print_warning
 

--- a/ast/warn.mli
+++ b/ast/warn.mli
@@ -1,13 +1,10 @@
 open Import
 
 val care_about_ite_branch : bool ref
-(** If set to [true] then the check regarding if-then-else branches is
-    performed. *)
+(** Ignored -- kept for compatibility. *)
 
 val about_ite_branch_ref : (Location.t -> unit) ref
-(** Used to override what happens for problematic locations.
-    By default just prints an error message on stderr. *)
+(** Ignored -- kept for compatibility. *)
 
 val about_ite_branch : Location.t -> unit
-(** This function is called by the parser when it wants to warn about an
-    if-then-else branch. *)
+(** Ignored -- kept for compatibility. *)

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -1110,7 +1110,7 @@ let standalone_args =
   ; "-print-passes", Arg.Set request_print_passes,
     " Print the actual passes over the whole AST in the order they are applied"
   ; "-ite-check", Arg.Set Extra_warnings.care_about_ite_branch,
-    " Enforce that \"complex\" if branches are delimited (disabled if -pp is given)"
+    " (no effect -- kept for compatibility)"
   ; "-pp", Arg.String (fun s -> preprocessor := Some s),
     "<command>  Pipe sources through preprocessor <command> (incompatible with -as-ppx)"
   ; "-reconcile", Arg.Unit (fun () -> set_output_mode (Reconcile Using_line_directives)),

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -1109,7 +1109,9 @@ let standalone_args =
     " Print linked-in code transformations, in the order they are applied"
   ; "-print-passes", Arg.Set request_print_passes,
     " Print the actual passes over the whole AST in the order they are applied"
-  ; "-ite-check", Arg.Set Extra_warnings.care_about_ite_branch,
+  ; "-ite-check",
+    Arg.Unit (fun () -> eprintf "warning: -ite-check has no effect\n%!";
+               Extra_warnings.care_about_ite_branch := true),
     " (no effect -- kept for compatibility)"
   ; "-pp", Arg.String (fun s -> preprocessor := Some s),
     "<command>  Pipe sources through preprocessor <command> (incompatible with -as-ppx)"

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -1110,8 +1110,10 @@ let standalone_args =
   ; "-print-passes", Arg.Set request_print_passes,
     " Print the actual passes over the whole AST in the order they are applied"
   ; "-ite-check",
-    Arg.Unit (fun () -> eprintf "warning: -ite-check has no effect\n%!";
-               Extra_warnings.care_about_ite_branch := true),
+    Arg.Unit (fun () ->
+      eprintf "Warning: the -ite-check flag is deprecated \
+               and has no effect.\n%!";
+      Extra_warnings.care_about_ite_branch := true),
     " (no effect -- kept for compatibility)"
   ; "-pp", Arg.String (fun s -> preprocessor := Some s),
     "<command>  Pipe sources through preprocessor <command> (incompatible with -as-ppx)"


### PR DESCRIPTION
note: this PR also removes support for the if-then-else check
(however elements, such as the command-line switch, are
kept for compatibility)