### PR TITLE
Remove the `--dev` passed to jbuilder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ INSTALL_ARGS := $(if $(PREFIX),--prefix $(PREFIX),)
 
 # Default rule
 default:
-	jbuilder build --dev --auto-promote @cinaps @install
+	jbuilder build --auto-promote @cinaps @install
 
 install:
 	jbuilder install $(INSTALL_ARGS)
@@ -13,13 +13,13 @@ uninstall:
 reinstall: uninstall reinstall
 
 test:
-	jbuilder runtest --dev
+	jbuilder runtest
 
 clean:
 	rm -rf _build
 
 all-supported-ocaml-versions:
-	jbuilder build --dev @install --workspace jbuild-workspace.dev --root .
+	jbuilder build @install --workspace jbuild-workspace.dev --root .
 
 .PHONY: default install uninstall reinstall clean test
 .PHONY: all-supported-ocaml-versions


### PR DESCRIPTION
It is an error to pass this command-line switch to recent
jbuilder versions, leading to build failures.