### PR TITLE
Fix attribute extraction for Otag/Rtag

### DIFF
--- a/src/attribute.ml
+++ b/src/attribute.ml
@@ -152,13 +152,17 @@ module Context = struct
       begin match x with
       | Rtag (lbl, _, can_be_constant, params_opts) ->
         Rtag (lbl, attrs, can_be_constant, params_opts)
-      | Rinherit _ -> x
+      | Rinherit _ ->
+        assert (List.is_empty attrs);
+        x
       end
     | Object_type_field ->
       begin match x with
       | Otag (lbl, _, typ) ->
         Otag (lbl, attrs, typ)
-      | Oinherit _ -> x
+      | Oinherit _ ->
+        assert (List.is_empty attrs);
+        x
       end
 
   let desc : type a. a t -> string = function

--- a/test/driver/attributes/test.ml
+++ b/test/driver/attributes/test.ml
@@ -78,3 +78,13 @@ let x = (42 [@foo])
 Line _, characters 14-17:
 Error: Attribute `foo' was silently dropped
 |}]
+
+type t1 = < >
+type t2 = < t1 >
+type t3 = < (t1[@foo]) >
+[%%expect{|
+type t1 = <  >
+type t2 = <  >
+Line _, characters 17-20:
+Error: Attribute `foo' was not used
+|}]


### PR DESCRIPTION
The library fails on declarations such as:

    type t1 = < >
    type t2 = < t1 >

This handles the `Oinherit`/`Rinherit` cases by just returning the
empty list for `get` and doing nothing for `set`. Another option
would be to perform the operation on the nested `core_type`
value, but I am not sure it makes sense.