### PR TITLE
Simplify generation of named interfaces

### DIFF
--- a/src/common.mli
+++ b/src/common.mli
@@ -51,3 +51,27 @@ val curry_applications : expression -> expression
 (** Encode a warning message into an 'ocaml.ppwarning' attribute which can be inserted in
     a generated Parsetree.  The compiler will be responsible for reporting the warning. *)
 val attribute_of_warning : Location.t -> string -> attribute
+
+val is_polymorphic_variant
+  : type_declaration -> sig_:bool -> [> `Definitely | `Maybe | `Surely_not ]
+
+(** [mk_named_sig ~loc ~sg_name:"Foo" ~handle_polymorphic_variant tds] will
+    generate
+    {[
+      include Foo (* or Foo1, Foo2, Foo3 *)
+        with type (* ('a, 'b, 'c) *) t := (* ('a, 'b, 'c) *) t
+    ]}
+    when:
+    - there is only one type declaration
+    - the type is named t
+    - there are less than 4 type parameters
+    - there are no constraints on the type parameters
+
+    It will take care of giving fresh names to unnamed type parameters.
+*)
+val mk_named_sig
+  : loc:Location.t
+  -> sg_name:string
+  -> handle_polymorphic_variant:bool
+  -> type_declaration list
+  -> include_description option


### PR DESCRIPTION
I plan to change various ppxes (ppx_bin_prot, ppx_sexp_conv, ppx_typerep_conv, etc.) to generate "nicer looking" signatures (when viewed from odoc).

For example I plan for `type ('a, 'foo) t [@@deriving sexp]` to generate:
```ocaml
include Sexpable.S2 with type ('a, 'foo) t := ('a, 'foo) t
```

That rewriting can only happen in very specific cases though, which are however the same in all the derivers. So ppxlib feels like a natural place to share this code between all of them.