### PR TITLE
Follow-up to PR#63

### DIFF
--- a/src/longident.ml
+++ b/src/longident.ml
@@ -12,8 +12,11 @@ module T = struct
     | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '\'' -> true
     | _ -> false
 
-  let is_normal_ident string =
-    String.for_all string ~f:is_normal_ident_char
+  let is_normal_ident = function
+    | "asr" | "land" | "lor" | "lsl" | "lsr" | "lxor" | "mod" | "or" ->
+      false
+    | string ->
+      String.for_all string ~f:is_normal_ident_char
 
   let short_name string =
     if is_normal_ident string

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -95,3 +95,9 @@ let _ = convert_longident "Base.( + )"
 - : string * longident =
 ("Base.( + )", Ppxlib.Longident.Ldot (Ppxlib.Longident.Lident "Base", " + "))
 |}]
+
+let _ = convert_longident "Base.( land )"
+[%%expect{|
+- : string * longident =
+("Base.( land )", Ppxlib.Longident.Ldot (Ppxlib.Longident.Lident "Base", " land "))
+|}]


### PR DESCRIPTION
OCaml has some operators whose names are purely alphabetical.
For instance `land` should be treated just as `+` is.