### PR TITLE
Set Location.input_name appropriately when reading a binary AST

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+next
+----
+
+- Set `Location.input_name` to the original filename when reading a
+  binary AST (#.., @diml)
+
 0.5.0
 -----
 


### PR DESCRIPTION
This should fix https://github.com/aantron/bisect_ppx/issues/187