### PR TITLE
Expose an abstract Code_path.t type to replace expanders' string path argument

### DIFF
--- a/src/ast_traverse.ml
+++ b/src/ast_traverse.ml
@@ -69,6 +69,25 @@ class map_with_path = object
     super#module_type_declaration (enter mtd.pmtd_name.txt path) mtd
 end
 
+class map_with_code_path = object
+  inherit [Code_path.t] map_with_context as super
+
+  method! module_binding path mb =
+       super#module_binding (Code_path.enter mb.pmb_name.txt path) mb
+
+  method! module_declaration path md =
+    super#module_declaration (Code_path.enter md.pmd_name.txt path) md
+
+  method! module_type_declaration path mtd =
+    super#module_type_declaration (Code_path.enter mtd.pmtd_name.txt path) mtd
+
+  method! value_description path vd =
+    super#value_description (Code_path.enter vd.pval_name.txt path) vd
+
+  method! value_binding path vb =
+    super#value_binding path vb
+end
+
 class sexp_of = object
   inherit [Sexp.t] Ast.lift
 

--- a/src/ast_traverse.ml
+++ b/src/ast_traverse.ml
@@ -83,22 +83,24 @@ class map_with_code_path = object (self)
   inherit [Code_path.t] map_with_context as super
 
   method! module_binding path mb =
-       super#module_binding (Code_path.enter mb.pmb_name.txt path) mb
+       super#module_binding (Code_path.enter ~loc:mb.pmb_loc mb.pmb_name.txt path) mb
 
   method! module_declaration path md =
-    super#module_declaration (Code_path.enter md.pmd_name.txt path) md
+    super#module_declaration (Code_path.enter ~loc:md.pmd_loc md.pmd_name.txt path) md
 
   method! module_type_declaration path mtd =
-    super#module_type_declaration (Code_path.enter mtd.pmtd_name.txt path) mtd
+    super#module_type_declaration (Code_path.enter ~loc:mtd.pmtd_loc mtd.pmtd_name.txt path) mtd
 
   method! value_description path vd =
-    super#value_description (Code_path.enter vd.pval_name.txt path) vd
+    super#value_description (Code_path.enter ~loc:vd.pval_loc vd.pval_name.txt path) vd
 
   method! value_binding path {pvb_pat; pvb_expr; pvb_attributes; pvb_loc} =
     let all_var_names = var_names_of#pattern pvb_pat [] in
     let var_name = Base.List.last all_var_names in
     let in_binding_path =
-      Base.Option.fold var_name ~init:path ~f:(fun path var_name -> Code_path.enter var_name path)
+      Base.Option.fold var_name
+        ~init:path
+        ~f:(fun path var_name -> Code_path.enter ~loc:pvb_loc var_name path)
     in
     let pvb_pat = self#pattern path pvb_pat in
     let pvb_expr = self#expression in_binding_path pvb_expr in

--- a/src/ast_traverse.ml
+++ b/src/ast_traverse.ml
@@ -82,6 +82,9 @@ end
 class map_with_code_path = object (self)
   inherit [Code_path.t] map_with_context as super
 
+  method! expression path expr =
+    super#expression (Code_path.enter_expr path) expr
+
   method! module_binding path mb =
        super#module_binding (Code_path.enter_module ~loc:mb.pmb_loc mb.pmb_name.txt path) mb
 

--- a/src/ast_traverse.ml
+++ b/src/ast_traverse.ml
@@ -69,7 +69,7 @@ class map_with_path = object
     super#module_type_declaration (enter mtd.pmtd_name.txt path) mtd
 end
 
-class map_with_code_path = object
+class map_with_code_path = object (self)
   inherit [Code_path.t] map_with_context as super
 
   method! module_binding path mb =
@@ -84,9 +84,15 @@ class map_with_code_path = object
   method! value_description path vd =
     super#value_description (Code_path.enter vd.pval_name.txt path) vd
 
-  method! value_binding path vb =
-    match vb.pvb_pat.ppat_desc with
-    | Ppat_var v -> super#value_binding (Code_path.enter v.txt path) vb
+  method! value_binding path ({pvb_pat; pvb_expr; pvb_attributes; pvb_loc} as vb) =
+    match pvb_pat.ppat_desc with
+    | Ppat_var v ->
+      let new_path = Code_path.enter v.txt path in
+      let pvb_pat = self#pattern path pvb_pat in
+      let pvb_expr = self#expression new_path pvb_expr in
+      let pvb_attributes = self#attributes new_path pvb_attributes in
+      let pvb_loc = self#location path pvb_loc in
+      { pvb_pat; pvb_expr; pvb_attributes; pvb_loc }
     | _ -> super#value_binding path vb
 end
 

--- a/src/ast_traverse.ml
+++ b/src/ast_traverse.ml
@@ -85,7 +85,9 @@ class map_with_code_path = object
     super#value_description (Code_path.enter vd.pval_name.txt path) vd
 
   method! value_binding path vb =
-    super#value_binding path vb
+    match vb.pvb_pat.ppat_desc with
+    | Ppat_var v -> super#value_binding (Code_path.enter v.txt path) vb
+    | _ -> super#value_binding path vb
 end
 
 class sexp_of = object

--- a/src/ast_traverse.ml
+++ b/src/ast_traverse.ml
@@ -83,16 +83,18 @@ class map_with_code_path = object (self)
   inherit [Code_path.t] map_with_context as super
 
   method! module_binding path mb =
-       super#module_binding (Code_path.enter ~loc:mb.pmb_loc mb.pmb_name.txt path) mb
+       super#module_binding (Code_path.enter_module ~loc:mb.pmb_loc mb.pmb_name.txt path) mb
 
   method! module_declaration path md =
-    super#module_declaration (Code_path.enter ~loc:md.pmd_loc md.pmd_name.txt path) md
+    super#module_declaration (Code_path.enter_module ~loc:md.pmd_loc md.pmd_name.txt path) md
 
   method! module_type_declaration path mtd =
-    super#module_type_declaration (Code_path.enter ~loc:mtd.pmtd_loc mtd.pmtd_name.txt path) mtd
+    super#module_type_declaration
+      (Code_path.enter_module ~loc:mtd.pmtd_loc mtd.pmtd_name.txt path)
+      mtd
 
   method! value_description path vd =
-    super#value_description (Code_path.enter ~loc:vd.pval_loc vd.pval_name.txt path) vd
+    super#value_description (Code_path.enter_value ~loc:vd.pval_loc vd.pval_name.txt path) vd
 
   method! value_binding path {pvb_pat; pvb_expr; pvb_attributes; pvb_loc} =
     let all_var_names = var_names_of#pattern pvb_pat [] in
@@ -100,7 +102,7 @@ class map_with_code_path = object (self)
     let in_binding_path =
       Base.Option.fold var_name
         ~init:path
-        ~f:(fun path var_name -> Code_path.enter ~loc:pvb_loc var_name path)
+        ~f:(fun path var_name -> Code_path.enter_value ~loc:pvb_loc var_name path)
     in
     let pvb_pat = self#pattern path pvb_pat in
     let pvb_expr = self#expression in_binding_path pvb_expr in

--- a/src/ast_traverse.mli
+++ b/src/ast_traverse.mli
@@ -54,6 +54,8 @@ end
 
 class map_with_path : [string] map_with_context
 
+class map_with_code_path : [Code_path.t] map_with_context
+
 class virtual ['res] lift : object
   inherit ['res] Ppxlib_traverse_builtins.lift
   inherit ['res] Ast.lift

--- a/src/code_path.ml
+++ b/src/code_path.ml
@@ -32,3 +32,5 @@ let to_string_path t =
     List.filter ~f:is_module_name val_path
   in
   String.concat ~sep:"." (t.file_path :: sub_module_path)
+
+let with_string_path f ~loc ~path = f ~loc ~path:(to_string_path path)

--- a/src/code_path.ml
+++ b/src/code_path.ml
@@ -1,0 +1,34 @@
+open! Import
+
+type t =
+  { file_path : string
+  ; main_module_name : string
+  ; val_path : string list
+  }
+
+let top_level ~file_path =
+  let main_module_name =
+    file_path
+    |> Caml.Filename.basename
+    |> Caml.Filename.remove_extension
+    |> String.capitalize
+  in
+  {file_path; main_module_name; val_path = []}
+
+let file_path t = t.file_path
+let main_module_name t = t.main_module_name
+let val_path t = List.rev t.val_path
+
+let fully_qualified_path t = 
+  String.concat ~sep:"." (t.main_module_name :: (val_path t))
+
+let enter mod_or_val_name t =
+  {t with val_path = mod_or_val_name :: t.val_path}
+
+let to_string_path t =
+  let val_path = val_path t in
+  let sub_module_path =
+    let is_module_name s = String.(s <> "") && Char.is_uppercase (String.get s 0) in
+    List.filter ~f:is_module_name val_path
+  in
+  String.concat ~sep:"." (t.file_path :: sub_module_path)

--- a/src/code_path.ml
+++ b/src/code_path.ml
@@ -3,7 +3,7 @@ open! Import
 type t =
   { file_path : string
   ; main_module_name : string
-  ; val_path : string list
+  ; val_path : string loc list
   }
 
 let top_level ~file_path =
@@ -17,13 +17,13 @@ let top_level ~file_path =
 
 let file_path t = t.file_path
 let main_module_name t = t.main_module_name
-let val_path t = List.rev t.val_path
+let val_path t = List.rev_map ~f:(fun located -> located.txt) t.val_path
 
 let fully_qualified_path t = 
   String.concat ~sep:"." (t.main_module_name :: (val_path t))
 
-let enter mod_or_val_name t =
-  {t with val_path = mod_or_val_name :: t.val_path}
+let enter ~loc mod_or_val_name t =
+  {t with val_path = {txt = mod_or_val_name; loc} :: t.val_path}
 
 let to_string_path t =
   let val_path = val_path t in

--- a/src/code_path.mli
+++ b/src/code_path.mli
@@ -28,6 +28,12 @@ val value : t -> string option
 *)
 val fully_qualified_path : t -> string
 
+(** Return a new code path that now descends into an expression.
+    This is used to delimit the "toplevel" path. It's required because of first class modules
+    and toplevel expressions [Pstr_eval ...].
+*)
+val enter_expr : t -> t
+
 (** Return a new code path updated with the given module name and location. *)
 val enter_module : loc:Location.t -> string -> t -> t
 

--- a/src/code_path.mli
+++ b/src/code_path.mli
@@ -3,9 +3,6 @@ open !Import
 (** Type for path to AST nodes *)
 type t
 
-(** [top_level ~file_path] returns the code path for any toplevel item in the file at [file_path]. *)
-val top_level : file_path: string -> t
-
 (** Return the path to the .ml or .mli file for this code path. *)
 val file_path : t -> string
 
@@ -28,6 +25,17 @@ val value : t -> string option
 *)
 val fully_qualified_path : t -> string
 
+(** Return the string version of this code path as built by [Ast_traverse.map_with_path].
+    Used for compatibility with path from version 0.5.0 and lower.
+*)
+val to_string_path : t -> string
+
+(**/**)
+(** Undocumented section *)
+
+(** [top_level ~file_path] returns the code path for any toplevel item in the file at [file_path]. *)
+val top_level : file_path: string -> t
+
 (** Return a new code path that now descends into an expression.
     This is used to delimit the "toplevel" path. It's required because of first class modules
     and toplevel expressions [Pstr_eval ...].
@@ -39,11 +47,6 @@ val enter_module : loc:Location.t -> string -> t -> t
 
 (** Return a new code path updated with the given variable name and location. *)
 val enter_value : loc:Location.t -> string -> t -> t
-
-(** Return the string version of this code path as built by [Ast_traverse.map_with_path].
-    Used for compatibility with path from version 0.5.0 and lower.
-*)
-val to_string_path : t -> string
 
 (** Wrap a [fun ~loc ~path] expecting a string path into one expecting a [t]. *)
 val with_string_path :

--- a/src/code_path.mli
+++ b/src/code_path.mli
@@ -22,8 +22,8 @@ val val_path : t -> string list
 *)
 val fully_qualified_path : t -> string
 
-(** [enter val_or_module_name t] returns *)
-val enter : string -> t -> t
+(** [enter val_or_module_name t] returns a new code path updated with the given name and location *)
+val enter : loc:Location.t -> string -> t -> t
 
 (** Return the string version of this code path as built by [Ast_traverse.map_with_path].
     Used for compatibility with path from version 0.5.0 and lower.

--- a/src/code_path.mli
+++ b/src/code_path.mli
@@ -12,18 +12,27 @@ val file_path : t -> string
 (** Return the module name corresponding to the file to which this code path leads to. *)
 val main_module_name : t -> string
 
-(** Return the path within the main module this code path represents as a list of module names and
-    eventually a value name if within a value binding.
+(** Return the path within the main module this code path represents as a list of module names.
 *)
-val val_path : t -> string list
+val submodule_path : t -> string list
 
-(** Return the fully qualified path represented by this code path as a single string, eg
+(** Return the name of the value to which this code path leads or [None] if it leads to the
+    toplevel of a module or submodule.
+*)
+val value : t -> string option
+
+(** Return the fully qualified path to the module or value this code path leads to, eg
     ["Some_main_module.Some_submodule.some_value"].
+    Note that the fully qualified path doesn't descend into expressions which means it will always
+    stop at the first value description or value binding.
 *)
 val fully_qualified_path : t -> string
 
-(** [enter val_or_module_name t] returns a new code path updated with the given name and location *)
-val enter : loc:Location.t -> string -> t -> t
+(** Return a new code path updated with the given module name and location. *)
+val enter_module : loc:Location.t -> string -> t -> t
+
+(** Return a new code path updated with the given variable name and location. *)
+val enter_value : loc:Location.t -> string -> t -> t
 
 (** Return the string version of this code path as built by [Ast_traverse.map_with_path].
     Used for compatibility with path from version 0.5.0 and lower.

--- a/src/code_path.mli
+++ b/src/code_path.mli
@@ -29,3 +29,8 @@ val enter : string -> t -> t
     Used for compatibility with path from version 0.5.0 and lower.
 *)
 val to_string_path : t -> string
+
+(** Wrap a [fun ~loc ~path] expecting a string path into one expecting a [t]. *)
+val with_string_path :
+  (loc:Location.t -> path:string -> 'a) ->
+  (loc:Location.t -> path:t -> 'a)

--- a/src/code_path.mli
+++ b/src/code_path.mli
@@ -1,0 +1,31 @@
+open !Import
+
+(** Type for path to AST nodes *)
+type t
+
+(** [top_level ~file_path] returns the code path for any toplevel item in the file at [file_path]. *)
+val top_level : file_path: string -> t
+
+(** Return the path to the .ml or .mli file for this code path. *)
+val file_path : t -> string
+
+(** Return the module name corresponding to the file to which this code path leads to. *)
+val main_module_name : t -> string
+
+(** Return the path within the main module this code path represents as a list of module names and
+    eventually a value name if within a value binding.
+*)
+val val_path : t -> string list
+
+(** Return the fully qualified path represented by this code path as a single string, eg
+    ["Some_main_module.Some_submodule.some_value"].
+*)
+val fully_qualified_path : t -> string
+
+(** [enter val_or_module_name t] returns *)
+val enter : string -> t -> t
+
+(** Return the string version of this code path as built by [Ast_traverse.map_with_path].
+    Used for compatibility with path from version 0.5.0 and lower.
+*)
+val to_string_path : t -> string

--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -12,8 +12,7 @@ module Rule = struct
     type ('a, 'b, 'c) unpacked =
       { attribute : ('b, 'c) Attribute.t
       ; expect    : bool
-      ; expand    : (loc:Location.t
-                     -> path:Code_path.t
+      ; expand    : (ctxt:Expansion_context.t
                      -> Asttypes.rec_flag
                      -> 'b list
                      -> 'c option list
@@ -31,8 +30,7 @@ module Rule = struct
     type ('a, 'b, 'c) unpacked =
       { attribute : ('b, 'c) Attribute.t
       ; expect    : bool
-      ; expand    : (loc:Location.t
-                     -> path:Code_path.t
+      ; expand    : (ctxt:Expansion_context.t
                      -> 'b
                      -> 'c
                      -> 'a list)
@@ -96,8 +94,7 @@ module Rule = struct
 
   type ('a, 'b, 'c) attr_group_inline =
     ('b, 'c) Attribute.t
-    -> (loc:Location.t
-        -> path:Code_path.t
+    -> (ctxt:Expansion_context.t
         -> Asttypes.rec_flag
         -> 'b list
         -> 'c option list
@@ -106,8 +103,7 @@ module Rule = struct
 
   type ('a, 'b, 'c) attr_inline =
     ('b, 'c) Attribute.t
-    -> (loc:Location.t
-        -> path:Code_path.t
+    -> (ctxt:Expansion_context.t
         -> 'b
         -> 'c
         -> 'a list)
@@ -202,20 +198,22 @@ module Generated_code_hook = struct
 end
 
 let rec map_node_rec context ts super_call loc path x =
+  let ctxt = Expansion_context.make ~loc ~code_path:path in
   match EC.get_extension context x with
   | None -> super_call path x
   | Some (ext, attrs) ->
-    match E.For_context.convert ts ~loc ~path ext with
+    match E.For_context.convert ts ~ctxt ext with
     | None -> super_call path x
     | Some x ->
       map_node_rec context ts super_call loc path (EC.merge_attributes context x attrs)
 ;;
 
 let map_node context ts super_call loc path x ~hook =
+  let ctxt = Expansion_context.make ~loc ~code_path:path in
   match EC.get_extension context x with
   | None -> super_call path x
   | Some (ext, attrs) ->
-    match E.For_context.convert ts ~loc ~path ext with
+    match E.For_context.convert ts ~ctxt ext with
     | None -> super_call path x
     | Some x ->
       let generated_code =
@@ -238,7 +236,8 @@ let rec map_nodes context ts super_call get_loc path l ~hook ~in_generated_code 
       x :: l
     | Some (ext, attrs) ->
       let loc = get_loc x in
-      match E.For_context.convert_inline ts ~loc ~path ext with
+      let ctxt = Expansion_context.make ~loc ~code_path:path in
+      match E.For_context.convert_inline ts ~ctxt ext with
       | None ->
         let x = super_call path x in
         let l =
@@ -322,7 +321,8 @@ let handle_attr_group_inline attrs rf items ~loc ~path =
       match get_group group.attribute items with
       | None -> acc
       | Some values ->
-        let expect_items = group.expand ~loc ~path rf items values in
+        let ctxt = Expansion_context.make ~loc ~code_path:path in
+        let expect_items = group.expand ~ctxt rf items values in
         expect_items :: acc)
 
 let handle_attr_inline attrs item ~loc ~path =
@@ -331,7 +331,8 @@ let handle_attr_inline attrs item ~loc ~path =
       match Attribute.get a.attribute item with
       | None -> acc
       | Some value ->
-        let expect_items = a.expand ~loc ~path item value in
+        let ctxt = Expansion_context.make ~loc ~code_path:path in
+        let expect_items = a.expand ~ctxt item value in
         expect_items :: acc)
 
 module Expect_mismatch_handler = struct
@@ -544,7 +545,8 @@ class map_top_down ?(expect_mismatch_handler=Expect_mismatch_handler.nop)
           match item.pstr_desc with
           | Pstr_extension (ext, attrs) -> begin
               let loc = item.pstr_loc in
-              match E.For_context.convert_inline structure_item ~loc ~path ext with
+              let ctxt = Expansion_context.make ~loc ~code_path:path in
+              match E.For_context.convert_inline structure_item ~ctxt ext with
               | None ->
                 let item = super#structure_item path item in
                 let rest = self#structure path rest in
@@ -614,7 +616,8 @@ class map_top_down ?(expect_mismatch_handler=Expect_mismatch_handler.nop)
           match item.psig_desc with
           | Psig_extension (ext, attrs) -> begin
               let loc = item.psig_loc in
-              match E.For_context.convert_inline signature_item ~loc ~path ext with
+              let ctxt = Expansion_context.make ~loc ~code_path:path in
+              match E.For_context.convert_inline signature_item ~ctxt ext with
               | None ->
                 let item = super#signature_item path item in
                 let rest = self#signature path rest in

--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -13,7 +13,7 @@ module Rule = struct
       { attribute : ('b, 'c) Attribute.t
       ; expect    : bool
       ; expand    : (loc:Location.t
-                     -> path:string
+                     -> path:Code_path.t
                      -> Asttypes.rec_flag
                      -> 'b list
                      -> 'c option list
@@ -32,7 +32,7 @@ module Rule = struct
       { attribute : ('b, 'c) Attribute.t
       ; expect    : bool
       ; expand    : (loc:Location.t
-                     -> path:string
+                     -> path:Code_path.t
                      -> 'b
                      -> 'c
                      -> 'a list)
@@ -97,7 +97,7 @@ module Rule = struct
   type ('a, 'b, 'c) attr_group_inline =
     ('b, 'c) Attribute.t
     -> (loc:Location.t
-        -> path:string
+        -> path:Code_path.t
         -> Asttypes.rec_flag
         -> 'b list
         -> 'c option list
@@ -107,7 +107,7 @@ module Rule = struct
   type ('a, 'b, 'c) attr_inline =
     ('b, 'c) Attribute.t
     -> (loc:Location.t
-        -> path:string
+        -> path:Code_path.t
         -> 'b
         -> 'c
         -> 'a list)
@@ -404,7 +404,7 @@ class map_top_down ?(expect_mismatch_handler=Expect_mismatch_handler.nop)
   let map_nodes = map_nodes ~hook in
 
   object(self)
-    inherit Ast_traverse.map_with_path as super
+    inherit Ast_traverse.map_with_code_path as super
 
     (* No point recursing into every location *)
     method! location _ x = x

--- a/src/context_free.mli
+++ b/src/context_free.mli
@@ -64,7 +64,7 @@ module Rule : sig
   type ('a, 'b, 'c) attr_group_inline =
     ('b, 'c) Attribute.t
     -> (loc:Location.t
-        -> path:string
+        -> path:Code_path.t
         -> Asttypes.rec_flag
         -> 'b list
         -> 'c option list
@@ -84,7 +84,7 @@ module Rule : sig
   type ('a, 'b, 'c) attr_inline =
     ('b, 'c) Attribute.t
     -> (loc:Location.t
-        -> path:string
+        -> path:Code_path.t
         -> 'b
         -> 'c
         -> 'a list)
@@ -136,4 +136,4 @@ class map_top_down
     -> ?generated_code_hook:Generated_code_hook.t
     (* default: Generated_code_hook.nop *)
     -> Rule.t list
-    -> Ast_traverse.map_with_path
+    -> Ast_traverse.map_with_code_path

--- a/src/context_free.mli
+++ b/src/context_free.mli
@@ -63,8 +63,7 @@ module Rule : sig
   *)
   type ('a, 'b, 'c) attr_group_inline =
     ('b, 'c) Attribute.t
-    -> (loc:Location.t
-        -> path:Code_path.t
+    -> (ctxt:Expansion_context.t
         -> Asttypes.rec_flag
         -> 'b list
         -> 'c option list
@@ -83,8 +82,7 @@ module Rule : sig
       exceptions and type extensions *)
   type ('a, 'b, 'c) attr_inline =
     ('b, 'c) Attribute.t
-    -> (loc:Location.t
-        -> path:Code_path.t
+    -> (ctxt:Expansion_context.t
         -> 'b
         -> 'c
         -> 'a list)

--- a/src/context_free.mli
+++ b/src/context_free.mli
@@ -63,7 +63,7 @@ module Rule : sig
   *)
   type ('a, 'b, 'c) attr_group_inline =
     ('b, 'c) Attribute.t
-    -> (ctxt:Expansion_context.t
+    -> (ctxt:Expansion_context.Deriver.t
         -> Asttypes.rec_flag
         -> 'b list
         -> 'c option list
@@ -82,7 +82,7 @@ module Rule : sig
       exceptions and type extensions *)
   type ('a, 'b, 'c) attr_inline =
     ('b, 'c) Attribute.t
-    -> (ctxt:Expansion_context.t
+    -> (ctxt:Expansion_context.Deriver.t
         -> 'b
         -> 'c
         -> 'a list)

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -187,7 +187,7 @@ module Generator = struct
   ;;
 
   let apply (T t) ~name:_ ~loc ~path x args =
-    Args.apply t.spec args (t.gen ~loc ~path x)
+    Args.apply t.spec args (t.gen ~loc ~path:(Code_path.to_string_path path) x)
   ;;
 
   let apply_all ~loc ~path entry (name, generators, args) =

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -137,7 +137,7 @@ module Generator = struct
   type deriver = t
   type ('a, 'b) t =
     | T : { spec           : ('c, 'a) Args.t
-          ; gen            : ctxt:Expansion_context.t -> 'b -> 'c
+          ; gen            : ctxt:Expansion_context.Deriver.t -> 'b -> 'c
           ; arg_names      : Set.M(String).t
           ; attributes     : Attribute.packed list
           ; deps           : deriver list
@@ -160,7 +160,7 @@ module Generator = struct
   end
 
   let make ?attributes ?deps spec gen =
-    V2.make ?attributes ?deps spec (Expansion_context.with_loc_and_path gen)
+    V2.make ?attributes ?deps spec (Expansion_context.Deriver.with_loc_and_path gen)
 
   let make_noarg ?attributes ?deps gen = make ?attributes ?deps Args.empty gen
 
@@ -616,32 +616,32 @@ let expand_str_type_decls ~ctxt rec_flag tds values =
     types_used_by_deriving tds
     @ Generator.apply_all ~ctxt (rec_flag, tds) generators;
   in
-  disable_unused_warning_str ~loc:(Expansion_context.loc ctxt) generated
+  disable_unused_warning_str ~loc:(Expansion_context.Deriver.derived_item_loc ctxt) generated
 
 let expand_sig_type_decls ~ctxt rec_flag tds values =
   let generators = merge_generators Deriver.Field.sig_type_decl values in
   let generated = Generator.apply_all ~ctxt (rec_flag, tds) generators in
-  disable_unused_warning_sig ~loc:(Expansion_context.loc ctxt) generated
+  disable_unused_warning_sig ~loc:(Expansion_context.Deriver.derived_item_loc ctxt) generated
 
 let expand_str_exception ~ctxt ec generators =
   let generators = Deriver.resolve_all Deriver.Field.str_exception generators in
   let generated = Generator.apply_all ~ctxt ec generators in
-  disable_unused_warning_str ~loc:(Expansion_context.loc ctxt) generated
+  disable_unused_warning_str ~loc:(Expansion_context.Deriver.derived_item_loc ctxt) generated
 
 let expand_sig_exception ~ctxt ec generators =
   let generators = Deriver.resolve_all Deriver.Field.sig_exception generators in
   let generated = Generator.apply_all ~ctxt ec generators in
-  disable_unused_warning_sig ~loc:(Expansion_context.loc ctxt) generated
+  disable_unused_warning_sig ~loc:(Expansion_context.Deriver.derived_item_loc ctxt) generated
 
 let expand_str_type_ext ~ctxt te generators =
   let generators = Deriver.resolve_all Deriver.Field.str_type_ext generators in
   let generated = Generator.apply_all ~ctxt te generators in
-  disable_unused_warning_str ~loc:(Expansion_context.loc ctxt) generated
+  disable_unused_warning_str ~loc:(Expansion_context.Deriver.derived_item_loc ctxt) generated
 
 let expand_sig_type_ext ~ctxt te generators =
   let generators = Deriver.resolve_all Deriver.Field.sig_type_ext generators in
   let generated = Generator.apply_all ~ctxt te generators in
-  disable_unused_warning_sig ~loc:(Expansion_context.loc ctxt) generated
+  disable_unused_warning_sig ~loc:(Expansion_context.Deriver.derived_item_loc ctxt) generated
 
 let () =
   Driver.register_transformation "deriving"

--- a/src/deriving.mli
+++ b/src/deriving.mli
@@ -62,21 +62,20 @@ module Generator : sig
       :  ?attributes:Attribute.packed list
       -> ?deps:deriver list
       -> ('f, 'output_ast) Args.t
-      -> (loc:Location.t -> path:Code_path.t -> 'input_ast -> 'f)
+      -> (ctxt:Expansion_context.t -> 'input_ast -> 'f)
       -> ('output_ast, 'input_ast) t
 
     val make_noarg
       :  ?attributes:Attribute.packed list
       -> ?deps:deriver list
-      -> (loc:Location.t -> path:Code_path.t -> 'input_ast -> 'output_ast)
+      -> (ctxt:Expansion_context.t -> 'input_ast -> 'output_ast)
       -> ('output_ast, 'input_ast) t
   end
 
   val apply
     :  ('output_ast, 'input_ast) t
     -> name:string
-    -> loc:Location.t
-    -> path:Code_path.t
+    -> ctxt:Expansion_context.t
     -> 'input_ast
     -> (string * expression) list
     -> 'output_ast

--- a/src/deriving.mli
+++ b/src/deriving.mli
@@ -61,7 +61,7 @@ module Generator : sig
     :  ('output_ast, 'input_ast) t
     -> name:string
     -> loc:Location.t
-    -> path:string
+    -> path:Code_path.t
     -> 'input_ast
     -> (string * expression) list
     -> 'output_ast

--- a/src/deriving.mli
+++ b/src/deriving.mli
@@ -62,20 +62,20 @@ module Generator : sig
       :  ?attributes:Attribute.packed list
       -> ?deps:deriver list
       -> ('f, 'output_ast) Args.t
-      -> (ctxt:Expansion_context.t -> 'input_ast -> 'f)
+      -> (ctxt:Expansion_context.Deriver.t -> 'input_ast -> 'f)
       -> ('output_ast, 'input_ast) t
 
     val make_noarg
       :  ?attributes:Attribute.packed list
       -> ?deps:deriver list
-      -> (ctxt:Expansion_context.t -> 'input_ast -> 'output_ast)
+      -> (ctxt:Expansion_context.Deriver.t -> 'input_ast -> 'output_ast)
       -> ('output_ast, 'input_ast) t
   end
 
   val apply
     :  ('output_ast, 'input_ast) t
     -> name:string
-    -> ctxt:Expansion_context.t
+    -> ctxt:Expansion_context.Deriver.t
     -> 'input_ast
     -> (string * expression) list
     -> 'output_ast

--- a/src/deriving.mli
+++ b/src/deriving.mli
@@ -57,6 +57,21 @@ module Generator : sig
     -> (loc:Location.t -> path:string -> 'input_ast -> 'output_ast)
     -> ('output_ast, 'input_ast) t
 
+  module V2 : sig
+    val make
+      :  ?attributes:Attribute.packed list
+      -> ?deps:deriver list
+      -> ('f, 'output_ast) Args.t
+      -> (loc:Location.t -> path:Code_path.t -> 'input_ast -> 'f)
+      -> ('output_ast, 'input_ast) t
+
+    val make_noarg
+      :  ?attributes:Attribute.packed list
+      -> ?deps:deriver list
+      -> (loc:Location.t -> path:Code_path.t -> 'input_ast -> 'output_ast)
+      -> ('output_ast, 'input_ast) t
+  end
+
   val apply
     :  ('output_ast, 'input_ast) t
     -> name:string

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -172,7 +172,8 @@ module Transform = struct
             let whole_loc = loc_of_list st ~get_loc:(fun st -> st.Parsetree.pstr_loc) in
             gen_header_and_footer Structure_item whole_loc f
         in
-        let st = map#structure (File_path.get_default_path_str st) st in
+        let file_path = File_path.get_default_path_str st in
+        let st = map#structure (Code_path.top_level ~file_path) st in
         match header, footer with
         | [], [] -> st
         | _      -> List.concat [ header; st; footer ]
@@ -190,7 +191,8 @@ module Transform = struct
             let whole_loc = loc_of_list sg ~get_loc:(fun sg -> sg.Parsetree.psig_loc) in
             gen_header_and_footer Signature_item whole_loc f
         in
-        let sg = map#signature (File_path.get_default_path_sig sg) sg in
+        let file_path = File_path.get_default_path_sig sg in
+        let sg = map#signature (Code_path.top_level ~file_path) sg in
         match header, footer with
         | [], [] -> sg
         | _      -> List.concat [ header; sg; footer ]

--- a/src/expansion_context.ml
+++ b/src/expansion_context.ml
@@ -1,0 +1,12 @@
+type t =
+  { loc : Location.t
+  ; code_path : Code_path.t
+  }
+
+let make ~loc ~code_path = {loc; code_path}
+
+let loc t = t.loc
+let code_path t = t.code_path
+
+let with_loc_and_path f =
+  fun ~ctxt -> f ~loc:ctxt.loc ~path:(Code_path.to_string_path ctxt.code_path)

--- a/src/expansion_context.ml
+++ b/src/expansion_context.ml
@@ -1,12 +1,29 @@
-type t =
-  { loc : Location.t
-  ; code_path : Code_path.t
-  }
+module Extension = struct
+  type t =
+    { extension_point_loc : Location.t
+    ; code_path : Code_path.t
+    }
 
-let make ~loc ~code_path = {loc; code_path}
+  let make ~extension_point_loc ~code_path = {extension_point_loc; code_path}
 
-let loc t = t.loc
-let code_path t = t.code_path
+  let extension_point_loc t = t.extension_point_loc
+  let code_path t = t.code_path
 
-let with_loc_and_path f =
-  fun ~ctxt -> f ~loc:ctxt.loc ~path:(Code_path.to_string_path ctxt.code_path)
+  let with_loc_and_path f =
+    fun ~ctxt -> f ~loc:ctxt.extension_point_loc ~path:(Code_path.to_string_path ctxt.code_path)
+end
+
+module Deriver = struct
+  type t =
+    { derived_item_loc : Location.t
+    ; code_path : Code_path.t
+    }
+
+  let make ~derived_item_loc ~code_path = {derived_item_loc; code_path}
+
+  let derived_item_loc t = t.derived_item_loc
+  let code_path t = t.code_path
+
+  let with_loc_and_path f =
+    fun ~ctxt -> f ~loc:ctxt.derived_item_loc ~path:(Code_path.to_string_path ctxt.code_path)
+end

--- a/src/expansion_context.mli
+++ b/src/expansion_context.mli
@@ -1,14 +1,33 @@
-(** Type of expansion contexts *)
-type t
+module Extension : sig
+  (** Type of expansion contexts for extensions *)
+  type t
 
-(** Build a new expansion context with the given location and code path *)
-val make : loc:Location.t -> code_path:Code_path.t -> t
+  (** Build a new expansion context with the given extension point location and code path *)
+  val make : extension_point_loc:Location.t -> code_path:Code_path.t -> t
 
-(** Return the location for the given expansion context *)
-val loc : t -> Location.t
+  (** Return the location of the extension point being expanded *)
+  val extension_point_loc : t -> Location.t
 
-(** Return the code path for the given expansion context *)
-val code_path : t -> Code_path.t
+  (** Return the code path for the given context *)
+  val code_path : t -> Code_path.t
 
-(** Wrap a [fun ~loc ~path] into a [fun ~ctxt] *)
-val with_loc_and_path : (loc:Location.t -> path:string -> 'a) -> (ctxt:t -> 'a)
+  (** Wrap a [fun ~loc ~path] into a [fun ~ctxt] *)
+  val with_loc_and_path : (loc:Location.t -> path:string -> 'a) -> (ctxt:t -> 'a)
+end
+
+module Deriver : sig
+  (** Type of expansion contexts for derivers *)
+  type t
+
+  (** Build a new expansion context with the given item location and code path *)
+  val make : derived_item_loc:Location.t -> code_path:Code_path.t -> t
+
+  (** Return the location of the item to which the deriver is being applied *)
+  val derived_item_loc : t -> Location.t
+
+  (** Return the code path for the given context *)
+  val code_path : t -> Code_path.t
+
+  (** Wrap a [fun ~loc ~path] into a [fun ~ctxt] *)
+  val with_loc_and_path : (loc:Location.t -> path:string -> 'a) -> (ctxt:t -> 'a)
+end

--- a/src/expansion_context.mli
+++ b/src/expansion_context.mli
@@ -2,9 +2,6 @@ module Extension : sig
   (** Type of expansion contexts for extensions *)
   type t
 
-  (** Build a new expansion context with the given extension point location and code path *)
-  val make : extension_point_loc:Location.t -> code_path:Code_path.t -> t
-
   (** Return the location of the extension point being expanded *)
   val extension_point_loc : t -> Location.t
 
@@ -13,14 +10,17 @@ module Extension : sig
 
   (** Wrap a [fun ~loc ~path] into a [fun ~ctxt] *)
   val with_loc_and_path : (loc:Location.t -> path:string -> 'a) -> (ctxt:t -> 'a)
+
+  (**/**)
+  (** Undocumented section *)
+
+  (** Build a new expansion context with the given extension point location and code path *)
+  val make : extension_point_loc:Location.t -> code_path:Code_path.t -> t
 end
 
 module Deriver : sig
   (** Type of expansion contexts for derivers *)
   type t
-
-  (** Build a new expansion context with the given item location and code path *)
-  val make : derived_item_loc:Location.t -> code_path:Code_path.t -> t
 
   (** Return the location of the item to which the deriver is being applied *)
   val derived_item_loc : t -> Location.t
@@ -30,4 +30,10 @@ module Deriver : sig
 
   (** Wrap a [fun ~loc ~path] into a [fun ~ctxt] *)
   val with_loc_and_path : (loc:Location.t -> path:string -> 'a) -> (ctxt:t -> 'a)
+
+  (**/**)
+  (** Undocumented section *)
+
+  (** Build a new expansion context with the given item location and code path *)
+  val make : derived_item_loc:Location.t -> code_path:Code_path.t -> t
 end

--- a/src/expansion_context.mli
+++ b/src/expansion_context.mli
@@ -1,0 +1,14 @@
+(** Type of expansion contexts *)
+type t
+
+(** Build a new expansion context with the given location and code path *)
+val make : loc:Location.t -> code_path:Code_path.t -> t
+
+(** Return the location for the given expansion context *)
+val loc : t -> Location.t
+
+(** Return the code path for the given expansion context *)
+val code_path : t -> Code_path.t
+
+(** Wrap a [fun ~loc ~path] into a [fun ~ctxt] *)
+val with_loc_and_path : (loc:Location.t -> path:string -> 'a) -> (ctxt:t -> 'a)

--- a/src/extension.ml
+++ b/src/extension.ml
@@ -163,7 +163,7 @@ module Expert = struct
 end
 
 module M = Make(struct
-    type 'a t = loc:Location.t -> path:Code_path.t -> arg:Longident.t Loc.t option -> 'a
+    type 'a t = ctxt:Expansion_context.t -> arg:Longident.t Loc.t option -> 'a
   end)
 
 type 'a expander_result =
@@ -173,20 +173,22 @@ type 'a expander_result =
 module For_context = struct
   type 'a t = ('a, 'a expander_result) M.t
 
-  let convert ts ~loc ~path ext =
+  let convert ts ~ctxt ext =
+    let loc = Expansion_context.loc ctxt in
     match M.find ts ext with
     | None -> None
     | Some ({ payload = M.Payload_parser (pattern, f); _  }, arg) ->
-      match Ast_pattern.parse pattern loc (snd ext) (f ~loc ~path ~arg) with
+      match Ast_pattern.parse pattern loc (snd ext) (f ~ctxt ~arg) with
       | Simple x -> Some x
       | Inline _ -> failwith "Extension.convert"
   ;;
 
-  let convert_inline ts ~loc ~path ext =
+  let convert_inline ts ~ctxt ext =
+    let loc = Expansion_context.loc ctxt in
     match M.find ts ext with
     | None -> None
     | Some ({ payload = M.Payload_parser (pattern, f); _  }, arg) ->
-      match Ast_pattern.parse pattern loc (snd ext) (f ~loc ~path ~arg) with
+      match Ast_pattern.parse pattern loc (snd ext) (f ~ctxt ~arg) with
       | Simple x -> Some [x]
       | Inline l -> Some l
   ;;
@@ -283,29 +285,29 @@ module V3 = struct
   let declare name context pattern k =
     let pattern = Ast_pattern.map_result pattern ~f:(fun x -> Simple x) in
     T (M.declare ~with_arg:false name context pattern
-         (fun ~loc ~path ~arg:_ -> k ~loc ~path))
+         (fun ~ctxt ~arg:_ -> k ~ctxt))
 
   let declare_inline name context pattern k =
     check_context_for_inline context ~func:"Extension.declare_inline";
     let pattern = Ast_pattern.map_result pattern ~f:(fun x -> Inline x) in
     T (M.declare ~with_arg:false name context pattern
-         (fun ~loc ~path ~arg:_ -> k ~loc ~path))
+         (fun ~ctxt ~arg:_ -> k ~ctxt))
 end
 
 let declare name context pattern f =
-  V3.declare name context pattern (Code_path.with_string_path f)
+  V3.declare name context pattern (Expansion_context.with_loc_and_path f)
 
 let declare_inline name context pattern f =
-  V3.declare_inline name context pattern (Code_path.with_string_path f)
+  V3.declare_inline name context pattern (Expansion_context.with_loc_and_path f)
 
 let declare_with_path_arg name context pattern k =
-  let k' = Code_path.with_string_path k in
+  let k' = Expansion_context.with_loc_and_path k in
   let pattern = Ast_pattern.map_result pattern ~f:(fun x -> Simple x) in
   T (M.declare ~with_arg:true  name context pattern k')
 ;;
 
 let declare_inline_with_path_arg name context pattern k =
-  let k' = Code_path.with_string_path k in
+  let k' = Expansion_context.with_loc_and_path k in
   check_context_for_inline context ~func:"Extension.declare_inline_with_path_arg";
   let pattern = Ast_pattern.map_result pattern ~f:(fun x -> Inline x) in
   T (M.declare ~with_arg:true name context pattern k')

--- a/src/extension.ml
+++ b/src/extension.ml
@@ -292,22 +292,20 @@ module V2 = struct
          (fun ~loc ~path ~arg:_ -> k ~loc ~path))
 end
 
-let with_string_path f ~loc ~path = f ~loc ~path:(Code_path.to_string_path path)
-
 let declare name context pattern f =
-  V2.declare name context pattern (with_string_path f)
+  V2.declare name context pattern (Code_path.with_string_path f)
 
 let declare_inline name context pattern f =
-  V2.declare_inline name context pattern (with_string_path f)
+  V2.declare_inline name context pattern (Code_path.with_string_path f)
 
 let declare_with_path_arg name context pattern k =
-  let k' = with_string_path k in
+  let k' = Code_path.with_string_path k in
   let pattern = Ast_pattern.map_result pattern ~f:(fun x -> Simple x) in
   T (M.declare ~with_arg:true  name context pattern k')
 ;;
 
 let declare_inline_with_path_arg name context pattern k =
-  let k' = with_string_path k in
+  let k' = Code_path.with_string_path k in
   check_context_for_inline context ~func:"Extension.declare_inline_with_path_arg";
   let pattern = Ast_pattern.map_result pattern ~f:(fun x -> Inline x) in
   T (M.declare ~with_arg:true name context pattern k')

--- a/src/extension.ml
+++ b/src/extension.ml
@@ -277,7 +277,7 @@ let check_unused = object
     | x -> super#structure_item_desc x
 end
 
-module V2 = struct
+module V3 = struct
   type nonrec t = t
 
   let declare name context pattern k =
@@ -293,10 +293,10 @@ module V2 = struct
 end
 
 let declare name context pattern f =
-  V2.declare name context pattern (Code_path.with_string_path f)
+  V3.declare name context pattern (Code_path.with_string_path f)
 
 let declare_inline name context pattern f =
-  V2.declare_inline name context pattern (Code_path.with_string_path f)
+  V3.declare_inline name context pattern (Code_path.with_string_path f)
 
 let declare_with_path_arg name context pattern k =
   let k' = Code_path.with_string_path k in
@@ -310,3 +310,10 @@ let declare_inline_with_path_arg name context pattern k =
   let pattern = Ast_pattern.map_result pattern ~f:(fun x -> Inline x) in
   T (M.declare ~with_arg:true name context pattern k')
 ;;
+
+module V2 = struct
+  type nonrec t = t
+
+  let declare = declare
+  let declare_inline = declare_inline
+end

--- a/src/extension.ml
+++ b/src/extension.ml
@@ -163,7 +163,7 @@ module Expert = struct
 end
 
 module M = Make(struct
-    type 'a t = ctxt:Expansion_context.t -> arg:Longident.t Loc.t option -> 'a
+    type 'a t = ctxt:Expansion_context.Extension.t -> arg:Longident.t Loc.t option -> 'a
   end)
 
 type 'a expander_result =
@@ -174,7 +174,7 @@ module For_context = struct
   type 'a t = ('a, 'a expander_result) M.t
 
   let convert ts ~ctxt ext =
-    let loc = Expansion_context.loc ctxt in
+    let loc = Expansion_context.Extension.extension_point_loc ctxt in
     match M.find ts ext with
     | None -> None
     | Some ({ payload = M.Payload_parser (pattern, f); _  }, arg) ->
@@ -184,7 +184,7 @@ module For_context = struct
   ;;
 
   let convert_inline ts ~ctxt ext =
-    let loc = Expansion_context.loc ctxt in
+    let loc = Expansion_context.Extension.extension_point_loc ctxt in
     match M.find ts ext with
     | None -> None
     | Some ({ payload = M.Payload_parser (pattern, f); _  }, arg) ->
@@ -295,19 +295,19 @@ module V3 = struct
 end
 
 let declare name context pattern f =
-  V3.declare name context pattern (Expansion_context.with_loc_and_path f)
+  V3.declare name context pattern (Expansion_context.Extension.with_loc_and_path f)
 
 let declare_inline name context pattern f =
-  V3.declare_inline name context pattern (Expansion_context.with_loc_and_path f)
+  V3.declare_inline name context pattern (Expansion_context.Extension.with_loc_and_path f)
 
 let declare_with_path_arg name context pattern k =
-  let k' = Expansion_context.with_loc_and_path k in
+  let k' = Expansion_context.Extension.with_loc_and_path k in
   let pattern = Ast_pattern.map_result pattern ~f:(fun x -> Simple x) in
   T (M.declare ~with_arg:true  name context pattern k')
 ;;
 
 let declare_inline_with_path_arg name context pattern k =
-  let k' = Expansion_context.with_loc_and_path k in
+  let k' = Expansion_context.Extension.with_loc_and_path k in
   check_context_for_inline context ~func:"Extension.declare_inline_with_path_arg";
   let pattern = Ast_pattern.map_result pattern ~f:(fun x -> Inline x) in
   T (M.declare ~with_arg:true name context pattern k')

--- a/src/extension.mli
+++ b/src/extension.mli
@@ -151,6 +151,22 @@ module V2 : sig
     :  string
     -> 'context Context.t
     -> (payload, 'a, 'context) Ast_pattern.t
+    -> (loc:Location.t -> path:string -> 'a)
+    -> t
+  val declare_inline
+    :  string
+    -> 'context Context.t
+    -> (payload, 'a, 'context list) Ast_pattern.t
+    -> (loc:Location.t -> path:string -> 'a)
+    -> t
+end
+
+module V3 : sig
+  type nonrec t = t
+  val declare
+    :  string
+    -> 'context Context.t
+    -> (payload, 'a, 'context) Ast_pattern.t
     -> (loc:Location.t -> path:Code_path.t -> 'a)
     -> t
   val declare_inline

--- a/src/extension.mli
+++ b/src/extension.mli
@@ -98,15 +98,13 @@ module For_context : sig
 
   val convert
     :  'a t list
-    -> loc:Location.t
-    -> path:Code_path.t
+    -> ctxt:Expansion_context.t
     -> extension
     -> 'a option
 
   val convert_inline
     :  'a t list
-    -> loc:Location.t
-    -> path:Code_path.t
+    -> ctxt:Expansion_context.t
     -> extension
     -> 'a list option
 end
@@ -167,13 +165,13 @@ module V3 : sig
     :  string
     -> 'context Context.t
     -> (payload, 'a, 'context) Ast_pattern.t
-    -> (loc:Location.t -> path:Code_path.t -> 'a)
+    -> (ctxt:Expansion_context.t -> 'a)
     -> t
   val declare_inline
     :  string
     -> 'context Context.t
     -> (payload, 'a, 'context list) Ast_pattern.t
-    -> (loc:Location.t -> path:Code_path.t -> 'a)
+    -> (ctxt:Expansion_context.t -> 'a)
     -> t
 end
 

--- a/src/extension.mli
+++ b/src/extension.mli
@@ -99,14 +99,14 @@ module For_context : sig
   val convert
     :  'a t list
     -> loc:Location.t
-    -> path:string
+    -> path:Code_path.t
     -> extension
     -> 'a option
 
   val convert_inline
     :  'a t list
     -> loc:Location.t
-    -> path:string
+    -> path:Code_path.t
     -> extension
     -> 'a list option
 end
@@ -151,13 +151,13 @@ module V2 : sig
     :  string
     -> 'context Context.t
     -> (payload, 'a, 'context) Ast_pattern.t
-    -> (loc:Location.t -> path:string -> 'a)
+    -> (loc:Location.t -> path:Code_path.t -> 'a)
     -> t
   val declare_inline
     :  string
     -> 'context Context.t
     -> (payload, 'a, 'context list) Ast_pattern.t
-    -> (loc:Location.t -> path:string -> 'a)
+    -> (loc:Location.t -> path:Code_path.t -> 'a)
     -> t
 end
 

--- a/src/extension.mli
+++ b/src/extension.mli
@@ -98,13 +98,13 @@ module For_context : sig
 
   val convert
     :  'a t list
-    -> ctxt:Expansion_context.t
+    -> ctxt:Expansion_context.Extension.t
     -> extension
     -> 'a option
 
   val convert_inline
     :  'a t list
-    -> ctxt:Expansion_context.t
+    -> ctxt:Expansion_context.Extension.t
     -> extension
     -> 'a list option
 end
@@ -165,13 +165,13 @@ module V3 : sig
     :  string
     -> 'context Context.t
     -> (payload, 'a, 'context) Ast_pattern.t
-    -> (ctxt:Expansion_context.t -> 'a)
+    -> (ctxt:Expansion_context.Extension.t -> 'a)
     -> t
   val declare_inline
     :  string
     -> 'context Context.t
     -> (payload, 'a, 'context list) Ast_pattern.t
-    -> (ctxt:Expansion_context.t -> 'a)
+    -> (ctxt:Expansion_context.Extension.t -> 'a)
     -> t
 end
 

--- a/src/ppxlib.ml
+++ b/src/ppxlib.ml
@@ -36,6 +36,7 @@ module Caller_id           = Caller_id
 module Context_free        = Context_free
 module Deriving            = Deriving
 module Driver              = Driver
+module Expansion_context   = Expansion_context
 module Extension           = Extension
 module File_path           = File_path
 module Loc                 = Loc

--- a/src/ppxlib.ml
+++ b/src/ppxlib.ml
@@ -31,6 +31,7 @@ module Ast_builder         = Ast_builder
 module Ast_pattern         = Ast_pattern
 module Ast_traverse        = Ast_traverse
 module Attribute           = Attribute
+module Code_path           = Code_path
 module Caller_id           = Caller_id
 module Context_free        = Context_free
 module Deriving            = Deriving

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -117,9 +117,9 @@ let complex_path =
   let open Ppxlib.Code_path in
   let loc = Ppxlib.Location.none in
   top_level ~file_path:"dir/main.ml"
-  |> enter ~loc "Sub"
-  |> enter ~loc "Sub_sub"
-  |> enter ~loc "some_val"
+  |> enter_module ~loc "Sub"
+  |> enter_module ~loc "Sub_sub"
+  |> enter_value ~loc "some_val"
 [%%expect{|
 val complex_path : Code_path.t = <abstr>
 |}]

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -102,3 +102,33 @@ let _ = convert_longident "Base.( land )"
 ("Base.( land )",
  Ppxlib.Longident.Ldot (Ppxlib.Longident.Lident "Base", "land"))
 |}]
+
+let _ = Ppxlib.Code_path.(file_path @@ top_level ~file_path:"dir/main.ml")
+[%%expect{|
+- : string = "dir/main.ml"
+|}]
+
+let _ = Ppxlib.Code_path.(fully_qualified_path @@ top_level ~file_path:"dir/main.ml")
+[%%expect{|
+- : string = "Main"
+|}]
+
+let complex_path =
+  let open Ppxlib.Code_path in
+  top_level ~file_path:"dir/main.ml"
+  |> enter "Sub"
+  |> enter "Sub_sub"
+  |> enter "some_val"
+[%%expect{|
+val complex_path : Code_path.t = <abstr>
+|}]
+
+let _ = Ppxlib.Code_path.fully_qualified_path complex_path
+[%%expect{|
+- : string = "Main.Sub.Sub_sub.some_val"
+|}]
+
+let _ = Ppxlib.Code_path.to_string_path complex_path
+[%%expect{|
+- : string = "dir/main.ml.Sub.Sub_sub"
+|}]

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -115,10 +115,11 @@ let _ = Ppxlib.Code_path.(fully_qualified_path @@ top_level ~file_path:"dir/main
 
 let complex_path =
   let open Ppxlib.Code_path in
+  let loc = Ppxlib.Location.none in
   top_level ~file_path:"dir/main.ml"
-  |> enter "Sub"
-  |> enter "Sub_sub"
-  |> enter "some_val"
+  |> enter ~loc "Sub"
+  |> enter ~loc "Sub_sub"
+  |> enter ~loc "some_val"
 [%%expect{|
 val complex_path : Code_path.t = <abstr>
 |}]

--- a/test/code_path/dune
+++ b/test/code_path/dune
@@ -1,0 +1,10 @@
+(alias
+ (name runtest)
+ (deps
+  (:test test.ml)
+  (glob_files %{project_root}/src/.ppxlib.objs/byte/*.cmi))
+ (action (chdir %{project_root}
+          (progn
+           (ignore-outputs
+            (run %{project_root}/test/expect/expect_test.exe %{test}))
+           (diff? %{test} %{test}.corrected)))))

--- a/test/code_path/test.ml
+++ b/test/code_path/test.ml
@@ -38,5 +38,5 @@ let s =
   end
   in A.A'.a
 [%%expect{|
-val s : string = "Test.s.A'.a.B'.b.C'.c"
+val s : string = "Test.s"
 |}]

--- a/test/code_path/test.ml
+++ b/test/code_path/test.ml
@@ -1,0 +1,42 @@
+#use "topfind";;
+#require "base";;
+
+open Ppxlib
+
+let () =
+  Driver.register_transformation "test"
+    ~extensions:[
+      Extension.V3.declare "code_path"
+        Expression
+        Ast_pattern.(pstr nil)
+        (fun ~ctxt ->
+           let loc = Expansion_context.Extension.extension_point_loc ctxt in
+           let code_path = Expansion_context.Extension.code_path ctxt in
+           Ast_builder.Default.estring ~loc
+             (Code_path.fully_qualified_path code_path))
+    ]
+[%%expect{|
+|}]
+
+let s =
+  let module A = struct
+    module A' = struct
+      let a =
+        let module B = struct
+          module B' = struct
+            let b =
+              let module C = struct
+                module C' = struct
+                  let c = [%code_path]
+                end
+              end
+              in C.C'.c
+          end
+        end
+        in B.B'.b
+    end
+  end
+  in A.A'.a
+[%%expect{|
+val s : string = "Test.s.A'.a.B'.b.C'.c"
+|}]

--- a/test/code_path/test.ml
+++ b/test/code_path/test.ml
@@ -37,6 +37,16 @@ let s =
     end
   end
   in A.A'.a
+;;
 [%%expect{|
 val s : string = "Test.s"
+|}]
+
+let module M = struct
+  let m = [%code_path]
+  end
+  in
+  M.m
+[%%expect{|
+- : string = "Test"
 |}]


### PR DESCRIPTION
Fixes #65 

This is PR adds a new `Code_path` module to represent code path in an abstract and improved way.
It exposes an abstract type, a smart constructor and a few accessors.

It also adds an `Ast_traverse.map_with_code_path` class similar to the current `map_with_path` which uses the new representation instead of a string.

This is now used by `Driver`, `Deriving` and `Extension` in order to expose V2 variants that pass a `Code_path.t` to expanders. V1 functions are just rewritten on top of them.
