### PR TITLE
Allow to opt-out from marking attributes as seen

### DIFF
--- a/src/attribute.ml
+++ b/src/attribute.ml
@@ -338,18 +338,18 @@ let get_internal =
     find_best_match t attributes None
 ;;
 
-let convert pattern attr =
-  mark_as_seen attr;
+let convert ?(do_mark_as_seen = true) pattern attr =
+  if do_mark_as_seen then mark_as_seen attr;
   let (Payload_parser (pattern, k)) = pattern in
   Ast_pattern.parse pattern (Common.loc_of_payload attr) (snd attr)
     (k ~name_loc:(fst attr).loc)
 ;;
 
-let get t x =
+let get t ?mark_as_seen:do_mark_as_seen x =
   let attrs = Context.get_attributes t.context x in
   match get_internal t attrs with
   | None -> None
-  | Some attr -> Some (convert t.payload attr)
+  | Some attr -> Some (convert t.payload attr ?do_mark_as_seen)
 ;;
 
 let consume t x =

--- a/src/attribute.mli
+++ b/src/attribute.mli
@@ -135,7 +135,13 @@ val declare_with_name_loc
 val name : _ t -> string
 val context : ('a, _) t -> 'a Context.t
 
-val get : ('a, 'b) t -> 'a -> 'b option
+(** Gets the associated attribute value. Marks the attribute as seen unless
+    [mark_as_seen=false]. *)
+val get
+  :  ('a, 'b) t
+  -> ?mark_as_seen:bool (** default [true] *)
+  -> 'a
+  -> 'b option
 
 (** [consume t x] returns the value associated to attribute [t] on [x] if present as well
     as [x] with [t] removed. *)


### PR DESCRIPTION
It seems desirable to be able to inspect an attribute
without marking it as seen.