### PR TITLE
Add omp_config to expansion context

### DIFF
--- a/src/ast_traverse.mli
+++ b/src/ast_traverse.mli
@@ -54,7 +54,7 @@ end
 
 class map_with_path : [string] map_with_context
 
-class map_with_code_path : [Code_path.t] map_with_context
+class map_with_expansion_context : [Expansion_context.Base.t] map_with_context
 
 class virtual ['res] lift : object
   inherit ['res] Ppxlib_traverse_builtins.lift

--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -198,7 +198,7 @@ module Generated_code_hook = struct
 end
 
 let rec map_node_rec context ts super_call loc base_ctxt x =
-  let ctxt = Expansion_context.Extension.make ~extension_point_loc:loc ~base:base_ctxt in
+  let ctxt = Expansion_context.Extension.make ~extension_point_loc:loc ~base:base_ctxt () in
   match EC.get_extension context x with
   | None -> super_call base_ctxt x
   | Some (ext, attrs) ->
@@ -209,7 +209,7 @@ let rec map_node_rec context ts super_call loc base_ctxt x =
 ;;
 
 let map_node context ts super_call loc base_ctxt x ~hook =
-  let ctxt = Expansion_context.Extension.make ~extension_point_loc:loc ~base:base_ctxt in
+  let ctxt = Expansion_context.Extension.make ~extension_point_loc:loc ~base:base_ctxt () in
   match EC.get_extension context x with
   | None -> super_call base_ctxt x
   | Some (ext, attrs) ->
@@ -236,7 +236,7 @@ let rec map_nodes context ts super_call get_loc base_ctxt l ~hook ~in_generated_
       x :: l
     | Some (ext, attrs) ->
       let extension_point_loc = get_loc x in
-      let ctxt = Expansion_context.Extension.make ~extension_point_loc ~base:base_ctxt in
+      let ctxt = Expansion_context.Extension.make ~extension_point_loc ~base:base_ctxt () in
       match E.For_context.convert_inline ts ~ctxt ext with
       | None ->
         let x = super_call base_ctxt x in
@@ -321,7 +321,7 @@ let handle_attr_group_inline attrs rf items ~loc ~base_ctxt =
       match get_group group.attribute items with
       | None -> acc
       | Some values ->
-        let ctxt = Expansion_context.Deriver.make ~derived_item_loc:loc ~base:base_ctxt in
+        let ctxt = Expansion_context.Deriver.make ~derived_item_loc:loc ~base:base_ctxt () in
         let expect_items = group.expand ~ctxt rf items values in
         expect_items :: acc)
 
@@ -331,7 +331,7 @@ let handle_attr_inline attrs item ~loc ~base_ctxt =
       match Attribute.get a.attribute item with
       | None -> acc
       | Some value ->
-        let ctxt = Expansion_context.Deriver.make ~derived_item_loc:loc ~base:base_ctxt in
+        let ctxt = Expansion_context.Deriver.make ~derived_item_loc:loc ~base:base_ctxt () in
         let expect_items = a.expand ~ctxt item value in
         expect_items :: acc)
 
@@ -545,7 +545,7 @@ class map_top_down ?(expect_mismatch_handler=Expect_mismatch_handler.nop)
           match item.pstr_desc with
           | Pstr_extension (ext, attrs) -> begin
               let extension_point_loc = item.pstr_loc in
-              let ctxt = Expansion_context.Extension.make ~extension_point_loc ~base:base_ctxt in
+              let ctxt = Expansion_context.Extension.make ~extension_point_loc ~base:base_ctxt () in
               match E.For_context.convert_inline structure_item ~ctxt ext with
               | None ->
                 let item = super#structure_item base_ctxt item in
@@ -616,7 +616,7 @@ class map_top_down ?(expect_mismatch_handler=Expect_mismatch_handler.nop)
           match item.psig_desc with
           | Psig_extension (ext, attrs) -> begin
               let extension_point_loc = item.psig_loc in
-              let ctxt = Expansion_context.Extension.make ~extension_point_loc ~base:base_ctxt in
+              let ctxt = Expansion_context.Extension.make ~extension_point_loc ~base:base_ctxt () in
               match E.For_context.convert_inline signature_item ~ctxt ext with
               | None ->
                 let item = super#signature_item base_ctxt item in

--- a/src/context_free.mli
+++ b/src/context_free.mli
@@ -134,4 +134,4 @@ class map_top_down
     -> ?generated_code_hook:Generated_code_hook.t
     (* default: Generated_code_hook.nop *)
     -> Rule.t list
-    -> Ast_traverse.map_with_code_path
+    -> Ast_traverse.map_with_expansion_context

--- a/src/expansion_context.ml
+++ b/src/expansion_context.ml
@@ -1,29 +1,47 @@
-module Extension = struct
+module Base = struct
   type t =
-    { extension_point_loc : Location.t
+    { omp_config : Migrate_parsetree.Driver.config
     ; code_path : Code_path.t
     }
 
-  let make ~extension_point_loc ~code_path = {extension_point_loc; code_path}
+  let top_level ~omp_config ~file_path =
+    let code_path = Code_path.top_level ~file_path in
+    {omp_config; code_path}
+
+  let enter_expr t = {t with code_path = Code_path.enter_expr t.code_path}
+  let enter_module ~loc name t = {t with code_path = Code_path.enter_module ~loc name t.code_path}
+  let enter_value ~loc name t = {t with code_path = Code_path.enter_value ~loc name t.code_path}
+end
+
+module Extension = struct
+  type t =
+    { extension_point_loc : Location.t
+    ; base : Base.t
+    }
+
+  let make ~extension_point_loc ~base = {extension_point_loc; base}
 
   let extension_point_loc t = t.extension_point_loc
-  let code_path t = t.code_path
+  let code_path t = t.base.code_path
+  let omp_config t = t.base.omp_config
 
   let with_loc_and_path f =
-    fun ~ctxt -> f ~loc:ctxt.extension_point_loc ~path:(Code_path.to_string_path ctxt.code_path)
+    fun ~ctxt ->
+      f ~loc:ctxt.extension_point_loc ~path:(Code_path.to_string_path ctxt.base.code_path)
 end
 
 module Deriver = struct
   type t =
     { derived_item_loc : Location.t
-    ; code_path : Code_path.t
+    ; base : Base.t
     }
 
-  let make ~derived_item_loc ~code_path = {derived_item_loc; code_path}
+  let make ~derived_item_loc ~base = {derived_item_loc; base}
 
   let derived_item_loc t = t.derived_item_loc
-  let code_path t = t.code_path
+  let code_path t = t.base.code_path
+  let omp_config t = t.base.omp_config
 
   let with_loc_and_path f =
-    fun ~ctxt -> f ~loc:ctxt.derived_item_loc ~path:(Code_path.to_string_path ctxt.code_path)
+    fun ~ctxt -> f ~loc:ctxt.derived_item_loc ~path:(Code_path.to_string_path ctxt.base.code_path)
 end

--- a/src/expansion_context.ml
+++ b/src/expansion_context.ml
@@ -19,7 +19,7 @@ module Extension = struct
     ; base : Base.t
     }
 
-  let make ~extension_point_loc ~base = {extension_point_loc; base}
+  let make ~extension_point_loc ~base () = {extension_point_loc; base}
 
   let extension_point_loc t = t.extension_point_loc
   let code_path t = t.base.code_path
@@ -36,7 +36,7 @@ module Deriver = struct
     ; base : Base.t
     }
 
-  let make ~derived_item_loc ~base = {derived_item_loc; base}
+  let make ~derived_item_loc ~base () = {derived_item_loc; base}
 
   let derived_item_loc t = t.derived_item_loc
   let code_path t = t.base.code_path

--- a/src/expansion_context.mli
+++ b/src/expansion_context.mli
@@ -39,7 +39,7 @@ module Extension : sig
   (** Undocumented section *)
 
   (** Build a new expansion context with the given extension point location and base context *)
-  val make : extension_point_loc:Location.t -> base:Base.t -> t
+  val make : extension_point_loc:Location.t -> base:Base.t -> unit -> t
 end
 
 module Deriver : sig
@@ -62,5 +62,5 @@ module Deriver : sig
   (** Undocumented section *)
 
   (** Build a new expansion context with the given item location and code path *)
-  val make : derived_item_loc:Location.t -> base:Base.t -> t
+  val make : derived_item_loc:Location.t -> base:Base.t -> unit -> t
 end

--- a/src/expansion_context.mli
+++ b/src/expansion_context.mli
@@ -1,3 +1,24 @@
+module Base : sig
+  (** Type for the location independent parts of the expansion context *)
+  type t
+
+  (**/*)
+  (** Undocumented section *)
+
+  (** Build a new base context at the top level of the given file with the given
+      ocaml-mirgate-parsetree configuration.
+  *)
+  val top_level :
+    omp_config:Migrate_parsetree.Driver.config ->
+    file_path:string ->
+    t
+
+  (** Proxy functions to update the wrapped code path. See code_path.mli for details. *)
+  val enter_expr : t -> t
+  val enter_module : loc:Location.t -> string -> t -> t
+  val enter_value : loc:Location.t -> string -> t -> t
+end
+
 module Extension : sig
   (** Type of expansion contexts for extensions *)
   type t
@@ -8,14 +29,17 @@ module Extension : sig
   (** Return the code path for the given context *)
   val code_path : t -> Code_path.t
 
+  (** Return the ocaml-migrate-parsetree configuration for the given expansion context *)
+  val omp_config : t -> Migrate_parsetree.Driver.config
+
   (** Wrap a [fun ~loc ~path] into a [fun ~ctxt] *)
   val with_loc_and_path : (loc:Location.t -> path:string -> 'a) -> (ctxt:t -> 'a)
 
   (**/**)
   (** Undocumented section *)
 
-  (** Build a new expansion context with the given extension point location and code path *)
-  val make : extension_point_loc:Location.t -> code_path:Code_path.t -> t
+  (** Build a new expansion context with the given extension point location and base context *)
+  val make : extension_point_loc:Location.t -> base:Base.t -> t
 end
 
 module Deriver : sig
@@ -28,6 +52,9 @@ module Deriver : sig
   (** Return the code path for the given context *)
   val code_path : t -> Code_path.t
 
+  (** Return the ocaml-migrate-parsetree configuration for the given expansion context *)
+  val omp_config : t -> Migrate_parsetree.Driver.config
+
   (** Wrap a [fun ~loc ~path] into a [fun ~ctxt] *)
   val with_loc_and_path : (loc:Location.t -> path:string -> 'a) -> (ctxt:t -> 'a)
 
@@ -35,5 +62,5 @@ module Deriver : sig
   (** Undocumented section *)
 
   (** Build a new expansion context with the given item location and code path *)
-  val make : derived_item_loc:Location.t -> code_path:Code_path.t -> t
+  val make : derived_item_loc:Location.t -> base:Base.t -> t
 end


### PR DESCRIPTION
Fixes #61 

This PR makes it possible to recover the `Ocaml_migrate_parsetree.Driver` config from the expansion context.

This is done by extracting the location independent parts of the context into `Expansion_context.Base` and replacing `Ast_traverse.map_with_code_path` with a `map_with_expansion_ctxt_base`.