### PR TITLE
Set compiler's error-style and color through env vars in standalone mode

### DIFF
--- a/src/driver.ml
+++ b/src/driver.ml
@@ -1257,6 +1257,7 @@ let standalone_run_as_ppx_rewriter () =
 ;;
 
 let standalone () =
+  Compiler_specifics.read_clflags_from_env ();
   try
     if Array.length Caml.Sys.argv >= 2 &&
        match Caml.Sys.argv.(1) with

--- a/src/gen-compiler_specifics
+++ b/src/gen-compiler_specifics
@@ -7,8 +7,11 @@ let () =
   let oc = open_out_bin Sys.argv.(2) in
   let pr fmt = fprintf oc (fmt ^^ "\n") in
   pr "module O = Ocaml_common";
-  if ver < (4, 08) then
-    pr "let get_load_path () = !Ocaml_common.Config.load_path"
-  else
+  if ver < (4, 08) then (
+    pr "let get_load_path () = !Ocaml_common.Config.load_path";
+    pr "let read_clflags_from_env () = ()"
+  ) else (
     pr "let get_load_path () = Ocaml_common.Load_path.get_paths ()";
+    pr "let read_clflags_from_env () = Ocaml_common.Compmisc.read_clflags_from_env ()"
+  );
   close_out oc


### PR DESCRIPTION
OCaml 4.08 introduced to new flags allowing users to configure the error reporting style and use of colors.

Those can also be set via the env variables `OCAML_COLOR` and `OCAML_ERROR_STYLE`.

When using a standalone `ppxlib` driver, the appropriate flags weren't set according to those env variables and therefore the error reporting wasn't impacted.

A nice follow up could be to re-expose the command line flags from the standalone driver as well.