### PR TITLE
do not produce a suprious empty correction in deriving_inline

### DIFF
--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -599,13 +599,14 @@ class map_top_down ?(expect_mismatch_handler=Expect_mismatch_handler.nop)
         if not in_generated_code then
           Generated_code_hook.insert_after hook Signature_item item.psig_loc
             (Many extra_items);
+        let original_rest = rest in
         let rest = loop rest ~in_generated_code in
         (match expect_items with
         | [] -> ()
         | _ ->
           let expected = rev_concat expect_items in
           let pos = item.psig_loc.loc_end in
-          Code_matcher.match_signature rest ~pos ~expected
+          Code_matcher.match_signature original_rest ~pos ~expected
             ~mismatch_handler:(fun loc repl ->
               expect_mismatch_handler.f Signature_item loc repl));
         item :: (extra_items @ rest)

--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -527,13 +527,14 @@ class map_top_down ?(expect_mismatch_handler=Expect_mismatch_handler.nop)
         if not in_generated_code then
           Generated_code_hook.insert_after hook Structure_item item.pstr_loc
             (Many extra_items);
+        let original_rest = rest in
         let rest = loop rest ~in_generated_code in
         (match expect_items with
         | [] -> ()
         | _ ->
           let expected = rev_concat expect_items in
           let pos = item.pstr_loc.loc_end in
-          Code_matcher.match_structure rest ~pos ~expected
+          Code_matcher.match_structure original_rest ~pos ~expected
             ~mismatch_handler:(fun loc repl ->
               expect_mismatch_handler.f Structure_item loc repl));
         item :: (extra_items @ rest)

--- a/src/dune
+++ b/src/dune
@@ -40,7 +40,9 @@
  (action (progn
           (run %{bin:cinaps} -no-color -diff-cmd - %{ml} %{mli})
           (diff? code_matcher.ml code_matcher.ml.cinaps-corrected)
-          (diff? driver.ml driver.ml.cinaps-corrected))))
+          (diff? driver.ml driver.ml.cinaps-corrected)
+          (diff? context_free.ml context_free.ml.cinaps-corrected)
+          )))
 
 ;; This is to make the code compatible with different versions of
 ;; OCaml

--- a/test/deriving/inline/example/dune
+++ b/test/deriving/inline/example/dune
@@ -1,0 +1,5 @@
+(library
+  (name ppx_deriving_example)
+  (inline_tests)
+  (preprocess (pps ppxlib ppx_foo_deriver ppxlib.runner))
+)

--- a/test/deriving/inline/example/dune
+++ b/test/deriving/inline/example/dune
@@ -1,5 +1,9 @@
 (library
   (name ppx_deriving_example)
-  (inline_tests)
   (preprocess (pps ppxlib ppx_foo_deriver ppxlib.runner))
 )
+
+(alias
+  (name runtest)
+  (deps ppx_deriving_example.cma)
+  )

--- a/test/deriving/inline/example/ppx_deriving_example.ml
+++ b/test/deriving/inline/example/ppx_deriving_example.ml
@@ -1,2 +1,4 @@
-type t = A [@@deriving_inline foo, foo]
+type t = A [@@deriving_inline foo]
+let _ = fun (_ : t) -> ()
+let _ = [%foo ]
 [@@@deriving.end]

--- a/test/deriving/inline/example/ppx_deriving_example.ml
+++ b/test/deriving/inline/example/ppx_deriving_example.ml
@@ -1,0 +1,2 @@
+type t = A [@@deriving_inline foo, foo]
+[@@@deriving.end]

--- a/test/deriving/inline/foo-deriver/dune
+++ b/test/deriving/inline/foo-deriver/dune
@@ -1,0 +1,5 @@
+(library
+  (kind ppx_deriver)
+  (name ppx_foo_deriver)
+  (libraries base ppxlib)
+)

--- a/test/deriving/inline/foo-deriver/ppx_foo_deriver.ml
+++ b/test/deriving/inline/foo-deriver/ppx_foo_deriver.ml
@@ -1,0 +1,69 @@
+open Ppxlib
+
+(*
+   [[@@deriving foo]] expands to:
+   {[
+     let _ = [%foo]
+   ]}
+
+   and then [[%foo]] expands to ["foo"].
+*)
+
+let add_deriver () =
+  let str_type_decl =
+    Deriving.Generator.make_noarg (
+      fun ~loc ~path:_ _ ->
+        let expr desc : expression=
+          { pexp_desc = desc;
+            pexp_loc = loc;
+            pexp_attributes = [];
+          }
+        in
+        [
+          {pstr_loc = loc;
+           pstr_desc =
+             (Pstr_value (Nonrecursive, [{
+                pvb_pat =
+                  { ppat_desc = Ppat_any;
+                    ppat_loc = loc;
+                    ppat_attributes = [];
+                  }
+              ;
+                pvb_expr = expr (
+                  Pexp_extension ({loc; txt = "foo"}, PStr []));
+                pvb_attributes = [];
+                pvb_loc = loc;
+              }]));
+          }
+        ]
+    )
+      ~attributes:[]
+  in
+  let sig_type_decl =
+    Deriving.Generator.make_noarg (
+      fun ~loc ~path decl ->
+        ignore loc;
+        ignore path;
+        ignore decl;
+        [
+        ]
+    )
+  in
+  Deriving.add "foo"
+    ~str_type_decl
+    ~sig_type_decl
+
+let () =
+  Driver.register_transformation "foo"
+    ~rules:[
+      Context_free.Rule.extension
+        (Extension.declare "foo"
+           Expression Ast_pattern.__
+           (fun ~loc ~path:_ _payload ->
+              { pexp_desc = Pexp_constant (Pconst_string ("foo", None));
+                pexp_loc = loc;
+                pexp_attributes = [];
+              }))
+    ]
+
+let (_ : Deriving.t) = add_deriver ()


### PR DESCRIPTION
Do not produce a suprious empty correction when deriving_inline expands into an extension that undergoes further expansion.

Empty corrections arise in particular when `deriving_inline` can see that the generated AST differs from the one in the source file, but after passing it through the styler it becomes the same.

I tried writing a test, but it doesn't seem to demonstrate the issue.

Apparently behavior is different between the two modes the driver is invoked:
If `diff_command = "-"` then we just "exit 0" after producing the corrected file (so the AST difference goes undetected).
If `diff_command <> "-"` then we "exit 1" so a very confusing error is reported (empty diff).

If I just run inline tests with dune, I get the former behavior so it's impossible to observe the improvement. The way we run it in Jane Street, `diff_command` is not `"-"` so we can see the difference.

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>