### PR TITLE
Add support for deriving on module types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@ Unreleased
 - Add `Ppxlib.Quoter`. This module allows to generate hygienic code fragments in
   the spirit of ppx_deriving. (#92, @rgrinberg)
 
+- Allow for registering derivers on module type declarations. (#94, fix #83,
+  @rgrinberg)
+
 0.8.1
 -----
 

--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -69,6 +69,8 @@ module Rule = struct
       | Constant           : Constant.t                                             t
       | Attr_str_type_decl : (structure_item, type_declaration) Attr_group_inline.t t
       | Attr_sig_type_decl : (signature_item, type_declaration) Attr_group_inline.t t
+      | Attr_str_module_type_decl : (structure_item, module_type_declaration) Attr_inline.t t
+      | Attr_sig_module_type_decl : (signature_item, module_type_declaration) Attr_inline.t t
       | Attr_str_type_ext  : (structure_item, type_extension) Attr_inline.t         t
       | Attr_sig_type_ext  : (signature_item, type_extension) Attr_inline.t         t
       | Attr_str_exception : (structure_item, type_exception) Attr_inline.t         t
@@ -87,6 +89,8 @@ module Rule = struct
       | Attr_sig_type_ext  , Attr_sig_type_ext  -> Eq
       | Attr_str_exception , Attr_str_exception -> Eq
       | Attr_sig_exception , Attr_sig_exception -> Eq
+      | Attr_str_module_type_decl, Attr_str_module_type_decl -> Eq
+      | Attr_sig_module_type_decl, Attr_sig_module_type_decl -> Eq
       | _ -> Ne
   end
 
@@ -139,6 +143,14 @@ module Rule = struct
     T (Attr_sig_type_decl, T { attribute; expand; expect = false })
   ;;
 
+  let attr_str_module_type_decl attribute expand =
+    T (Attr_str_module_type_decl, T { attribute; expand; expect = false })
+  ;;
+
+  let attr_sig_module_type_decl attribute expand =
+    T (Attr_sig_module_type_decl, T { attribute; expand; expect = false })
+  ;;
+
   let attr_str_type_ext attribute expand =
     T (Attr_str_type_ext, T { attribute; expand; expect = false })
   ;;
@@ -161,6 +173,14 @@ module Rule = struct
 
   let attr_sig_type_decl_expect attribute expand =
     T (Attr_sig_type_decl, T { attribute; expand; expect = true })
+  ;;
+
+  let attr_str_module_type_decl_expect attribute expand =
+    T (Attr_str_module_type_decl, T { attribute; expand; expect = true })
+  ;;
+
+  let attr_sig_module_type_decl_expect attribute expand =
+    T (Attr_sig_module_type_decl, T { attribute; expand; expect = true })
   ;;
 
   let attr_str_type_ext_expect attribute expand =
@@ -379,6 +399,17 @@ class map_top_down ?(expect_mismatch_handler=Expect_mismatch_handler.nop)
     |> Rule.Attr_group_inline.split_normal_and_expect
   in
 
+  let attr_str_module_type_decls, attr_str_module_type_decls_expect =
+    Rule.filter Attr_str_module_type_decl rules
+    |> sort_attr_inline
+    |> Rule.Attr_inline.split_normal_and_expect
+  in
+  let attr_sig_module_type_decls, attr_sig_module_type_decls_expect =
+    Rule.filter Attr_sig_module_type_decl rules
+    |> sort_attr_inline
+    |> Rule.Attr_inline.split_normal_and_expect
+  in
+
   let attr_str_type_exts, attr_str_type_exts_expect =
     Rule.filter Attr_str_type_ext rules
     |> sort_attr_inline
@@ -572,6 +603,15 @@ class map_top_down ?(expect_mismatch_handler=Expect_mismatch_handler.nop)
             in
             with_extra_items item ~extra_items ~expect_items ~rest ~in_generated_code
 
+          | Pstr_modtype mtd ->
+            let extra_items =
+              handle_attr_inline attr_str_module_type_decls mtd ~loc ~base_ctxt
+            in
+            let expect_items =
+              handle_attr_inline attr_str_module_type_decls_expect mtd ~loc ~base_ctxt
+            in
+            with_extra_items item ~extra_items ~expect_items ~rest ~in_generated_code
+
           | Pstr_typext te ->
             let extra_items = handle_attr_inline attr_str_type_exts te ~loc ~base_ctxt in
             let expect_items =
@@ -641,6 +681,15 @@ class map_top_down ?(expect_mismatch_handler=Expect_mismatch_handler.nop)
             in
             let expect_items =
               handle_attr_group_inline attr_sig_type_decls_expect rf tds ~loc ~base_ctxt
+            in
+            with_extra_items item ~extra_items ~expect_items ~rest ~in_generated_code
+
+          | Psig_modtype mtd ->
+            let extra_items =
+              handle_attr_inline attr_sig_module_type_decls mtd ~loc ~base_ctxt
+            in
+            let expect_items =
+              handle_attr_inline attr_sig_module_type_decls_expect mtd ~loc ~base_ctxt
             in
             with_extra_items item ~extra_items ~expect_items ~rest ~in_generated_code
 

--- a/src/context_free.mli
+++ b/src/context_free.mli
@@ -88,6 +88,12 @@ module Rule : sig
         -> 'a list)
     -> t
 
+  val attr_str_module_type_decl : (structure_item, module_type_declaration, _) attr_inline
+  val attr_sig_module_type_decl : (signature_item, module_type_declaration, _) attr_inline
+
+  val attr_str_module_type_decl_expect : (structure_item, module_type_declaration, _) attr_inline
+  val attr_sig_module_type_decl_expect : (signature_item, module_type_declaration, _) attr_inline
+
   val attr_str_type_ext : (structure_item, type_extension, _) attr_inline
   val attr_sig_type_ext : (signature_item, type_extension, _) attr_inline
 

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -704,8 +704,8 @@ let rules_module_type_decl =
     ~expand_str:expand_str_module_type_decl
     ~expand_sig:expand_sig_module_type_decl
     ~rule_str:Context_free.Rule.attr_str_module_type_decl
-    ~rule_sig:Context_free.Rule.attr_sig_module_type_decl_expect
-    ~rule_str_expect:Context_free.Rule.attr_str_module_type_decl
+    ~rule_sig:Context_free.Rule.attr_sig_module_type_decl
+    ~rule_str_expect:Context_free.Rule.attr_str_module_type_decl_expect
     ~rule_sig_expect:Context_free.Rule.attr_sig_module_type_decl_expect
 
 let () =

--- a/src/deriving.mli
+++ b/src/deriving.mli
@@ -99,9 +99,11 @@ val add
   :  ?str_type_decl:(structure, rec_flag * type_declaration list) Generator.t
   -> ?str_type_ext :(structure, type_extension                  ) Generator.t
   -> ?str_exception:(structure, type_exception                  ) Generator.t
+  -> ?str_module_type_decl:(structure, module_type_declaration  ) Generator.t
   -> ?sig_type_decl:(signature, rec_flag * type_declaration list) Generator.t
   -> ?sig_type_ext :(signature, type_extension                  ) Generator.t
   -> ?sig_exception:(signature, type_exception                  ) Generator.t
+  -> ?sig_module_type_decl:(signature, module_type_declaration  ) Generator.t
   -> ?extension:(loc:Location.t -> path:string -> core_type -> expression)
   -> string
   -> t
@@ -115,9 +117,11 @@ val add_alias
   -> ?str_type_decl:t list
   -> ?str_type_ext :t list
   -> ?str_exception:t list
+  -> ?str_module_type_decl:t list
   -> ?sig_type_decl:t list
   -> ?sig_type_ext :t list
   -> ?sig_exception:t list
+  -> ?sig_module_type_decl:t list
   -> t list
   -> t
 

--- a/test/deriving/test.ml
+++ b/test/deriving/test.ml
@@ -78,6 +78,5 @@ end = struct
   let y = 42
 end
 [%%expect{|
-Line _, characters 42-42:
-Error: ppxlib: [@@@deriving.end] attribute missing
+module Y : sig module type X = sig  end val y : int end
 |}]

--- a/test/deriving/test.ml
+++ b/test/deriving/test.ml
@@ -10,6 +10,8 @@ let foo =
   Deriving.add "foo"
     ~str_type_decl:(Deriving.Generator.make_noarg
                       (fun ~loc ~path:_ _ -> [%str let x = 42]))
+    ~sig_type_decl:(Deriving.Generator.make_noarg
+                      (fun ~loc ~path:_ _ -> [%sig: val y : int]))
 [%%expect{|
 val foo : Deriving.t = <abstr>
 |}]
@@ -51,6 +53,16 @@ type nonrec int = int [@@deriving foo, bar]
 [%%expect{|
 type nonrec int = int
 val x : int = 42
+|}]
+
+module Foo_sig : sig
+  type t [@@deriving foo]
+end = struct
+  type t
+end
+[%%expect{|
+Line _, characters 25-25:
+Error: ppxlib: [@@@deriving.end] attribute missing
 |}]
 
 module type X = sig end [@@deriving mtd]

--- a/test/deriving/test.ml
+++ b/test/deriving/test.ml
@@ -23,6 +23,15 @@ let bar =
 val bar : Deriving.t = <abstr>
 |}]
 
+let mtd =
+  Deriving.add "mtd"
+    ~str_module_type_decl:(
+      Deriving.Generator.make_noarg
+        (fun ~loc ~path:_ _ -> [%str let y = 42]))
+[%%expect{|
+val mtd : Deriving.t = <abstr>
+|}]
+
 type t = int [@@deriving bar]
 [%%expect{|
 Line _, characters 25-28:
@@ -39,4 +48,10 @@ type nonrec int = int [@@deriving foo, bar]
 [%%expect{|
 type nonrec int = int
 val x : int = 42
+|}]
+
+module type X = sig end [@@deriving mtd]
+[%%expect{|
+module type X = sig  end
+val y : int = 42
 |}]

--- a/test/deriving/test.ml
+++ b/test/deriving/test.ml
@@ -25,6 +25,9 @@ val bar : Deriving.t = <abstr>
 
 let mtd =
   Deriving.add "mtd"
+    ~sig_module_type_decl:(
+      Deriving.Generator.make_noarg
+        (fun ~loc ~path:_ _ -> [%sig: val y : int]))
     ~str_module_type_decl:(
       Deriving.Generator.make_noarg
         (fun ~loc ~path:_ _ -> [%str let y = 42]))
@@ -54,4 +57,15 @@ module type X = sig end [@@deriving mtd]
 [%%expect{|
 module type X = sig  end
 val y : int = 42
+|}]
+
+module Y : sig
+  module type X = sig end [@@deriving mtd]
+end = struct
+  module type X = sig end
+  let y = 42
+end
+[%%expect{|
+Line _, characters 42-42:
+Error: ppxlib: [@@@deriving.end] attribute missing
 |}]


### PR DESCRIPTION
This PR adds support for deriving generators on module type declarations. For example:

```ocaml
module type Foo = sig .. end [@@deriving bar]
```

It is necessary to achieve feature parity with ppx_deriving.

Fix #93 

cc @kwshi who was interested in this feature.