### PR TITLE
Fix a bug in Longident.parse

### DIFF
--- a/src/longident.ml
+++ b/src/longident.ml
@@ -57,18 +57,20 @@ let parse_simple s =
 
 (* handle ["A.B.(+.+)"] or ["Vec.(.%.()<-)"] *)
 let parse s =
+  let invalid () =
+    invalid_arg (Printf.sprintf "Ppxlib.Longident.parse: %S" s)
+  in
   match String.index s '(' with
   | None -> parse_simple  s
   | Some l -> match String.rindex s ')' with
-    | None -> invalid_arg "Ppxlib.Longident.parse"
+    | None -> invalid ()
     | Some r ->
-      if Int.( r <> String.length s - 1 ) then
-        invalid_arg "Ppxlib.Longident.parse";
+      if Int.( r <> String.length s - 1 ) then invalid ();
       let group = if Int.(r = l + 1) then "()" else
           String.strip (String.sub s ~pos:(l+1) ~len:(r-l-1))
       in
       if Int.(l = 0) then Lident group
-      else if Char.(s.[l - 1] <> '.') then invalid_arg "Ppxlib.Longident.parse"
+      else if Char.(s.[l - 1] <> '.') then invalid ()
       else
         let before = String.sub s ~pos:0 ~len:(l-1) in
         match String.split before ~on:'.' with

--- a/src/longident.ml
+++ b/src/longident.ml
@@ -60,11 +60,10 @@ let parse s =
   let invalid () =
     invalid_arg (Printf.sprintf "Ppxlib.Longident.parse: %S" s)
   in
-  match String.index s '(' with
-  | None -> parse_simple  s
-  | Some l -> match String.rindex s ')' with
-    | None -> invalid ()
-    | Some r ->
+  match String.index s '(', String.rindex s ')' with
+  | None, None -> parse_simple  s
+  | None, _ | _, None -> invalid ()
+  | Some l, Some r ->
       if Int.( r <> String.length s - 1 ) then invalid ();
       let group = if Int.(r = l + 1) then "()" else
           String.strip (String.sub s ~pos:(l+1) ~len:(r-l-1))

--- a/src/longident.ml
+++ b/src/longident.ml
@@ -65,9 +65,12 @@ let parse s =
       if Int.( r <> String.length s - 1 ) then
         invalid_arg "Ppxlib.Longident.parse";
       let group = if Int.(r = l + 1) then "()" else
-          String.strip (String.sub s ~pos:(l+1) ~len:(r-l-1)) in
-      if Int.(l = 0) then Lident group else
+          String.strip (String.sub s ~pos:(l+1) ~len:(r-l-1))
+      in
+      if Int.(l = 0) then Lident group
+      else if Char.(s.[l - 1] <> '.') then invalid_arg "Ppxlib.Longident.parse"
+      else
         let before = String.sub s ~pos:0 ~len:(l-1) in
         match String.split before ~on:'.' with
-        | [] -> Lident group
+        | [] -> assert false
         | s :: l -> Ldot(unflatten ~init:(Lident s) l, group)

--- a/src/longident.mli
+++ b/src/longident.mli
@@ -11,5 +11,11 @@ include Comparable.S with type t := t
 
 val flatten_exn : t -> string list
 val last_exn : t -> string
+
+(** Parses the given string as a longident, properly handling infix operators
+    which may contain '.'.
+    Note that it does not parse [Lapply _] longidents and will raise
+    [Invalid_argument _] if passed values such as ["A(B)"]. *)
 val parse : string -> t
+
 val name : t -> string

--- a/test/base/dune
+++ b/test/base/dune
@@ -3,8 +3,10 @@
  (deps
   (:test test.ml)
   (glob_files %{project_root}/src/.ppxlib.objs/byte/*.cmi))
- (action (chdir %{project_root}
-          (progn
-           (ignore-outputs
-            (run %{project_root}/test/expect/expect_test.exe %{test}))
-           (diff? %{test} %{test}.corrected)))))
+ (action
+  (chdir %{project_root}
+   (progn
+    (setenv OCAMLRUNPARAM ""
+     (ignore-outputs
+      (run %{project_root}/test/expect/expect_test.exe %{test})))
+    (diff? %{test} %{test}.corrected)))))

--- a/test/base/dune
+++ b/test/base/dune
@@ -6,7 +6,6 @@
  (action
   (chdir %{project_root}
    (progn
-    (setenv OCAMLRUNPARAM ""
-     (ignore-outputs
-      (run %{project_root}/test/expect/expect_test.exe %{test})))
+    (ignore-outputs
+     (run %{project_root}/test/expect/expect_test.exe %{test}))
     (diff? %{test} %{test}.corrected)))))

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -113,6 +113,11 @@ let _ = convert_longident "A.B(C)"
 Exception: Invalid_argument "Ppxlib.Longident.parse: \"A.B(C)\"".
 |}]
 
+let _ = convert_longident ")"
+[%%expect{|
+- : string * longident = ("( ) )", Ppxlib.Longident.Lident ")")
+|}]
+
 let _ = Ppxlib.Code_path.(file_path @@ top_level ~file_path:"dir/main.ml")
 [%%expect{|
 - : string = "dir/main.ml"

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -103,6 +103,20 @@ let _ = convert_longident "Base.( land )"
  Ppxlib.Longident.Ldot (Ppxlib.Longident.Lident "Base", "land"))
 |}]
 
+let _ = convert_longident "A(B)"
+[%%expect{|
+- : string * longident =
+(".B", Ppxlib.Longident.Ldot (Ppxlib.Longident.Lident "", "B"))
+|}]
+
+let _ = convert_longident "A.B(C)"
+[%%expect{|
+- : string * longident =
+("A..C",
+ Ppxlib.Longident.Ldot
+  (Ppxlib.Longident.Ldot (Ppxlib.Longident.Lident "A", ""), "C"))
+|}]
+
 let _ = Ppxlib.Code_path.(file_path @@ top_level ~file_path:"dir/main.ml")
 [%%expect{|
 - : string = "dir/main.ml"

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -105,16 +105,18 @@ let _ = convert_longident "Base.( land )"
 
 let _ = convert_longident "A(B)"
 [%%expect{|
-- : string * longident =
-(".B", Ppxlib.Longident.Ldot (Ppxlib.Longident.Lident "", "B"))
+Exception: Invalid_argument "Ppxlib.Longident.parse".
+Raised at file "stdlib.ml", line 34, characters 25-45
+Called from file "test/base/test.ml", line 3, characters 15-37
+Called from file "toplevel/toploop.ml", line 180, characters 17-56
 |}]
 
 let _ = convert_longident "A.B(C)"
 [%%expect{|
-- : string * longident =
-("A..C",
- Ppxlib.Longident.Ldot
-  (Ppxlib.Longident.Ldot (Ppxlib.Longident.Lident "A", ""), "C"))
+Exception: Invalid_argument "Ppxlib.Longident.parse".
+Raised at file "stdlib.ml", line 34, characters 25-45
+Called from file "test/base/test.ml", line 3, characters 15-37
+Called from file "toplevel/toploop.ml", line 180, characters 17-56
 |}]
 
 let _ = Ppxlib.Code_path.(file_path @@ top_level ~file_path:"dir/main.ml")

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -106,17 +106,11 @@ let _ = convert_longident "Base.( land )"
 let _ = convert_longident "A(B)"
 [%%expect{|
 Exception: Invalid_argument "Ppxlib.Longident.parse: \"A(B)\"".
-Raised at file "stdlib.ml", line 34, characters 25-45
-Called from file "test/base/test.ml", line 3, characters 15-37
-Called from file "toplevel/toploop.ml", line 180, characters 17-56
 |}]
 
 let _ = convert_longident "A.B(C)"
 [%%expect{|
 Exception: Invalid_argument "Ppxlib.Longident.parse: \"A.B(C)\"".
-Raised at file "stdlib.ml", line 34, characters 25-45
-Called from file "test/base/test.ml", line 3, characters 15-37
-Called from file "toplevel/toploop.ml", line 180, characters 17-56
 |}]
 
 let _ = Ppxlib.Code_path.(file_path @@ top_level ~file_path:"dir/main.ml")

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -105,7 +105,7 @@ let _ = convert_longident "Base.( land )"
 
 let _ = convert_longident "A(B)"
 [%%expect{|
-Exception: Invalid_argument "Ppxlib.Longident.parse".
+Exception: Invalid_argument "Ppxlib.Longident.parse: \"A(B)\"".
 Raised at file "stdlib.ml", line 34, characters 25-45
 Called from file "test/base/test.ml", line 3, characters 15-37
 Called from file "toplevel/toploop.ml", line 180, characters 17-56
@@ -113,7 +113,7 @@ Called from file "toplevel/toploop.ml", line 180, characters 17-56
 
 let _ = convert_longident "A.B(C)"
 [%%expect{|
-Exception: Invalid_argument "Ppxlib.Longident.parse".
+Exception: Invalid_argument "Ppxlib.Longident.parse: \"A.B(C)\"".
 Raised at file "stdlib.ml", line 34, characters 25-45
 Called from file "test/base/test.ml", line 3, characters 15-37
 Called from file "toplevel/toploop.ml", line 180, characters 17-56

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -115,7 +115,7 @@ Exception: Invalid_argument "Ppxlib.Longident.parse: \"A.B(C)\"".
 
 let _ = convert_longident ")"
 [%%expect{|
-- : string * longident = ("( ) )", Ppxlib.Longident.Lident ")")
+Exception: Invalid_argument "Ppxlib.Longident.parse: \")\"".
 |}]
 
 let _ = Ppxlib.Code_path.(file_path @@ top_level ~file_path:"dir/main.ml")

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -2,6 +2,8 @@
 #require "base";;
 #require "stdio";;
 
+let () = Printexc.record_backtrace false
+
 open Base
 open Stdio
 open Ppxlib


### PR DESCRIPTION
This PR fixes a bug in `Longident.parse` and adds a couple regression tests.

`Longident.parse` doesn't not support Lapply-type longident (ie `A.B(C)`). That is fine but it used to return inconsistent values in such cases instead of raising an exception.

I fixed the bug and also made it clear in the documentation that these aren't handled as this function is part of the public API of `ppxlib`.