### PR TITLE
Allow to pass extra arguments to patdiff

### DIFF
--- a/print-diff/ppxlib_print_diff.ml
+++ b/print-diff/ppxlib_print_diff.ml
@@ -1,17 +1,18 @@
 open StdLabels
 
-let patdiff_cmd ~use_color =
+let patdiff_cmd ~use_color ~extra_patdiff_args =
   let args =
     List.concat [
       ["-keep-whitespace"];
       ["-location-style omake"];
       (if use_color then [] else ["-ascii"]);
+      extra_patdiff_args
     ]
   in
   String.concat ~sep:" " ("patdiff" :: args)
 ;;
 
-let print ?diff_command ?(use_color=false) ~file1 ~file2 () =
+let print ?diff_command ?(extra_patdiff_args=[]) ?(use_color=false) ~file1 ~file2 () =
   let exec cmd =
     let cmd =
       Printf.sprintf "%s %s %s 1>&2" cmd (Filename.quote file1) (Filename.quote file2)
@@ -24,7 +25,7 @@ let print ?diff_command ?(use_color=false) ~file1 ~file2 () =
   match diff_command with
   | Some s -> ignore (exec s : [> `Same | `Different | `Error of int * string])
   | None ->
-    begin match exec (patdiff_cmd ~use_color) with
+    begin match exec (patdiff_cmd ~use_color ~extra_patdiff_args) with
     | `Same ->
       (* patdiff produced no output, fallback to diff -u *)
       Printf.eprintf "File \"%s\", line 1, characters 0-0:\n%!" file1;

--- a/print-diff/ppxlib_print_diff.mli
+++ b/print-diff/ppxlib_print_diff.mli
@@ -3,6 +3,7 @@
     differences. *)
 val print
   :  ?diff_command:string
+  -> ?extra_patdiff_args:string list (** default: [] *)
   -> ?use_color:bool (** default: false *)
   -> file1:string
   -> file2:string


### PR DESCRIPTION
This pull request tweaks the interface of the `ppxlib.print_diff`
library so that it is possible to pass extra arguments to the
`patdiff` executable.

As I understand it, the use case it to ensure reproducibility
by passing `-default` to patdiff. Indeed, if the flag is not passed,
the configuration will be read from "~/.patdiff". This in turn
can lead to different outputs according to the local configuration.