### PR TITLE
Preserve module-level attributes

### DIFF
--- a/src/driver.ml
+++ b/src/driver.ml
@@ -181,9 +181,7 @@ module Transform = struct
         let base_ctxt = Expansion_context.Base.top_level ~omp_config ~file_path in
         let attrs = map#structure base_ctxt attrs in
         let st = map#structure base_ctxt st in
-        match header, footer with
-        | [], [] -> attrs @ st
-        | _      -> List.concat [ attrs; header; st; footer ]
+        List.concat [ attrs; header; st; footer ]
       in
       match impl with
       | None -> st
@@ -207,9 +205,7 @@ module Transform = struct
         let base_ctxt = Expansion_context.Base.top_level ~omp_config ~file_path in
         let attrs = map#signature base_ctxt attrs in
         let sg = map#signature base_ctxt sg in
-        match header, footer with
-        | [], [] -> attrs @ sg
-        | _      -> List.concat [ attrs; header; sg; footer ]
+        List.concat [ attrs; header; sg; footer ]
       in
       match intf with
       | None -> sg

--- a/src/driver.mli
+++ b/src/driver.mli
@@ -63,9 +63,10 @@ end
     backward compatibility.
 
     [enclose_impl] and [enclose_intf] produces a header and footer for
-    implementation/interface files. They are a special case of [impl] and [intf]. Both
-    functions receive a location that denotes the whole file, or [None] if the file
-    contains nothing.
+    implementation/interface files. They are a special case of [impl] and [intf]. The
+    header is placed after any initial module-level attributes; the footer is placed after
+    everything else. Both functions receive a location that denotes all of the items
+    between header and footer, or [None] if the that list of items is empty.
 
     [impl] is an optional function that is applied on implementation files and [intf] is
     an optional function that is applied on interface files. These two functions are


### PR DESCRIPTION
Currently `~enclose_impl` and `~enclose_intf` transformations can break module-level attributes like `@@@alert` because they move them away from the top of the signature/structure, where the compiler looks for them.

This patch changes `~enclose_intf` and `~enclose_impl` to leave attributes at the start of a structure/signature if they started there.