### PR TITLE
Add full code path to deriving expansion context

### DIFF
--- a/src/code_path.mli
+++ b/src/code_path.mli
@@ -30,6 +30,9 @@ val fully_qualified_path : t -> string
 *)
 val to_string_path : t -> string
 
+(** Return the name of the closest enclosing module to this path. *)
+val enclosing_module : t -> string
+
 (**/**)
 (** Undocumented section *)
 

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -162,6 +162,9 @@ module Generator = struct
   let make ?attributes ?deps spec gen =
     V2.make ?attributes ?deps spec (Expansion_context.Deriver.with_loc_and_path gen)
 
+  let make_code_path ?attributes ?deps spec gen =
+    V2.make ?attributes ?deps spec (Expansion_context.Deriver.with_loc_and_code_path gen)
+
   let make_noarg ?attributes ?deps gen = make ?attributes ?deps Args.empty gen
 
   let merge_accepted_args l =

--- a/src/deriving.mli
+++ b/src/deriving.mli
@@ -51,6 +51,13 @@ module Generator : sig
     -> (loc:Location.t -> path:string -> 'input_ast -> 'f)
     -> ('output_ast, 'input_ast) t
 
+  val make_code_path
+    :  ?attributes:Attribute.packed list
+    -> ?deps:deriver list
+    -> ('f, 'output_ast) Args.t
+    -> (loc:Location.t -> path:Code_path.t -> 'input_ast -> 'f)
+    -> ('output_ast, 'input_ast) t
+
   val make_noarg
     :  ?attributes:Attribute.packed list
     -> ?deps:deriver list

--- a/src/expansion_context.ml
+++ b/src/expansion_context.ml
@@ -46,4 +46,8 @@ module Deriver = struct
 
   let with_loc_and_path f =
     fun ~ctxt -> f ~loc:ctxt.derived_item_loc ~path:(Code_path.to_string_path ctxt.base.code_path)
+
+  let with_loc_and_code_path f =
+    fun ~ctxt -> f ~loc:ctxt.derived_item_loc ~path:(ctxt.base.code_path)
+
 end

--- a/src/expansion_context.mli
+++ b/src/expansion_context.mli
@@ -58,6 +58,9 @@ module Deriver : sig
   (** Wrap a [fun ~loc ~path] into a [fun ~ctxt] *)
   val with_loc_and_path : (loc:Location.t -> path:string -> 'a) -> (ctxt:t -> 'a)
 
+  (** Wrap a [fun ~loc ~path] into a [fun ~ctxt]. Uses Code_path.t, rather than a string. *)
+  val with_loc_and_code_path : (loc:Location.t -> path:Code_path.t -> 'a) -> (ctxt:t -> 'a)
+
   (** Whether the derived code is going to be inlined in the source *)
   val inline : t -> bool
 


### PR DESCRIPTION
A PPX deriver that I'm developing could benefit from knowing the name of the enclosing module, which it uses to suggest a name for the derived structure.

This PR includes:
1. An addition to Code_path to keep track of the current parent module
2. An additional API call to create a Deriver.Generator that takes [Code_path.t]s, rather than [string]s.

Similarly, we could also do the same with extensions, but that isn't included currently in this PR.