### PR TITLE
Add tests for parsing longident's with .

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 unreleased
 -------------------
 
+- Fix `Longident.parse` so it properly handles unparenthesized dotted operators
+  such as `+.` or `*.`. (#111, @rgrinberg, @NathanReb)
+
 - raising an exception does no longer cancel the whole context free phase(#453, @burnleydev1)
 
 - Sort embedded errors that are appended to the AST by location so the compiler

--- a/src/longident.ml
+++ b/src/longident.ml
@@ -51,10 +51,14 @@ let parse s =
   let invalid () =
     invalid_arg (Printf.sprintf "Ppxlib.Longident.parse: %S" s)
   in
-  match (String.index_opt s '(', String.rindex_opt s ')') with
-  | None, None -> parse_simple s
-  | None, _ | _, None -> invalid ()
-  | Some l, Some r -> (
+  if String.length s < 1 then invalid ();
+  let open_par = String.index_opt s '(' in
+  let close_par = String.index_opt s ')' in
+  match (s.[0], open_par, close_par) with
+  | ('A' .. 'Z' | 'a' .. 'z' | '_'), None, None -> parse_simple s
+  | _, None, None -> Lident s (* This is a raw operator, no module path *)
+  | _, None, _ | _, _, None -> invalid ()
+  | _, Some l, Some r -> (
       if Int.(r <> String.length s - 1) then invalid ();
       let group =
         if Int.(r = l + 1) then "()"

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -121,6 +121,11 @@ let _ = convert_longident "+."
 ("( + ).", Ppxlib.Longident.Ldot (Ppxlib.Longident.Lident "+", ""))
 |}]
 
+let _ = convert_longident "(+.)"
+[%%expect{|
+- : string * longident = ("( +. )", Ppxlib.Longident.Lident "+.")
+|}]
+
 let _ = convert_longident "Foo.(+.)"
 [%%expect{|
 - : string * longident =

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -114,11 +114,9 @@ let _ = convert_longident ")"
 Exception: Invalid_argument "Ppxlib.Longident.parse: \")\"".
 |}]
 
-(* FIXME this is a bug *)
 let _ = convert_longident "+."
 [%%expect{|
-- : string * longident =
-("( + ).", Ppxlib.Longident.Ldot (Ppxlib.Longident.Lident "+", ""))
+- : string * longident = ("( +. )", Ppxlib.Longident.Lident "+.")
 |}]
 
 let _ = convert_longident "(+.)"

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -101,17 +101,36 @@ let _ = convert_longident "Base.( land )"
 
 let _ = convert_longident "A(B)"
 [%%expect{|
-Exception: Invalid_argument "Ppxlib.Longident.parse: \"A(B)\"".
+Exception: (Invalid_argument "Ppxlib.Longident.parse: \"A(B)\"")
 |}]
 
 let _ = convert_longident "A.B(C)"
 [%%expect{|
-Exception: Invalid_argument "Ppxlib.Longident.parse: \"A.B(C)\"".
+Exception: (Invalid_argument "Ppxlib.Longident.parse: \"A.B(C)\"")
 |}]
 
 let _ = convert_longident ")"
 [%%expect{|
-Exception: Invalid_argument "Ppxlib.Longident.parse: \")\"".
+Exception: (Invalid_argument "Ppxlib.Longident.parse: \")\"")
+|}]
+
+(* FIXME this is a bug *)
+let _ = convert_longident "+."
+[%%expect{|
+- : string * longident =
+("( + ).", Ppxlib.Longident.Ldot (Ppxlib.Longident.Lident "+", ""))
+|}]
+
+let _ = convert_longident "Foo.(+.)"
+[%%expect{|
+- : string * longident =
+("Foo.( +. )", Ppxlib.Longident.Ldot (Ppxlib.Longident.Lident "Foo", "+."))
+|}]
+
+let _ = convert_longident "Foo.( *. )"
+[%%expect{|
+- : string * longident =
+("Foo.( *. )", Ppxlib.Longident.Ldot (Ppxlib.Longident.Lident "Foo", "*."))
 |}]
 
 let _ = Ppxlib.Code_path.(file_path @@ top_level ~file_path:"dir/main.ml")

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -101,17 +101,17 @@ let _ = convert_longident "Base.( land )"
 
 let _ = convert_longident "A(B)"
 [%%expect{|
-Exception: (Invalid_argument "Ppxlib.Longident.parse: \"A(B)\"")
+Exception: Invalid_argument "Ppxlib.Longident.parse: \"A(B)\"".
 |}]
 
 let _ = convert_longident "A.B(C)"
 [%%expect{|
-Exception: (Invalid_argument "Ppxlib.Longident.parse: \"A.B(C)\"")
+Exception: Invalid_argument "Ppxlib.Longident.parse: \"A.B(C)\"".
 |}]
 
 let _ = convert_longident ")"
 [%%expect{|
-Exception: (Invalid_argument "Ppxlib.Longident.parse: \")\"")
+Exception: Invalid_argument "Ppxlib.Longident.parse: \")\"".
 |}]
 
 (* FIXME this is a bug *)


### PR DESCRIPTION
There are some identifiers that have the `.` character. We test cases with `+.`
and `*.`

It seems like the `+.` isn't handled correctly when there's no module prefixing.