### PR TITLE
Bump dune language to 1.11

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+next
+----
+
+- Bump dune language to 1.11 since the cinaps extension requires at
+  least Dune 1.11 (#126, @diml)
+
 0.12.0 (01/07/2020)
 -------------------
 

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 1.0)
+(lang dune 1.11)
 (name ppxlib)
 (using cinaps 1.0)


### PR DESCRIPTION
To avoid:

```
File "dune-project", line 3, characters 14-17:
3 | (using cinaps 1.0)
                  ^^^
Warning: Version 1.0 of the cinaps extension is not supported until version
1.11 of the dune language.
There are no supported versions of this extension in version 1.0 of the dune
language.
```

/cc @avsm 