### PR TITLE
Don't leak OMP's config through ppxlib's API

### DIFF
--- a/src/expansion_context.ml
+++ b/src/expansion_context.ml
@@ -1,12 +1,12 @@
 module Base = struct
   type t =
-    { omp_config : Migrate_parsetree.Driver.config
+    { tool_name : string
     ; code_path : Code_path.t
     }
 
-  let top_level ~omp_config ~file_path =
+  let top_level ~tool_name ~file_path =
     let code_path = Code_path.top_level ~file_path in
-    {omp_config; code_path}
+    {tool_name; code_path}
 
   let enter_expr t = {t with code_path = Code_path.enter_expr t.code_path}
   let enter_module ~loc name t = {t with code_path = Code_path.enter_module ~loc name t.code_path}
@@ -23,7 +23,7 @@ module Extension = struct
 
   let extension_point_loc t = t.extension_point_loc
   let code_path t = t.base.code_path
-  let omp_config t = t.base.omp_config
+  let tool_name t = t.base.tool_name
 
   let with_loc_and_path f =
     fun ~ctxt ->
@@ -41,7 +41,7 @@ module Deriver = struct
 
   let derived_item_loc t = t.derived_item_loc
   let code_path t = t.base.code_path
-  let omp_config t = t.base.omp_config
+  let tool_name t = t.base.tool_name
   let inline t = t.inline
 
   let with_loc_and_path f =

--- a/src/expansion_context.mli
+++ b/src/expansion_context.mli
@@ -6,10 +6,10 @@ module Base : sig
   (** Undocumented section *)
 
   (** Build a new base context at the top level of the given file with the given
-      ocaml-mirgate-parsetree configuration.
+      calling tool name.
   *)
   val top_level :
-    omp_config:Migrate_parsetree.Driver.config ->
+    tool_name:string ->
     file_path:string ->
     t
 
@@ -29,8 +29,10 @@ module Extension : sig
   (** Return the code path for the given context *)
   val code_path : t -> Code_path.t
 
-  (** Return the ocaml-migrate-parsetree configuration for the given expansion context *)
-  val omp_config : t -> Migrate_parsetree.Driver.config
+  (** Can be used within a ppx preprocessor to know which tool is
+      calling it ["ocamlc"], ["ocamlopt"], ["ocamldoc"], ["ocamldep"],
+      ["ocaml"], ... . *)
+  val tool_name : t -> string
 
   (** Wrap a [fun ~loc ~path] into a [fun ~ctxt] *)
   val with_loc_and_path : (loc:Location.t -> path:string -> 'a) -> (ctxt:t -> 'a)
@@ -52,8 +54,10 @@ module Deriver : sig
   (** Return the code path for the given context *)
   val code_path : t -> Code_path.t
 
-  (** Return the ocaml-migrate-parsetree configuration for the given expansion context *)
-  val omp_config : t -> Migrate_parsetree.Driver.config
+  (** Can be used within a ppx preprocessor to know which tool is
+      calling it ["ocamlc"], ["ocamlopt"], ["ocamldoc"], ["ocamldep"],
+      ["ocaml"], ... . *)
+  val tool_name : t -> string
 
   (** Wrap a [fun ~loc ~path] into a [fun ~ctxt] *)
   val with_loc_and_path : (loc:Location.t -> path:string -> 'a) -> (ctxt:t -> 'a)


### PR DESCRIPTION
This removes `Migrate_parestree.Driver.config` from ppxlib's interface. We still expose the `tool_name` as it's the only part of it that was used as far as I can tell. This change is required ahead of the future omp.2.0.0 release.