### PR TITLE
Update dune constraint in ppxlib.opam

### DIFF
--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -16,7 +16,7 @@ run-test: [
 depends: [
   "ocaml"                   {>= "4.04.1"}
   "base"                    {>= "v0.11.0"}
-  "dune"
+  "dune"                    {>= "1.11"}
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "1.5.0"}
   "ppx_derivers"            {>= "1.0"}


### PR DESCRIPTION
We added a `(lang dune 1.11)` requirement to the dune-project a while back but didn't update the opam file accordingly as noted by @kit-ty-kate!