### PR TITLE
implement and test name mangling for ppxlib_traverse

### DIFF
--- a/test/traverse/test.ml
+++ b/test/traverse/test.ml
@@ -47,3 +47,30 @@ class virtual ['res] lift :
     method u : u -> 'res
   end
 |}]
+
+type t =
+  { a : int
+  ; b : Int.t
+  ; c : (int, bool) Stdlib.Result.t
+  ; d : int Map.Make(Int).t
+  }
+[@@deriving traverse_iter]
+[%%expect{|
+type t = {
+  a : int;
+  b : int;
+  c : (int, bool) result;
+  d : int Map.Make(Int).t;
+}
+class virtual iter :
+  object
+    method virtual bool : bool -> unit
+    method virtual int : int -> unit
+    method virtual int__t : int -> unit
+    method virtual map__make_'int'__t :
+      ('a -> unit) -> 'a Map.Make(Int).t -> unit
+    method virtual stdlib__result__t :
+      ('a -> unit) -> ('b -> unit) -> ('a, 'b) result -> unit
+    method t : t -> unit
+  end
+|}]


### PR DESCRIPTION
This change makes `[@@deriving traverse]` more meaningful in the presence of nontrivial type identifiers. Previously, types like `t`, `Int.t`, and `Map.Make(Int).t` would all be mapped to a single method called `t`.