### PR TITLE
`register_transformation`: add opt `~instrument`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+unreleased
+-------------------
+
+- `Driver.register_transformation`: add optional parameter `~instrument` 
+  (#161, @pitag-ha)
+
 0.15.0 (04/08/2020)
 -------------------
 

--- a/test/instrument/dune
+++ b/test/instrument/dune
@@ -1,0 +1,9 @@
+(alias
+   (name runtest)
+   (deps
+      (:test test.ml)
+      (package ppxlib))
+   (action (chdir %{project_root}
+                     (progn
+                        (run expect-test %{test})
+                        (diff? %{test} %{test}.corrected)))))

--- a/test/instrument/test.ml
+++ b/test/instrument/test.ml
@@ -1,0 +1,36 @@
+open Ppxlib
+
+let extend_list_by name = object
+  inherit Ast_traverse.map as super
+
+  method! expression e =
+    match e.pexp_desc with
+    | Pexp_construct ({txt = Lident "[]"; _}, None) -> Ast_builder.Default.elist ~loc:e.pexp_loc [Ast_builder.Default.estring ~loc:e.pexp_loc name]
+    | _ -> super#expression e
+end
+[%%expect{|
+val extend_list_by : string -> Ast_traverse.map = <fun>
+|}]
+
+let () = 
+  let name = "a: instr pos=Before" in
+  let transform = extend_list_by name in
+  Driver.(register_transformation ~instrument:(Instrument.make ~position:Before transform#structure) name)
+
+let () = 
+  let name = "b: instr pos=After" in
+  let transform = extend_list_by name in
+  Driver.(register_transformation ~instrument:(Instrument.make ~position:After transform#structure) name)
+
+let () =
+  let name = "c: impl" in
+  let transform = extend_list_by name in
+  Driver.register_transformation ~impl:transform#structure name
+
+(* The order of the list should only depend on how the rewriters got registered,
+   not on the alphabetic order of the names they got registered with. *)
+let x = []
+[%%expect{|
+val x : string list =
+  ["a: instr pos=Before"; "c: impl"; "b: instr pos=After"]
+|}]


### PR DESCRIPTION
Before, the way to register an instrumentation PPX was to pass the implementation file transformation to the `~impl`-argument of `Driver.register_transformation`. That way, the position at which it was applied was determined as follows: a deriver registered through `~impl` is a whole file transformation. All whole file transformations get applied after `~rules` rewriters get applied. Among whole file transformations, the order is alphabetic with respect to the name they are registered with. So the only way to influence when an instrumentation PPX got applied was through its name.

This commit adds an optional `~instrument`-argument to `Driver.register_transformation`, that allows to specify if one wants the instrumentation PPX to be applied before or after all other whole file transfomrations and `rules` rewriters get applied.

Signed-off-by: Sonja Heinze <sonjaleaheinze@gmail.com>