### PR TITLE
Fix documentation: get rid of warnings

### DIFF
--- a/src/ast_pattern.mli
+++ b/src/ast_pattern.mli
@@ -174,8 +174,8 @@ val pack2 : ('a, 'b -> 'c -> 'd, 'e) t -> ('a, 'b * 'c -> 'd, 'e) t
 val pack3 : ('a, 'b -> 'c -> 'd -> 'e, 'f) t -> ('a, 'b * 'c * 'd -> 'e, 'f) t
 
 (** AST patterns for each constructur/record of the parsetree are generated in the same
-    way AST builders are generated. In addition, for every {it wrapper} we generate a
-    pattern to match the [loc] and [attributes] fields. For instanct for the [expression]
+    way AST builders are generated. In addition, for every {i wrapper} we generate a
+    pattern to match the [loc] and [attributes] fields. For instance for the [expression]
     type:
 
     {[

--- a/src/common.mli
+++ b/src/common.mli
@@ -23,7 +23,7 @@ val assert_no_attributes : attributes -> unit
 val assert_no_attributes_in : Ast_traverse.iter
 
 val get_type_param_name : (core_type * variance) -> string Loc.t
-(** [get_tparam_id tp] @return the string identifier associated with [tp] if it is a type
+(** [get_tparam_id tp] returns the string identifier associated with [tp] if it is a type
     parameter. *)
 
 (** [(new type_is_recursive rec_flag tds)#go ()] returns whether [rec_flag, tds] is really

--- a/src/deriving.mli
+++ b/src/deriving.mli
@@ -35,7 +35,7 @@ module Args : sig
   with type ('a, 'b, 'c) t := ('a, 'b, 'c) Ast_pattern.t
 end
 
-(** {6 Generator registration} *)
+(** {5 Generator registration} *)
 
 (** Type of registered derivers *)
 type t


### PR DESCRIPTION
The commit gets rid of the three warnings that were thrown every time the documentation was generated.