### PR TITLE
Location: add `init lexer_buffer filename`

### DIFF
--- a/src/location.ml
+++ b/src/location.ml
@@ -23,6 +23,15 @@ let in_file name =
 
 let none = in_file "_none_"
 
+let init lexbuf fname =
+  let open Lexing in
+  lexbuf.lex_curr_p <- {
+    pos_fname = fname;
+    pos_lnum = 1;
+    pos_bol = 0;
+    pos_cnum = 0;
+  }
+
 let raise_errorf ?loc fmt = L.raise_errorf ?loc fmt
 let report_exception = L.report_exception
 

--- a/src/location.mli
+++ b/src/location.mli
@@ -17,6 +17,10 @@ val in_file : string -> t
 (** An arbitrary value of type [t]; describes an empty ghost range. *)
 val none : t
 
+(** Set the file name and line number of the [lexbuf] to be the start
+    of the named file. *)
+val init : Lexing.lexbuf -> string -> unit
+
 (** Raise a located error. The exception is caught by driver and handled
     appropriately *)
 val raise_errorf : ?loc:t -> ('a, Caml.Format.formatter, unit, 'b) format4 -> 'a


### PR DESCRIPTION
The `Parse` module of `ppxlib` offers to parse a lexer buffer. Such a lexer buffer might come from a file created through an input channel. The `Location` module of `ppxlib` shadows the compiler-libs `Location` module, which contains an `init lexer_buffer filename` function to initialize such a lexer buffer's position tracker.

Before, `ppxlib`'s `Location` module didn't contain that init function. This commit copies it.

Signed-off-by: Sonja Heinze <sonjaleaheinze@gmail.com>