### PR TITLE
Add accessors for code_path and tool_name to Expansion_context.Base

### DIFF
--- a/src/expansion_context.ml
+++ b/src/expansion_context.ml
@@ -8,6 +8,9 @@ module Base = struct
     let code_path = Code_path.top_level ~file_path in
     {tool_name; code_path}
 
+  let code_path t = t.code_path
+  let tool_name t = t.tool_name
+
   let enter_expr t = {t with code_path = Code_path.enter_expr t.code_path}
   let enter_module ~loc name t = {t with code_path = Code_path.enter_module ~loc name t.code_path}
   let enter_value ~loc name t = {t with code_path = Code_path.enter_value ~loc name t.code_path}

--- a/src/expansion_context.mli
+++ b/src/expansion_context.mli
@@ -2,7 +2,14 @@ module Base : sig
   (** Type for the location independent parts of the expansion context *)
   type t
 
-  (**/*)
+  (** Return the code path for the given context *)
+  val code_path : t -> Code_path.t
+
+  (** Can be used within a ppx preprocessor to know which tool is
+      calling it ["ocamlc"], ["ocamlopt"], ["ocamldep"], ["ocaml"], ... . *)
+  val tool_name : t -> string
+
+  (**/**)
   (** Undocumented section *)
 
   (** Build a new base context at the top level of the given file with the given


### PR DESCRIPTION
For code implemented using
e.g. `Ast_traverse.map_with_expansion_context`, there is a base
expansion context available, but no accessors for e.g. the `code_path`
within. A hacky workaround is to write e.g.
```ocaml
let code_path base =
  Expansion_context.Extension.code_path
    (Expansion_context.Extension.make
       ~extension_point_loc:Location.none ~base ())
```
This patch adds accessors to directly obtain these values without such
a detour.