### PR TITLE
Fix ppxlib_ast preprocessing

### DIFF
--- a/ast/dune
+++ b/ast/dune
@@ -1,3 +1,7 @@
+;; Note that to use the preprocessor for the (* IF_AT_LEAST ... *)
+;; syntax you have to make sure the module is in the module list in
+;; (per_module <action> <module_list>)
+
 (library
  (name        ppxlib_ast)
  (public_name ppxlib.ast)
@@ -8,7 +12,11 @@
   ocaml-migrate-parsetree
   stdlib-shims)
  (flags (:standard -open Ocaml_shadow -safe-string) -w -9-27-32)
- (preprocess (action (run %{exe:pp/pp.exe} %{ocaml_version} %{input-file})))
+ (preprocess
+  (per_module
+    ((action (run %{exe:pp/pp.exe} %{ocaml_version} %{input-file}))
+     versions
+     location_error)))
  (lint (pps ppxlib_traverse -deriving-keep-w32=impl)))
 
 ;; This is to make the code compatible with different versions of

--- a/ast/pp/pp.ml
+++ b/ast/pp/pp.ml
@@ -8,12 +8,9 @@ let () =
         Printf.eprintf "Unknown OCaml version %s\n" ocaml_version_str;
         exit 1
     in
-    let is_current =
-      (Filename.basename fname = Printf.sprintf "ast_%s.ml" ocaml_version)
-    in
     let ic = open_in_bin fname in
     Printf.printf "# 1 %S\n" fname;
-    Pp_rewrite.rewrite is_current ocaml_version (Lexing.from_channel ic)
+    Pp_rewrite.rewrite ocaml_version (Lexing.from_channel ic)
   | _ ->
     Printf.eprintf "%s: <ocaml-version> <file-name>\n"
       Sys.executable_name;

--- a/ast/pp/pp_rewrite.mli
+++ b/ast/pp/pp_rewrite.mli
@@ -1,1 +1,1 @@
-val rewrite : bool -> string -> Lexing.lexbuf -> unit
+val rewrite : string -> Lexing.lexbuf -> unit

--- a/ast/pp/pp_rewrite.mll
+++ b/ast/pp/pp_rewrite.mll
@@ -7,18 +7,10 @@ let print_ocaml_version version =
   printf "%-*s" patt_len version
 }
 
-rule rewrite is_current ocaml_version = parse
+rule rewrite ocaml_version = parse
   | "OCAML_VERSION"
     { print_ocaml_version ocaml_version;
-      rewrite is_current ocaml_version lexbuf
-    }
-  |          "(*IF_CURRENT " ([^'*']* as s) "*)"
-    { let chunk = if is_current
-        then "             " ^ s ^          "  "
-        else Lexing.lexeme lexbuf
-      in
-      print_string chunk;
-      rewrite is_current ocaml_version lexbuf
+      rewrite ocaml_version lexbuf
     }
   |          "(*IF_AT_LEAST " ([^'*' ' ']* as v) " " ([^'*']* as s) "*)"
     { let chunk = if (v <= ocaml_version)
@@ -26,7 +18,7 @@ rule rewrite is_current ocaml_version = parse
         else Lexing.lexeme lexbuf
       in
       print_string chunk;
-      rewrite is_current ocaml_version lexbuf
+      rewrite ocaml_version lexbuf
     }
   |          "(*IF_NOT_AT_LEAST " ([^'*' ' ']* as v) " " ([^'*']* as s) "*)"
     { let chunk = if not (v <= ocaml_version)
@@ -34,12 +26,10 @@ rule rewrite is_current ocaml_version = parse
         else Lexing.lexeme lexbuf
       in
       print_string chunk;
-      rewrite is_current ocaml_version lexbuf
+      rewrite ocaml_version lexbuf
     }
   | _ as c
     { print_char c;
-      rewrite is_current ocaml_version lexbuf
+      rewrite ocaml_version lexbuf
     }
   | eof { () }
-
-


### PR DESCRIPTION
The `deriving_inline` code generation was broken by the preprocessing action and this PR fixes it + remove some code that belonged in OMP but doesn't in ppxlib anymore.

Previously running `dune build @lint` would result in the following error:
```
Error: ppxlib_driver: the rewriting contains parts from another file.
It is too complicated to reconcile it with the source
```