### PR TITLE
Make ppxlib compatible with 4.11 and add 4.11 builds to the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ env:
   - OCAML_VERSION="4.09"
     TEST=false
   - OCAML_VERSION="4.10"
+  - OCAML_VERSION="4.11.1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,10 +43,16 @@ environment:
   - OPAM_SWITCH: 4.09.0+mingw32c
     PACKAGE: ppxlib
     TESTS: false
-  - OPAM_SWITCH: 4.10.0+mingw64c
+  - OPAM_SWITCH: 4.10.1+mingw64c
     PACKAGE: ppxlib
     TESTS: false
-  - OPAM_SWITCH: 4.10.0+mingw32c
+  - OPAM_SWITCH: 4.10.1+mingw32c
+    PACKAGE: ppxlib
+    TESTS: false
+  - OPAM_SWITCH: 4.11.1+mingw64c
+    PACKAGE: ppxlib
+    TESTS: false
+  - OPAM_SWITCH: 4.11.1+mingw32c
     PACKAGE: ppxlib
     TESTS: false
 install:

--- a/src/gen/import.ml
+++ b/src/gen/import.ml
@@ -11,7 +11,7 @@ let lident x = Longident.Lident x
 
 module Loc = struct
   let mk     x = { Location.loc; txt = x }
-  let lident x = mk (Longident.parse x)
+  let lident x = mk (Longident.parse x) [@@warning "-3"]
 end
 
 module List = Stdppx.List


### PR DESCRIPTION
Note that this PR does not bump the internal AST to 4.11.

For now I kept `Longident.parse` and discarded the warning but I'm happy to add a compat function that would
be equal to `Parse.longident (Lexing.from_string x)` for 4.11+ and default to `Longident.parse` otherwise but I'm just not too sure where to put it.

It might also be a good idea to use it to replace our `Longident.parse` buggy implementation in `src/` but I'm guessing that a proper fix for all versions would be better suited there. Actually it might be better suited anywhere!