### PR TITLE
Remove unused dependency on result

### DIFF
--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -19,7 +19,6 @@ depends: [
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "2.0.0"}
   "ppx_derivers"            {>= "1.0"}
-  "result"
   "sexplib0"
   "stdlib-shims"
   "ocamlfind"               {with-test}


### PR DESCRIPTION
The `result` library does not seem to be used anywhere.