### PR TITLE
Add a check to make sure changelog is updated when necessary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: Changelog check
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: git diff
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'no changelog') }}
+      env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+      run: |
+        ! git diff --exit-code origin/$BASE_REF -- CHANGES.md


### PR DESCRIPTION
Keeping the changelog up to date on master should ease the release process.