### PR TITLE
The ppxlib package is always only valid for a limited set of OCaml compilers

### DIFF
--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -14,7 +14,7 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.10" }
 ]
 depends: [
-  "ocaml"                   {>= "4.04.1"}
+  "ocaml"                   {>= "4.04.1" & < "4.12"}
   "dune"                    {>= "1.11"}
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "2.0.0"}


### PR DESCRIPTION
Supported versions are listed in `ast/supported_version/supported_version.ml`

If someone could also merge https://github.com/ocaml-ppx/ocaml-migrate-parsetree/pull/106 at the same time if this is accepted, that'd be really appreciated.