### PR TITLE
Add support for OCaml 4.12

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+unreleased
+----------
+
+- Make ppxlib compatible with 4.12 compiler (#191, @kit-ty-kate)
+
 0.18.0 (06/10/2020)
 -------------------
 

--- a/ast/supported_version/supported_version.ml
+++ b/ast/supported_version/supported_version.ml
@@ -11,6 +11,7 @@ let all =
   ; 4, 09
   ; 4, 10
   ; 4, 11
+  ; 4, 12
   ]
 
 let to_string (a, b) = Printf.sprintf "%d.%02d" a b

--- a/ast/versions.ml
+++ b/ast/versions.ml
@@ -478,6 +478,13 @@ module OCaml_411 = struct
   let string_version = "4.11"
 end
 let ocaml_411 : OCaml_411.types ocaml_version = (module OCaml_411)
+module OCaml_412 = struct
+  module Ast = Migrate_parsetree.Ast_412
+  include Make_witness(Migrate_parsetree.Ast_412)
+  let version = 412
+  let string_version = "4.12"
+end
+let ocaml_412 : OCaml_412.types ocaml_version = (module OCaml_412)
 (*$*)
 
 (*$foreach_version_pair (fun a b ->
@@ -503,6 +510,8 @@ include Register_migration(OCaml_409)(OCaml_410)
     (Migrate_parsetree.Migrate_409_410)(Migrate_parsetree.Migrate_410_409)
 include Register_migration(OCaml_410)(OCaml_411)
     (Migrate_parsetree.Migrate_410_411)(Migrate_parsetree.Migrate_411_410)
+include Register_migration(OCaml_411)(OCaml_412)
+    (Migrate_parsetree.Migrate_411_412)(Migrate_parsetree.Migrate_412_411)
 (*$*)
 
 module OCaml_current = OCaml_OCAML_VERSION

--- a/ast/versions.mli
+++ b/ast/versions.mli
@@ -125,6 +125,7 @@ module OCaml_408 : OCaml_version with module Ast = Migrate_parsetree.Ast_408
 module OCaml_409 : OCaml_version with module Ast = Migrate_parsetree.Ast_409
 module OCaml_410 : OCaml_version with module Ast = Migrate_parsetree.Ast_410
 module OCaml_411 : OCaml_version with module Ast = Migrate_parsetree.Ast_411
+module OCaml_412 : OCaml_version with module Ast = Migrate_parsetree.Ast_412
 (*$*)
 
 (* An alias to the current compiler version *)

--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -14,7 +14,7 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.10" }
 ]
 depends: [
-  "ocaml"                   {>= "4.04.1" & < "4.12"}
+  "ocaml"                   {>= "4.04.1" & < "4.13"}
   "dune"                    {>= "1.11"}
   "ocaml-compiler-libs"     {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "2.0.0"}

--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"                   {>= "4.04.1" & < "4.13"}
   "dune"                    {>= "1.11"}
   "ocaml-compiler-libs"     {>= "v0.11.0"}
-  "ocaml-migrate-parsetree" {>= "2.0.0"}
+  "ocaml-migrate-parsetree" {>= "2.1.0"}
   "ppx_derivers"            {>= "1.0"}
   "sexplib0"
   "stdlib-shims"


### PR DESCRIPTION
This requires the OCaml 4.12 support in omp to be merged first: https://github.com/ocaml-ppx/ocaml-migrate-parsetree/pull/107

This is just a PR to make ppxlib compile in case someone needs to test packages requiring ppxlib with OCaml 4.12. I do not know the internal nor have i tested if the tests ran correctly.

This branch will temporary be used in [opam-alpha-repository](https://github.com/kit-ty-kate/opam-alpha-repository/)