### PR TITLE
Silence a warning 16 spotted by ocaml 4.12

### DIFF
--- a/src/driver.ml
+++ b/src/driver.ml
@@ -313,6 +313,7 @@ let register_transformation = Transform.register
 
 let register_code_transformation ~name ?(aliases=[]) ~impl ~intf =
   register_transformation name ~impl ~intf ~aliases
+[@@warning "-16"] (* This function triggers a warning 16 as of ocaml 4.12 *)
 ;;
 
 let register_transformation_using_ocaml_current_ast ?impl ?intf ?aliases name =


### PR DESCRIPTION
There must have been a bug in the previous versions of the compiler which failed to detect this warning. The function is deprecated so there isn't really any point fixing it until we delete it from ppxlib.