### PR TITLE
Re-implement standalone_run_as_ppx_rewriter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+unreleased
+----------
+
+- `-as-ppx`: take into account the `-loc-filename` argument (#197, @pitag-ha)
+
 0.20.0 (16/11/2020)
 -------------------
 

--- a/dune-project
+++ b/dune-project
@@ -3,3 +3,4 @@
 (using cinaps 1.0)
 (allow_approximate_merlin)
 (formatting disabled)
+(cram enable)

--- a/test/driver/standalone_run_as_ppx/dune
+++ b/test/driver/standalone_run_as_ppx/dune
@@ -1,0 +1,6 @@
+(executable
+ (public_name print_stuff)
+ (libraries ppxlib))
+
+(cram
+ (deps %{bin:print_stuff}))

--- a/test/driver/standalone_run_as_ppx/print_stuff.ml
+++ b/test/driver/standalone_run_as_ppx/print_stuff.ml
@@ -1,0 +1,45 @@
+open Ppxlib
+
+let mk_expression ~loc pexp_desc =
+  { pexp_desc; pexp_loc_stack = []; pexp_loc = loc; pexp_attributes = [] }
+
+let print_string s ~loc =
+  let print_exp =
+    mk_expression ~loc (Pexp_ident { txt = Lident "print_endline"; loc })
+  in
+  let string_exp =
+    mk_expression ~loc (Pexp_constant (Pconst_string (s, loc, None)))
+  in
+  mk_expression ~loc (Pexp_apply (print_exp, [ (Nolabel, string_exp) ]))
+
+let hi_rule =
+  let expand ~loc ~path:_ = print_string "hi" ~loc in
+  Extension.declare "print_hi" Extension.Context.expression
+    Ast_pattern.(pstr nil)
+    expand
+  |> Context_free.Rule.extension
+
+let tool_name_rule =
+  let expand ~ctxt =
+    let loc = Expansion_context.Extension.extension_point_loc ctxt in
+    let tool_name = Expansion_context.Extension.tool_name ctxt in
+    print_string tool_name ~loc
+  in
+  Extension.V3.declare "print_tool_name" Extension.Context.expression
+    Ast_pattern.(pstr nil)
+    expand
+  |> Context_free.Rule.extension
+
+let fname_rule =
+  let expand ~loc ~path:_ = print_string ~loc loc.loc_start.pos_fname in
+  Extension.declare "print_fname" Extension.Context.expression
+    Ast_pattern.(pstr nil)
+    expand
+  |> Context_free.Rule.extension
+
+let () =
+  Driver.register_transformation
+    ~rules:[ hi_rule; tool_name_rule; fname_rule ]
+    "test"
+
+let () = Ppxlib.Driver.standalone ()

--- a/test/driver/standalone_run_as_ppx/run.t
+++ b/test/driver/standalone_run_as_ppx/run.t
@@ -1,0 +1,37 @@
+Keep the error output short in order to avoid different error output between different compiler versions in the subsequent tests
+
+  $ export OCAML_ERROR_STYLE=short
+
+The rewriter gets applied when using `--as-ppx`
+
+  $ echo "let _ = [%print_hi]" > impl.ml
+  $ ocaml -ppx 'print_stuff --as-ppx' impl.ml
+  hi
+
+If a non-compatible file gets fed, the file name is reported correctly
+
+  $ touch no_binary_ast.ml
+  $ print_stuff --as-ppx no_binary_ast.ml some_output
+  File "no_binary_ast.ml", line 1:
+  Error: Expected a binary AST as input
+  [1]
+
+The ocaml.ppx.context attribute gets parsed correctly; in particular, the tool name gets set correctly
+
+  $ echo "let _ = [%print_tool_name]" > impl.ml
+  $ ocaml -ppx 'print_stuff --as-ppx' impl.ml
+  ocaml
+
+The driver's `shared_args` arguments are taken into account. For example, `-loc-filename`
+
+  $ echo "let _ = [%print_fname]" > impl.ml
+  $ ocaml -ppx 'print_stuff --as-ppx -loc-filename new_fn.ml' impl.ml
+  new_fn.ml
+
+or `dont-apply`
+
+  $ echo "let _ = [%print_hi]" > impl.ml
+  $ ocaml -ppx 'print_stuff --as-ppx -dont-apply test' impl.ml
+  File "./impl.ml", line 1, characters 10-18:
+  Error: Uninterpreted extension 'print_hi'.
+  [2]


### PR DESCRIPTION
Before, the `standalone_run_as_ppx_rewriter` implementation was based on compiler-lib's Ast_mapper. With this commit, it reuses the adequate parts of the internal implementation of the main standalone. That has three advantages:
- it takes away a burden for Astlib
- it makes it possible to access the source file name from within the driver module
- it makes it possible to implement that ppxlib preserves the compiler version, also when using standalone_run_as_ppx_rewriter or run_as_ppx_rewriter.

This commit also fixes the following: now, `standalone_run_as_ppx_rewriter` takes into account the `loc-filename` argument when provided. Since that argument forms part of `shared_args`, that's the expected behaviour.

When comparing the new implementation with the old one, note that in the new one the ppx context gets restored through `extract_cookies` and the cookies get updated through `Intf_or_impl.to_ast_io` with `~add_ppx_context:true`.