### PR TITLE
Disable tests on older compiler using dune

### DIFF
--- a/examples/simple-deriver/ppx_deriving_accessors.ml
+++ b/examples/simple-deriver/ppx_deriving_accessors.ml
@@ -32,23 +32,25 @@ let accessor_intf ~ptype_name (ld : label_declaration) =
 
 let generate_impl ~ctxt (_rec_flag, type_declarations) =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
-  List.concat_map type_declarations
+  List.map type_declarations
     ~f:(fun (td : type_declaration) ->
       match td with
       | {ptype_kind = (Ptype_abstract | Ptype_variant _ | Ptype_open); _} ->
         Location.raise_errorf ~loc "Cannot derive accessors for non record types"
       | {ptype_kind = Ptype_record fields; _} ->
         List.map fields ~f:accessor_impl)
+  |> List.concat
 
 let generate_intf ~ctxt (_rec_flag, type_declarations) =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
-  List.concat_map type_declarations
+  List.map type_declarations
     ~f:(fun (td : type_declaration) ->
       match td with
       | {ptype_kind = (Ptype_abstract | Ptype_variant _ | Ptype_open); _} ->
         Location.raise_errorf ~loc "Cannot derive accessors for non record types"
       | {ptype_kind = Ptype_record fields; ptype_name; _} ->
         List.map fields ~f:(accessor_intf ~ptype_name))
+  |> List.concat
 
 let impl_generator = Deriving.Generator.V2.make_noarg generate_impl
 

--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 run-test: [
-  ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.10" }
+  ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.07" }
 ]
 depends: [
   "ocaml"                   {>= "4.04.1" & < "4.13"}

--- a/test/base/dune
+++ b/test/base/dune
@@ -1,6 +1,6 @@
 (rule
  (alias runtest)
- (enabled_if (>= %{ocaml_version} "4.08.0"))
+ (enabled_if (>= %{ocaml_version} "4.09.0"))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/base/dune
+++ b/test/base/dune
@@ -1,5 +1,6 @@
 (rule
  (alias runtest)
+ (enabled_if (>= %{ocaml_version} "4.08.0"))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/code_path/dune
+++ b/test/code_path/dune
@@ -1,5 +1,6 @@
 (rule
  (alias runtest)
+ (enabled_if (>= %{ocaml_version} "4.08.0"))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/deriving/dune
+++ b/test/deriving/dune
@@ -1,6 +1,6 @@
 (rule
  (alias runtest)
- (enabled_if (>= %{ocaml_version} "4.08.0"))
+ (enabled_if (>= %{ocaml_version} "4.09.0"))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/deriving/dune
+++ b/test/deriving/dune
@@ -1,6 +1,6 @@
 (rule
  (alias runtest)
- (enabled_if (>= %{ocaml_version} "4.09.0"))
+ (enabled_if (>= %{ocaml_version} "4.10.0"))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/deriving/dune
+++ b/test/deriving/dune
@@ -1,5 +1,6 @@
 (rule
  (alias runtest)
+ (enabled_if (>= %{ocaml_version} "4.08.0"))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/driver/attributes/dune
+++ b/test/driver/attributes/dune
@@ -1,5 +1,6 @@
 (rule
  (alias runtest)
+ (enabled_if (>= %{ocaml_version} "4.08.0"))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/driver/non-compressible-suffix/dune
+++ b/test/driver/non-compressible-suffix/dune
@@ -1,5 +1,6 @@
 (rule
  (alias runtest)
+ (enabled_if (>= %{ocaml_version} "4.08.0"))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/driver/transformations/dune
+++ b/test/driver/transformations/dune
@@ -1,5 +1,6 @@
 (rule
  (alias runtest)
+ (enabled_if (>= %{ocaml_version} "4.08.0"))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/expect/dune
+++ b/test/expect/dune
@@ -1,5 +1,6 @@
 (executable
  (name expect_test)
+ (enabled_if (>= %{ocaml_version} "4.08.0"))
  (link_flags (-linkall))
  (modes byte)
  (libraries unix compiler-libs.toplevel ppxlib ppxlib.metaquot ppxlib.traverse

--- a/test/instrument/dune
+++ b/test/instrument/dune
@@ -1,5 +1,6 @@
 (rule
    (alias runtest)
+   (enabled_if (>= %{ocaml_version} "4.08.0"))
    (deps
       (:test test.ml)
       (package ppxlib))

--- a/test/quoter/dune
+++ b/test/quoter/dune
@@ -1,5 +1,6 @@
 (rule
  (alias runtest)
+ (enabled_if (>= %{ocaml_version} "4.08.0"))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/traverse/dune
+++ b/test/traverse/dune
@@ -1,5 +1,6 @@
 (rule
  (alias runtest)
+ (enabled_if (>= %{ocaml_version} "4.08.0"))
  (deps
   (:test test.ml)
   (package ppxlib))


### PR DESCRIPTION
This fixes ocaml-ci for 4.07+ by disabling incompatible tests via dune. The higher the ocaml version the more tests are run.

We still need to investigate the arm32 build failure which might be related to cinaps/the cinaps stanza somehow.

For versions older than 4.07, cinaps is not available. At the moment there's no good way to handle this in ocaml-ci meaning we'll have to live without older builds for now.