### PR TITLE
Make context available in transformation callbacks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ unreleased
 
 - `-as-ppx`: take into account the `-loc-filename` argument (#197, @pitag-ha)
 
+- Add input name to expansion context (#202, @pitag-ha)
+
 0.20.0 (16/11/2020)
 -------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@ unreleased
 
 - Add input name to expansion context (#202, @pitag-ha)
 
+- Add Driver.V2: give access to expansion context in whole file transformation
+  callbacks of `register_transformation` (#202, @pitag-ha)
+
 0.20.0 (16/11/2020)
 -------------------
 

--- a/ast/import.ml
+++ b/ast/import.ml
@@ -82,11 +82,11 @@ module Select_ast(Ocaml : Versions.OCaml_version) = struct
         let g = to_ocaml b in
         fun (x, y) -> (f x, g y)
 
-  let of_ocaml_mapper item f x =
-    to_ocaml item x |> f |> of_ocaml item
+  let of_ocaml_mapper item f ctxt x =
+    to_ocaml item x |> f ctxt |> of_ocaml item
 
-  let to_ocaml_mapper item f x =
-    of_ocaml item x |> f |> to_ocaml item
+  let to_ocaml_mapper item f ctxt x =
+    of_ocaml item x |> f ctxt |> to_ocaml item
 end
 
 module Selected_ast = Select_ast(Ocaml)

--- a/src/expansion_context.ml
+++ b/src/expansion_context.ml
@@ -2,13 +2,17 @@ module Base = struct
   type t =
     { tool_name : string
     ; code_path : Code_path.t
+    ; input_name : string
     }
 
-  let top_level ~tool_name ~file_path =
+  let top_level ~tool_name ~file_path ~input_name =
     let code_path = Code_path.top_level ~file_path in
-    {tool_name; code_path}
+    {tool_name; code_path; input_name }
 
   let code_path t = t.code_path
+
+  let input_name t = t.input_name
+
   let tool_name t = t.tool_name
 
   let enter_expr t = {t with code_path = Code_path.enter_expr t.code_path}

--- a/src/expansion_context.mli
+++ b/src/expansion_context.mli
@@ -2,8 +2,22 @@ module Base : sig
   (** Type for the location independent parts of the expansion context *)
   type t
 
-  (** Return the code path for the given context *)
+  (** Return the code path for the given context
+  In Driver, Deriving and Extension, the context is initialized so that the [file_path] component of
+  the [code_path] is determined from the first location found in the input AST. That means that:
+  - It's the empty string in empty structures or signatures
+  - It can be altered by earlier running PPX's
+  - It can be altered by line directives *)
   val code_path : t -> Code_path.t
+
+  (** Return the input name for the given context.
+  In Driver, Deriving and Extension, the context argument is initialized so that the [input_name]
+  matches the input filename passed to the driver on the command line. That means that:
+  - It has a value even for empty files
+  - It is not affected by earlier running PPX's
+  - It is not affected by line directives
+  - It is ["_none_"] when using [Driver.map_structure] or [Driver.map_signature] *)
+  val input_name : t -> string
 
   (** Can be used within a ppx preprocessor to know which tool is
       calling it ["ocamlc"], ["ocamlopt"], ["ocamldep"], ["ocaml"], ... . *)
@@ -18,6 +32,7 @@ module Base : sig
   val top_level :
     tool_name:string ->
     file_path:string ->
+    input_name:string ->
     t
 
   (** Proxy functions to update the wrapped code path. See code_path.mli for details. *)

--- a/src/expansion_context.mli
+++ b/src/expansion_context.mli
@@ -6,7 +6,6 @@ module Base : sig
   In Driver, Deriving and Extension, the context is initialized so that the [file_path] component of
   the [code_path] is determined from the first location found in the input AST. That means that:
   - It's the empty string in empty structures or signatures
-  - It can be altered by earlier running PPX's
   - It can be altered by line directives *)
   val code_path : t -> Code_path.t
 
@@ -14,7 +13,6 @@ module Base : sig
   In Driver, Deriving and Extension, the context argument is initialized so that the [input_name]
   matches the input filename passed to the driver on the command line. That means that:
   - It has a value even for empty files
-  - It is not affected by earlier running PPX's
   - It is not affected by line directives
   - It is ["_none_"] when using [Driver.map_structure] or [Driver.map_signature] *)
   val input_name : t -> string

--- a/test/expansion_context/dune
+++ b/test/expansion_context/dune
@@ -1,0 +1,18 @@
+(library
+ (name register_print_ctxt)
+ (modules register_print_ctxt)
+ (kind ppx_rewriter)
+ (libraries ppxlib))
+
+(executable
+ (public_name standalone_print_ctxt)
+ (modules standalone_print_ctxt)
+ (libraries ppxlib register_print_ctxt))
+
+(executable
+ (public_name map_structure_print_ctxt)
+ (modules map_structure_print_ctxt)
+ (libraries ppxlib register_print_ctxt))
+
+(cram
+ (deps %{bin:standalone_print_ctxt} %{bin:map_structure_print_ctxt}))

--- a/test/expansion_context/map_structure_print_ctxt.ml
+++ b/test/expansion_context/map_structure_print_ctxt.ml
@@ -1,0 +1,9 @@
+open Ppxlib
+
+let set_filename (lexbuf : Lexing.lexbuf) ~filename =
+  { lexbuf with lex_curr_p = { lexbuf.lex_curr_p with pos_fname = filename } }
+
+let _ =
+  Lexing.from_channel stdin
+  |> set_filename ~filename:"lexbuf_pos_fname"
+  |> Parse.implementation |> Driver.map_structure

--- a/test/expansion_context/register_print_ctxt.ml
+++ b/test/expansion_context/register_print_ctxt.ml
@@ -1,0 +1,24 @@
+open Ppxlib
+
+let pprint_ctxt ctxt =
+  let tool_name = Expansion_context.Base.tool_name ctxt in
+  let input_name = Expansion_context.Base.input_name ctxt in
+  let file_path = Code_path.file_path @@ Expansion_context.Base.code_path @@ ctxt in
+  Printf.printf "tool_name: %s\ninput_name: %s\nfile_path: %s\n" tool_name input_name file_path
+
+
+let side_print_ctxt = object
+  inherit Ast_traverse.map_with_expansion_context as super
+
+  method! structure ctxt st =
+    pprint_ctxt ctxt;
+    super#structure ctxt st
+
+  method! signature ctxt sg =
+    pprint_ctxt ctxt;
+    super#signature ctxt sg
+
+end
+
+let () =
+  Driver.V2.(register_transformation ~impl:(side_print_ctxt#structure) ~intf:(side_print_ctxt#signature) "print_ctxt")

--- a/test/expansion_context/run.t
+++ b/test/expansion_context/run.t
@@ -1,0 +1,39 @@
+The three context fields can be accessed in a rewriter, both from within an implementation file
+
+  $ echo "let x = 0" > file.ml
+  $ standalone_print_ctxt file.ml | egrep 'tool_name|input_name|file_path'
+  tool_name: ppx_driver
+  input_name: file.ml
+  file_path: file.ml
+
+and from within an interface file
+
+  $ echo "val x : int" > file.mli
+  $ standalone_print_ctxt file.mli | egrep 'tool_name|input_name|file_path'
+  tool_name: ppx_driver
+  input_name: file.mli
+  file_path: file.mli
+
+In most cases, the input name and the file path coincide. But there are some exceptions, such as
+1. empty files
+
+  $ touch empty_file.ml
+  $ standalone_print_ctxt empty_file.ml | egrep 'input_name|file_path'
+  input_name: empty_file.ml
+  file_path: 
+
+2. files with directives pointing to other files
+
+  $ cat > directive.ml << EOF
+  > # 1 "file.ml"
+  > let y = 0
+  > EOF
+  $ standalone_print_ctxt directive.ml | egrep 'input_name|file_path'
+  input_name: directive.ml
+  file_path: file.ml
+
+3. using `map_structure` (or `map_signature`)
+
+  $ echo "let x = 0" | map_structure_print_ctxt | egrep 'input_name|file_path'
+  input_name: _none_
+  file_path: lexbuf_pos_fname

--- a/test/expansion_context/standalone_print_ctxt.ml
+++ b/test/expansion_context/standalone_print_ctxt.ml
@@ -1,0 +1,1 @@
+let () = Ppxlib.Driver.standalone ()


### PR DESCRIPTION
The later versions (V2 or V3) of the Extension and Deriving modules allow to access an expansion context when writing such rewriters. By adding a V2 to Driver, this commit also adds that possibility to whole file transformations registered through the `~impl`, `intf`, `~preprocess_impl`, `~preprocess_intf`, `lint_impl` or `lint-intf` arguments of `Driver.register_transformation`. The expansion context chosen is the Base expansion context in order to be compatible with `Ast_traverse.map_with_expansion_context`.

There are other kinds of transformations that still don't offer that possibility such as other context free rules than extensions (see issue #169).

The PR also adds input name to the expansion context.