### PR TITLE
Add bucklescript support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 unreleased
 ----------
 
+- Driver (important for bucklescript): handling binary AST's, accept any
+  supported version as input; preserve that version (#205, @pitag-ha)
+
 - `-as-ppx`: take into account the `-loc-filename` argument (#197, @pitag-ha)
 
 - Add input name to expansion context (#202, @pitag-ha)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@ unreleased
 - `run_as_ppx_rewriter`: take into account the arguments
   `-loc-filename`, `apply` and `dont-apply` (#205, @pitag-ha)
 
+- Location.Error: add functions `raise` and `update_loc`
+  (#205, @pitag-ha)
+
 0.20.0 (16/11/2020)
 -------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@ unreleased
 - Driver: take `-cookie` argument into account, also when the input is a
   binary AST (@pitag-ha, #209)
 
+- `run_as_ppx_rewriter`: take into account the arguments
+  `-loc-filename`, `apply` and `dont-apply` (#205, @pitag-ha)
+
 0.20.0 (16/11/2020)
 -------------------
 

--- a/ast/location_error.ml
+++ b/ast/location_error.ml
@@ -110,3 +110,16 @@ let make_error_of_message_new ~loc msg ~sub =
 let make ~loc msg ~sub =
   (*IF_NOT_AT_LEAST 408 make_error_of_message_old ~loc msg ~sub*)
   (*IF_AT_LEAST 408 make_error_of_message_new ~loc msg ~sub*)
+
+let raise error = raise (Location.Error error)
+
+let update_loc_old error loc =
+  { error with loc }
+
+let update_loc_new error loc =
+  let main = { error.main with loc } in
+  { error with main }
+
+let update_loc error loc =
+  (*IF_NOT_AT_LEAST 408 update_loc_old error loc*)
+  (*IF_AT_LEAST 408 update_loc_new error loc*)

--- a/ast/location_error.mli
+++ b/ast/location_error.mli
@@ -6,3 +6,5 @@ val message : t -> string
 val set_message : t -> string -> t
 val make : loc:Location.t -> string -> sub:(Location.t * string) list -> t
 val to_extension : t -> Import.Parsetree.extension
+val raise : t -> 'a
+val update_loc : t -> Location.t -> t

--- a/ast/ppxlib_ast.ml
+++ b/ast/ppxlib_ast.ml
@@ -1,10 +1,15 @@
 open Import
 
+module type OCaml_version = Versions.OCaml_version
+
 module Ast            = Ast
 module Ast_helper     = Ast_helper
 module Ast_magic      = Selected_ast.Ast.Config
 module Asttypes       = Asttypes
-module Compiler_ast   = Versions.OCaml_current.Ast
+module Compiler_version = Versions.OCaml_current
+module Js             = Js
+module Find_version   = Versions.Find_version
+module Convert        = Versions.Convert
 module Extra_warnings = Warn
 module Lexer          = Lexer
 module Location_error = Location_error

--- a/ast/versions.ml
+++ b/ast/versions.ml
@@ -487,6 +487,23 @@ end
 let ocaml_412 : OCaml_412.types ocaml_version = (module OCaml_412)
 (*$*)
 
+let all_versions : (module OCaml_version) list = [
+  (*$foreach_version (fun n _ ->
+      printf "(module OCaml_%d : OCaml_version);\n" n)*)
+(module OCaml_402 : OCaml_version);
+(module OCaml_403 : OCaml_version);
+(module OCaml_404 : OCaml_version);
+(module OCaml_405 : OCaml_version);
+(module OCaml_406 : OCaml_version);
+(module OCaml_407 : OCaml_version);
+(module OCaml_408 : OCaml_version);
+(module OCaml_409 : OCaml_version);
+(module OCaml_410 : OCaml_version);
+(module OCaml_411 : OCaml_version);
+(module OCaml_412 : OCaml_version);
+(*$*)
+]
+
 (*$foreach_version_pair (fun a b ->
     printf "include Register_migration(OCaml_%d)(OCaml_%d)\n" a b;
     printf "    (Migrate_parsetree.Migrate_%d_%d)(Migrate_parsetree.Migrate_%d_%d)\n" a b b a
@@ -515,3 +532,20 @@ include Register_migration(OCaml_411)(OCaml_412)
 (*$*)
 
 module OCaml_current = OCaml_OCAML_VERSION
+
+module Find_version = struct
+  type t = Impl of (module OCaml_version) | Intf of (module OCaml_version) | Unknown
+
+  let from_magic magic =
+    let rec loop = function
+      | [] -> Unknown
+      | (module Version : OCaml_version) :: tail ->
+          if Version.Ast.Config.ast_impl_magic_number = magic then
+            Impl (module Version)
+          else if Version.Ast.Config.ast_intf_magic_number = magic then
+            Intf (module Version)
+          else
+            loop tail
+    in
+    loop all_versions
+end

--- a/ast/versions.mli
+++ b/ast/versions.mli
@@ -131,6 +131,9 @@ module OCaml_412 : OCaml_version with module Ast = Migrate_parsetree.Ast_412
 (* An alias to the current compiler version *)
 module OCaml_current = OCaml_OCAML_VERSION
 
+(* The list of all supported versions *)
+val all_versions : (module OCaml_version) list
+
 (** {1 Convenience definitions} *)
 
 (** Module level migration *)
@@ -149,4 +152,11 @@ module Convert (A : OCaml_version) (B : OCaml_version) : sig
   val copy_type_extension        : A.Ast.Parsetree.type_extension        -> B.Ast.Parsetree.type_extension
   val copy_extension_constructor : A.Ast.Parsetree.extension_constructor -> B.Ast.Parsetree.extension_constructor
 (*$*)
+end
+
+(** Helper to find the frontend corresponding to a given magic number *)
+module Find_version : sig
+  type t = Impl of (module OCaml_version) | Intf of (module OCaml_version) | Unknown
+
+  val from_magic : string -> t
 end

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -598,24 +598,12 @@ let string_contains_binary_ast s =
   test Ast_magic.ast_intf_magic_number ||
   test Ast_magic.ast_impl_magic_number
 
-type pp_error = { filename : string; command_line : string }
-exception Pp_error of pp_error
-
-let report_pp_error e =
-  let buff = Buffer.create 128 in
-  let ppf = Caml.Format.formatter_of_buffer buff in
-  Caml.Format.fprintf ppf "Error while running external preprocessor@.\
-                           Command line: %s@." e.command_line;
-  Caml.Format.pp_print_flush ppf ();
-  Buffer.contents buff
-
-let () =
-  Location.Error.register_error_of_exn
-    (function
-      | Pp_error e ->
-        Some (Location.Error.make ~loc:(Location.in_file e.filename) ~sub:[]
-                (report_pp_error e))
-      | _ -> None)
+let versioned_errorf input_version input_file_name =
+  Printf.ksprintf (fun msg ->
+    let err =
+      Location.Error.make ~loc:(Location.in_file input_file_name) msg ~sub:[]
+    in
+    Error (err, input_version))
 
 let remove_no_error fn =
   try Caml.Sys.remove fn with Sys_error _ -> ()
@@ -633,23 +621,13 @@ let with_preprocessed_file fn ~f =
     protectx (Caml.Filename.temp_file "ocamlpp" "")
       ~finally:remove_no_error
       ~f:(fun tmpfile ->
-        let comm =
-          Printf.sprintf "%s %s > %s"
-            pp (if String.equal fn "-" then "" else Caml.Filename.quote fn)
-            (Caml.Filename.quote tmpfile)
-        in
-        if Caml.Sys.command comm <> 0 then
-          raise (Pp_error { filename = fn
-                          ; command_line = comm
-                          });
-        f tmpfile)
-
-let with_preprocessed_input fn ~f =
-  with_preprocessed_file fn ~f:(fun fn ->
-    if String.equal fn "-" then
-      f stdin
-    else
-      In_channel.with_file fn ~f)
+        match System.run_preprocessor ~pp ~input:fn ~output:tmpfile with
+          | Ok () -> f tmpfile
+          | Error (failed_command, fall_back_version) ->
+            versioned_errorf fall_back_version fn
+              "Error while running external preprocessor\n\
+               Command line: %s\n" failed_command
+      )
 ;;
 
 let relocate_mapper = object
@@ -662,69 +640,47 @@ let relocate_mapper = object
       pos
 end
 
-let read_ast ic =
-  match Ast_io.read ic with
-  | Ok (input_name, ast) ->
-      let ast = Intf_or_impl.of_ast_io ast in
-      let kind = Intf_or_impl.kind ast in
-      Ok (ast, input_name, kind)
-  | Error e -> Error e
-
 (* Set the input name globally. This is used by some ppx rewriters
    such as bisect_ppx. *)
 let set_input_name name =
   Ocaml_common.Location.input_name := name
 
-let load_input (kind : Kind.t) fn input_name ~relocate ic =
+let load_input ~(kind : Kind.t) ~input_name ~relocate fn =
   set_input_name input_name;
-  match read_ast ic with
-  | Ok (ast, ast_input_name, ast_kind) ->
+  let input_source = if String.equal fn "-" then Ast_io.Stdin else File fn in
+  let input_kind = Ast_io.Possibly_source (kind, input_name) in
+  match Ast_io.read input_source ~input_kind with
+  | Ok { input_name = ast_input_name; input_version; ast } ->
+    let ast_kind = Intf_or_impl.kind ast in
     if not (Kind.equal kind ast_kind) then
-      Location.raise_errorf ~loc:(Location.in_file fn)
+      versioned_errorf input_version fn
         "File contains a binary %s AST but an %s was expected"
-        (Kind.describe ast_kind)
-        (Kind.describe kind);
-    if String.equal ast_input_name input_name || not relocate then begin
+        (Kind.describe ast_kind) (Kind.describe kind)
+    else if String.equal ast_input_name input_name || not relocate then (
       set_input_name ast_input_name;
-      (ast_input_name, ast)
-    end else
-      (input_name,
-       Intf_or_impl.map_with_context ast relocate_mapper
-         (ast_input_name, input_name))
-
-  | Error (Unknown_version _) ->
-    Location.raise_errorf ~loc:(Location.in_file fn)
-      "File is a binary ast for an unknown version of OCaml"
-  | Error (Not_a_binary_ast prefix_read_from_file) ->
-    (* To test if a file is an AST file, we have to read the first few bytes of the
-       file. If it is not, we have to parse these bytes and the rest of the file as
-       source code.
-
-       The compiler just does [seek_on 0] in this case, however this doesn't work when
-       the input is a pipe.
-
-       What we do instead is create a lexing buffer from the input channel and pre-fill
-       it with what we read to do the test. *)
-    let lexbuf = Lexing.from_channel ic in
-    let len = String.length prefix_read_from_file in
-    Bytes.blit_string ~src:prefix_read_from_file ~src_pos:0 ~dst:lexbuf.lex_buffer ~dst_pos:0
-      ~len;
-    lexbuf.lex_buffer_len <- len;
-    lexbuf.lex_curr_p <-
-      { pos_fname = input_name
-      ; pos_lnum  = 1
-      ; pos_bol   = 0
-      ; pos_cnum  = 0
-      };
-    Lexer.skip_hash_bang lexbuf;
-    match kind with
-    | Intf -> input_name, Intf (Parse.interface      lexbuf)
-    | Impl -> input_name, Impl (Parse.implementation lexbuf)
+      Ok (ast_input_name, input_version, ast) )
+    else
+      Ok
+        ( input_name,
+          input_version,
+          Intf_or_impl.map_with_context ast relocate_mapper
+            (ast_input_name, input_name) )
+  | Error (Unknown_version (unknown_magic, fall_back_version)) ->
+    versioned_errorf fall_back_version fn
+      "File is a binary ast for an unknown version of OCaml with magic \
+       number '%s'" unknown_magic
+  | Error (System_error (error, fall_back_version))
+  | Error (Source_parse_error (error, fall_back_version)) ->
+    Error (error, fall_back_version)
+  | Error Not_a_binary_ast -> assert false
 ;;
 
-let load_input_run_as_ppx ~input_fn ic =
-  match read_ast ic with
-  | Ok (ast, ast_input_name, kind) ->
+let load_input_run_as_ppx fn =
+  (* If there's an error while loading in run_as_ppx mode, the kind of AST (impl/intf) is still unknown.
+     That's why, as opposed to load_input, this function raises errors instead of returning a result:
+     handling an error by returning an AST with the error packed as extension node wouldn't be possible. *)
+  match Ast_io.read (File fn) ~input_kind:Ast_io.Necessarily_binary with
+  | Ok {input_name = ast_input_name; input_version; ast} ->
       let ast =
         match !loc_fname with
         | None ->
@@ -741,15 +697,19 @@ let load_input_run_as_ppx ~input_fn ic =
          with the filename as metadata that it gets from the previous call. relocate_mapper only
          relocates positions whose position filename coincides with that metadata filename.
          So always return the metadata filename itself, even if `-loc-filename` is provided. *)
-      (ast_input_name, ast, kind)
-  | Error (Unknown_version _) ->
+      (ast_input_name, input_version, ast)
+  | Error (Unknown_version (unknown_magic, _)) ->
       Location.raise_errorf
-        ~loc:(Location.in_file input_fn)
-        "The input is a binary ast for an unknown version of OCaml"
-  | Error (Not_a_binary_ast _) ->
+        ~loc:(Location.in_file fn)
+        "The input is a binary ast for an unknown version of OCaml with magic number '%s'" unknown_magic
+  | Error Not_a_binary_ast ->
       Location.raise_errorf
-        ~loc:(Location.in_file input_fn)
+        ~loc:(Location.in_file fn)
         "Expected a binary AST as input"
+  | Error (System_error (error, _)) | Error (Source_parse_error (error, _)) ->
+      Location.in_file fn
+      |> Location.Error.update_loc error
+      |> Location.Error.raise
 ;;
 
 let load_source_file fn =
@@ -880,29 +840,31 @@ module Create_file_property(Name : sig val name : string end)(T : Sexpable.S) = 
   let set x = t.data <- Some x
 end
 
-let handle_exn exn ~input_name ~(kind : Kind.t) =
+
+let error_to_extension error ~(kind : Kind.t) =
+  let loc = Location.none in
+  let ext = Location.Error.to_extension error in
+  let open Ast_builder.Default in
+  let ast = match kind with
+    | Intf -> Intf_or_impl.Intf [ psig_extension ~loc ext [] ]
+    | Impl -> Intf_or_impl.Impl [ pstr_extension ~loc ext [] ]
+  in
+  ast
+;;
+
+let exn_to_extension exn ~(kind : Kind.t) =
   match Location.Error.of_exn exn with
   | None -> raise exn
-  | Some error ->
-    let loc = Location.none in
-    let ext = Location.Error.to_extension error in
-    let open Ast_builder.Default in
-    let ast = match kind with
-      | Intf -> Intf_or_impl.Intf [ psig_extension ~loc ext [] ]
-      | Impl -> Intf_or_impl.Impl [ pstr_extension ~loc ext [] ]
-    in
-    input_name, ast
+  | Some error -> error_to_extension error ~kind
 ;;
 
 let process_ast (ast : Intf_or_impl.t) ~input_name ~tool_name ~hook ~expect_mismatch_handler =
   match ast with
   | Intf x ->
-    input_name,
     Intf_or_impl.Intf
       (map_signature_gen x
          ~tool_name ~hook ~expect_mismatch_handler ~input_name:(Some input_name))
   | Impl x ->
-    input_name,
     Intf_or_impl.Impl
       (map_structure_gen x
          ~tool_name ~hook ~expect_mismatch_handler ~input_name:(Some input_name))
@@ -938,16 +900,28 @@ let process_file (kind : Kind.t) fn ~input_name ~relocate ~output_mode ~embed_er
              ~repl:(Many generated))
     }
   in
-  let input_name, ast =
-    try
-      let input_name, ast =
-        with_preprocessed_input fn ~f:(load_input kind fn input_name ~relocate)
-      in
-      let ast = extract_cookies ast in
-      process_ast ast ~input_name ~tool_name ~hook ~expect_mismatch_handler
-    with exn when embed_errors -> handle_exn exn ~input_name ~kind
-  in
 
+  let input_name, input_version, ast =
+    let preprocessed_and_loaded =
+      with_preprocessed_file fn ~f:(load_input ~kind ~input_name ~relocate)
+    in
+    match preprocessed_and_loaded with
+    | Ok (input_fname, input_version, ast) -> (
+        try
+          let ast =
+            extract_cookies ast
+            |> process_ast ~input_name ~tool_name ~hook ~expect_mismatch_handler
+          in
+          (input_fname, input_version, ast)
+        with exn when embed_errors ->
+          (input_fname, input_version, exn_to_extension exn ~kind) )
+    | Error (error, input_version) when embed_errors ->
+        (input_name, input_version, error_to_extension error ~kind)
+    | Error (error, _) ->
+        Location.in_file fn
+        |> Location.Error.update_loc error
+        |> Location.Error.raise
+  in
   Option.iter !output_metadata_filename ~f:(fun fn ->
     let metadata = File_property.dump_and_reset_all () in
     Out_channel.write_all fn
@@ -986,8 +960,7 @@ let process_file (kind : Kind.t) fn ~input_name ~relocate ~output_mode ~embed_er
        if not null_ast then Caml.Format.pp_print_newline ppf ())
    | Dump_ast ->
      with_output output ~binary:true ~f:(fun oc ->
-       let ast = Intf_or_impl.to_ast_io ast ~add_ppx_context:true in
-       Ast_io.write oc input_name ast)
+       Ast_io.write oc {input_name; input_version; ast} ~add_ppx_context:true)
    | Dparsetree ->
      with_output output ~binary:false ~f:(fun oc ->
        let ppf = Caml.Format.formatter_of_out_channel oc in
@@ -1271,21 +1244,20 @@ let standalone_main () =
 ;;
 
 let rewrite_binary_ast_file input_fn output_fn =
-  let input_name, ast, kind =
-    In_channel.with_file input_fn ~f:(load_input_run_as_ppx ~input_fn)
+  let input_name, input_version, ast =
+    load_input_run_as_ppx input_fn
   in
-  let input_name, ast =
+  let ast =
     try
       let ast = extract_cookies ast in
       let tool_name = Ocaml_common.Ast_mapper.tool_name () in
       let hook = Context_free.Generated_code_hook.nop in
       let expect_mismatch_handler = Context_free.Expect_mismatch_handler.nop in
       process_ast ast ~input_name ~tool_name ~hook ~expect_mismatch_handler
-    with exn -> handle_exn exn ~input_name ~kind
+    with exn -> exn_to_extension exn ~kind:(Intf_or_impl.kind ast)
   in
   with_output (Some output_fn) ~binary:true ~f:(fun oc ->
-      let ast = Intf_or_impl.to_ast_io ast ~add_ppx_context:true in
-      Ast_io.write oc input_name ast)
+    Ast_io.write oc {input_name; input_version; ast} ~add_ppx_context:true)
 ;;
 
 let parse_input passed_in_args ~valid_args
@@ -1303,7 +1275,8 @@ let parse_input passed_in_args ~valid_args
       Caml.exit 0
 ;;
 
-let run_as_ppx_rewriter_main ~valid_args ~usage input =
+let run_as_ppx_rewriter_main ~standalone_args ~usage input =
+  let valid_args = get_args ~standalone_args () in
   match List.rev @@ Array.to_list @@ input with
   | output_fn :: input_fn :: flags_and_prog_name
     when List.length flags_and_prog_name > 0 ->
@@ -1332,8 +1305,7 @@ let standalone_run_as_ppx_rewriter () =
     List.map standalone_args ~f:(fun (arg, spec, _doc) ->
       (arg, spec, " Unused with -as-ppx"))
   in
-  let valid_args = get_args ~standalone_args () in
-  run_as_ppx_rewriter_main ~valid_args ~usage argv
+  run_as_ppx_rewriter_main ~standalone_args ~usage argv
 ;;
 
 let standalone () =
@@ -1355,9 +1327,8 @@ let standalone () =
 
 let run_as_ppx_rewriter () =
   let usage = Printf.sprintf "%s [extra_args] <infile> <outfile>" exe_name in
-  let valid_args = List.rev !args in
   let input = Caml.Sys.argv in
-  try run_as_ppx_rewriter_main ~valid_args ~usage input
+  try run_as_ppx_rewriter_main ~standalone_args:[] ~usage input
   with exn ->
     Location.report_exception Caml.Format.err_formatter exn;
     Caml.exit 1

--- a/src/driver.mli
+++ b/src/driver.mli
@@ -147,10 +147,10 @@ val register_transformation
     library.
 *)
 val register_transformation_using_ocaml_current_ast
-  :  ?impl : (Compiler_ast.Parsetree.structure ->
-              Compiler_ast.Parsetree.structure)
-  -> ?intf : (Compiler_ast.Parsetree.signature ->
-              Compiler_ast.Parsetree.signature)
+  :  ?impl : (Compiler_version.Ast.Parsetree.structure ->
+              Compiler_version.Ast.Parsetree.structure)
+  -> ?intf : (Compiler_version.Ast.Parsetree.signature ->
+              Compiler_version.Ast.Parsetree.signature)
   -> ?aliases : string list
   -> string
   -> unit
@@ -205,10 +205,10 @@ module V2 : sig
   (** Same as [Driver.register_transformation_using_ocaml_current_ast], but the callbacks [?impl]
       and [?intf] have access to an expansion context. *)
   val register_transformation_using_ocaml_current_ast
-    :  ?impl : (Expansion_context.Base.t -> Compiler_ast.Parsetree.structure ->
-                Compiler_ast.Parsetree.structure)
-    -> ?intf : (Expansion_context.Base.t -> Compiler_ast.Parsetree.signature ->
-                Compiler_ast.Parsetree.signature)
+    :  ?impl : (Expansion_context.Base.t -> Compiler_version.Ast.Parsetree.structure ->
+                Compiler_version.Ast.Parsetree.structure)
+    -> ?intf : (Expansion_context.Base.t -> Compiler_version.Ast.Parsetree.signature ->
+                Compiler_version.Ast.Parsetree.signature)
     -> ?aliases : string list
     -> string
     -> unit

--- a/src/location.mli
+++ b/src/location.mli
@@ -64,6 +64,13 @@ module Error : sig
   (** Convert an error to an extension point. The compiler recognizes this and displays
       the error properly. *)
   val to_extension : t -> extension
+
+ (** Raise a compiler [Parsing.Location.Error] exception.
+     The composition of [Location.Error.createf] with [Location.Error.raise] is the
+     same as [Location.raise_errorf]. *)
+  val raise : t -> 'a
+
+  val update_loc : t -> location -> t
 end with type location := t
 
 exception Error of Error.t

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -59,9 +59,11 @@ module Ast_io = struct
         let payload = Intf (input_value ic) in
         Ok (filename, payload)
       else
-      if String.equal s
+      if String.equal
+           (String.sub s ~pos:0 ~len:9)
            (String.sub Ocaml_common.Config.ast_impl_magic_number ~pos:0 ~len:9)
-      || String.equal s
+      || String.equal
+           (String.sub s ~pos:0 ~len:9)
            (String.sub Ocaml_common.Config.ast_intf_magic_number ~pos:0 ~len:9)
       then
         Error (Unknown_version s)

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -33,11 +33,7 @@ module Ast_io = struct
 
   type read_error =
     | Not_a_binary_ast of string
-    (* The input doesn't contain a binary AST. The argument
-       corresponds to the bytes from the input that were consumed. *)
-  | Unknown_version of string
-    (* The input contains a binary AST for an unknown version of
-       OCaml.  The argument is the unknown magic number. *)
+    | Unknown_version of string
 
   let magic_length = String.length Ocaml_common.Config.ast_impl_magic_number
 

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -26,62 +26,6 @@ module Kind = struct
   let equal : t -> t -> bool = Poly.equal
 end
 
-module Ast_io = struct
-  type t =
-    | Intf of Compiler_ast.Parsetree.signature
-    | Impl of Compiler_ast.Parsetree.structure
-
-  type read_error =
-    | Not_a_binary_ast of string
-    | Unknown_version of string
-
-  let magic_length = String.length Ocaml_common.Config.ast_impl_magic_number
-
-  let read_magic ic =
-    let buf = Bytes.create magic_length in
-    let len = input ic buf 0 magic_length in
-    let s = Bytes.sub_string buf ~pos:0 ~len in
-    if len = magic_length then
-      Ok s
-    else
-      Error s
-
-  let read ic =
-    match read_magic ic with
-    | Error s -> Error (Not_a_binary_ast s)
-    | Ok s ->
-      if String.equal s Ocaml_common.Config.ast_impl_magic_number then
-        let filename : string = input_value ic in
-        let payload = Impl (input_value ic) in
-        Ok (filename, payload)
-      else if String.equal s Ocaml_common.Config.ast_intf_magic_number then
-        let filename : string = input_value ic in
-        let payload = Intf (input_value ic) in
-        Ok (filename, payload)
-      else
-      if String.equal
-           (String.sub s ~pos:0 ~len:9)
-           (String.sub Ocaml_common.Config.ast_impl_magic_number ~pos:0 ~len:9)
-      || String.equal
-           (String.sub s ~pos:0 ~len:9)
-           (String.sub Ocaml_common.Config.ast_intf_magic_number ~pos:0 ~len:9)
-      then
-        Error (Unknown_version s)
-      else
-        Error (Not_a_binary_ast s)
-
-  let write oc (filename : string) x =
-    match x with
-    | Intf x ->
-      output_string oc Ocaml_common.Config.ast_intf_magic_number;
-      output_value oc filename;
-      output_value oc x
-    | Impl x ->
-      output_string oc Ocaml_common.Config.ast_impl_magic_number;
-      output_value oc filename;
-      output_value oc x
-end
-
 module Intf_or_impl = struct
   type t =
     | Intf of signature
@@ -102,30 +46,175 @@ module Intf_or_impl = struct
   let kind : _ -> Kind.t = function
     | Intf _ -> Intf
     | Impl _ -> Impl
+end
 
-  let of_ast_io ast : t =
-    match ast with
-    | Ast_io.Intf sg -> Intf (Selected_ast.Of_ocaml.copy_signature sg)
-    | Ast_io.Impl st -> Impl (Selected_ast.Of_ocaml.copy_structure st)
+module Ast_io = struct
+  type input_version = (module OCaml_version)
 
-  let to_ast_io (ast : t) ~add_ppx_context =
+  let fall_back_input_version = (module Compiler_version : OCaml_version)
+  (* This should only be used when the input version can't be determined due to
+      loading or preprocessing errors *)
+
+  type t = {
+    input_name : string;
+    input_version : input_version;
+    ast : Intf_or_impl.t;
+  }
+
+  type read_error =
+    | Not_a_binary_ast
+    | Unknown_version of string * input_version
+    | Source_parse_error of Location.Error.t * input_version
+    | System_error of Location.Error.t * input_version
+
+  type input_source = Stdin | File of string
+
+  type input_kind =
+    | Possibly_source of Kind.t * string
+    | Necessarily_binary
+
+  let parse_source_code ~(kind : Kind.t) ~input_name ~prefix_read_from_source ic =
+    (* The input version is determined by the fact that the input will get parsed by
+       the current compiler Parse module *)
+    let input_version = (module Compiler_version : OCaml_version) in
+    try
+    (* To test if a file is an AST file, we have to read the first few bytes of the
+        file. If it is not, we have to parse these bytes and the rest of the file as
+        source code.
+
+        The compiler just does [seek_on 0] in this case, however this doesn't work when
+        the input is a pipe.
+
+        What we do instead is create a lexing buffer from the input channel and pre-fill
+        it with what we read to do the test. *)
+      let lexbuf = Lexing.from_channel ic in
+      let len = String.length prefix_read_from_source in
+      Bytes.blit_string ~src:prefix_read_from_source ~src_pos:0 ~dst:lexbuf.lex_buffer ~dst_pos:0
+        ~len;
+      lexbuf.lex_buffer_len <- len;
+      lexbuf.lex_curr_p <-
+        { pos_fname = input_name
+        ; pos_lnum  = 1
+        ; pos_bol   = 0
+        ; pos_cnum  = 0
+        };
+      Lexer.skip_hash_bang lexbuf;
+      let ast : Intf_or_impl.t =
+        match kind with
+        | Intf -> Intf (Parse.interface      lexbuf)
+        | Impl -> Impl (Parse.implementation lexbuf)
+      in Ok {input_name; input_version; ast}
+    with exn -> (
+      match Location.Error.of_exn exn with
+      | None -> raise exn
+      | Some error -> Error (Source_parse_error (error, input_version)))
+
+  let magic_length = String.length Ocaml_common.Config.ast_impl_magic_number
+
+  let read_magic ic =
+    let buf = Bytes.create magic_length in
+    let len = input ic buf 0 magic_length in
+    let s = Bytes.sub_string buf ~pos:0 ~len in
+    if len = magic_length then
+      Ok s
+    else
+      Error s
+
+  let from_channel ch ~input_kind =
+    let handle_non_binary prefix_read_from_source =
+      match input_kind with
+      | Possibly_source (kind, input_name) ->
+          parse_source_code ~kind ~input_name ~prefix_read_from_source ch
+      | Necessarily_binary -> Error Not_a_binary_ast
+    in
+    match read_magic ch with Error s -> handle_non_binary s
+    | Ok s -> (
+        match Find_version.from_magic s with
+        | Intf (module Input_version : OCaml_version) ->
+            let input_name : string = input_value ch in
+            let ast = input_value ch in
+            let module Input_to_ppxlib = Convert (Input_version) (Js) in
+            let ast = Intf_or_impl.Intf (Input_to_ppxlib.copy_signature ast) in
+            Ok
+              {
+                input_name;
+                input_version = (module Input_version : OCaml_version);
+                ast;
+              }
+        | Impl (module Input_version : OCaml_version) ->
+            let input_name : string = input_value ch in
+            let ast = input_value ch in
+            let module Input_to_ppxlib = Convert (Input_version) (Js) in
+            let ast = Intf_or_impl.Impl (Input_to_ppxlib.copy_structure ast) in
+            Ok
+              {
+                input_name;
+                input_version = (module Input_version : OCaml_version);
+                ast;
+              }
+        | Unknown ->
+          if
+            String.equal
+              (String.sub s ~pos:0 ~len:9)
+              (String.sub Ocaml_common.Config.ast_impl_magic_number ~pos:0
+                ~len:9)
+            || String.equal
+                (String.sub s ~pos:0 ~len:9)
+                (String.sub Ocaml_common.Config.ast_intf_magic_number ~pos:0
+                    ~len:9)
+            then Error (Unknown_version (s, fall_back_input_version))
+            else (handle_non_binary s))
+
+  let read input_source ~input_kind =
+    try
+      match input_source with
+        | Stdin -> from_channel stdin ~input_kind
+        | File fn -> In_channel.with_file fn ~f:(from_channel ~input_kind)
+    with exn ->
+      match Location.Error.of_exn exn with
+        | None -> raise exn
+        | Some error ->
+      Error (System_error (error, fall_back_input_version))
+
+
+
+  let write oc { input_name; input_version = (module Input_version); ast }
+      ~add_ppx_context =
+    let module Ppxlib_to_input = Convert (Js) (Input_version) in
+    let module Ocaml_to_input = Convert (Compiler_version) (Input_version) in
     match ast with
     | Intf sg ->
-      let sg = Selected_ast.To_ocaml.copy_signature sg in
-      let sg =
-        if add_ppx_context then
-          Ocaml_common.Ast_mapper.add_ppx_context_sig ~tool_name:"ppx_driver" sg
-        else
-          sg
-      in
-      Ast_io.Intf sg
+        let sg =
+          if add_ppx_context then
+            Selected_ast.To_ocaml.copy_signature sg
+            |> Ocaml_common.Ast_mapper.add_ppx_context_sig ~tool_name:"ppx_driver"
+            |> Ocaml_to_input.copy_signature
+          else Ppxlib_to_input.copy_signature sg
+        in
+        output_string oc Input_version.Ast.Config.ast_intf_magic_number;
+        output_value oc input_name;
+        output_value oc sg
     | Impl st ->
-      let st = Selected_ast.To_ocaml.copy_structure st in
-      let st =
-        if add_ppx_context then
-          Ocaml_common.Ast_mapper.add_ppx_context_str ~tool_name:"ppx_driver" st
-        else
-          st
-      in
-      Ast_io.Impl st
+        let st =
+          if add_ppx_context then
+            Selected_ast.To_ocaml.copy_structure st
+            |> Ocaml_common.Ast_mapper.add_ppx_context_str ~tool_name:"ppx_driver"
+            |> Ocaml_to_input.copy_structure
+          else Ppxlib_to_input.copy_structure st
+        in
+        output_string oc Input_version.Ast.Config.ast_impl_magic_number;
+        output_value oc input_name;
+        output_value oc st
+end
+
+module System = struct
+  let run_preprocessor ~pp ~input ~output =
+    let command =
+      Printf.sprintf "%s %s > %s"
+        pp (if String.equal input "-" then "" else Caml.Filename.quote input)
+        (Caml.Filename.quote output)
+    in
+  if Caml.Sys.command command = 0 then
+    Ok ()
+  else Error (command, Ast_io.fall_back_input_version)
 end

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -1,0 +1,45 @@
+open Import
+
+val with_output : label option -> binary:bool -> f:(out_channel -> 'a) -> 'a
+
+module Kind : sig
+  type t = Intf | Impl
+
+  val of_filename : string -> t option
+
+  val describe : t -> string
+
+  val equal : t -> t -> bool
+end
+
+module Ast_io : sig
+  type t
+
+  type read_error =
+  | Not_a_binary_ast of string
+  (* The input doesn't contain a binary AST. The argument
+      corresponds to the bytes from the input that were consumed. *)
+  | Unknown_version of string
+  (* The input contains a binary AST for an unknown version of
+      OCaml.  The argument is the unknown magic number. *)
+
+  val read : in_channel -> (string * t, read_error) result
+
+  val write : out_channel -> string -> t -> unit
+end
+
+module Intf_or_impl  : sig
+  type t =
+  | Intf of signature
+  | Impl of structure
+
+  val map : t -> Ast_traverse.map -> t
+
+  val map_with_context : t -> 'a Ast_traverse.map_with_context -> 'a -> t
+
+  val kind : t -> Kind.t
+
+  val of_ast_io : Ast_io.t -> t
+
+  val to_ast_io : t -> add_ppx_context:bool -> Ast_io.t
+end

--- a/test/driver/error_embedding/test.t/run.t
+++ b/test/driver/error_embedding/test.t/run.t
@@ -27,17 +27,18 @@ error from the preprocessor's stderr also gets reported on the driver's stderr)
   [%%ocaml.error
     "Error while running external preprocessor\nCommand line: pp 'file.ml' > tmpfile\n"]
 
-Also `unknown version` errors get embedded into an AST when using the main
-standalone
+Also `unknown version` errors are embedded into an AST when using the
+main standalone
 
   $ raiser -embed-errors -intf unknown_version_binary_ast
-  [%%ocaml.error "File is a binary ast for an unknown version of OCaml"]
+  [%%ocaml.error
+    "File is a binary ast for an unknown version of OCaml with magic number 'Caml1999N012'"]
 
 ... but the `-as-ppx` standalone raises them
 
   $ raiser -as-ppx unknown_version_binary_ast output
   File "unknown_version_binary_ast", line 1:
-  Error: The input is a binary ast for an unknown version of OCaml
+  Error: The input is a binary ast for an unknown version of OCaml with magic number 'Caml1999N012'
   [1]
 
 Similar for 'input doesn't exist' errors: they get embedded by the main standalone...
@@ -45,11 +46,9 @@ Similar for 'input doesn't exist' errors: they get embedded by the main standalo
   $ raiser -embed-errors -impl non_existing_file
   [%%ocaml.error "I/O error: non_existing_file: No such file or directory"]
 
-[To be fixed]
-... but not by the `-as-ppx` standalone, which should report the missing file
-name correctly when raising, but doesn't at the moment
+... but not by the `-as-ppx` standalone
 
   $ raiser -as-ppx non_existing_file output
-  File "_none_", line 1:
+  File "non_existing_file", line 1:
   Error: I/O error: non_existing_file: No such file or directory
   [1]

--- a/test/driver/error_embedding/test.t/run.t
+++ b/test/driver/error_embedding/test.t/run.t
@@ -27,25 +27,17 @@ error from the preprocessor's stderr also gets reported on the driver's stderr)
   [%%ocaml.error
     "Error while running external preprocessor\nCommand line: pp 'file.ml' > tmpfile\n"]
 
-[To be fixed]
 Also `unknown version` errors get embedded into an AST when using the main
-standalone. But at the moment they get recognized as syntax errors
-instead of unknown version errors. That makes the following test variant
-under different versions and would break the CI at the moment.
+standalone
 
-$ raiser -embed-errors -intf unknown_version_binary_ast
-File "unknown_version_binary_ast", line 1, characters 0-13:
-Alert deprecated: ISO-Latin1 characters in identifiers
-[%%ocaml.error "Syntax error"]
+  $ raiser -embed-errors -intf unknown_version_binary_ast
+  [%%ocaml.error "File is a binary ast for an unknown version of OCaml"]
 
-
-[To be fixed]
-... but the `-as-ppx` standalone raises them (although at the moment they get
-recognized as 'expected a binary AST as input' errors instead of unknown version errors)
+... but the `-as-ppx` standalone raises them
 
   $ raiser -as-ppx unknown_version_binary_ast output
   File "unknown_version_binary_ast", line 1:
-  Error: Expected a binary AST as input
+  Error: The input is a binary ast for an unknown version of OCaml
   [1]
 
 Similar for 'input doesn't exist' errors: they get embedded by the main standalone...

--- a/test/driver/run_as_ppx_rewriter/test.t/run.t
+++ b/test/driver/run_as_ppx_rewriter/test.t/run.t
@@ -13,12 +13,15 @@ The registered rewriters get applied when using `run_as_ppx_rewriter` as entry p
   hi
   bye
 
-The driver's `shared_args` arguments should be taken into account with the
-exception of the perform check arguments.
+The driver's `shared_args` are taken into account, such as `-apply`...
 
-[To be fixed]
-But at the moment, it's the other way around: the check argument is taken into
-account...
+  $ ocaml -ppx 'print_greetings -apply print_hi' file.ml
+  hi
+  File "./file.ml", line 2, characters 11-20:
+  Error: Uninterpreted extension 'print_bye'.
+  [2]
+
+... and `-check`
 
   $ echo "[@@@attr non_registered_attr]" > attribute_file.ml
   $ ocaml -ppx 'print_greetings -check' attribute_file.ml
@@ -26,41 +29,63 @@ account...
   Error: Attribute `attr' was not used
   [2]
 
-[To be fixed]
-...while some of the other `shared_args` aren't
 
-  $ ocaml -ppx 'print_greetings -apply print_hi' file.ml
-  hi
-  bye
-
-[To be fixed]
-If a non-compatible file gets fed, the file name should get reported correctly,
-but isn't at the moment
+If a non-compatible file gets fed, the file name is reported correctly
 
   $ touch no_binary_ast.ml
   $ print_greetings no_binary_ast.ml some_output
-  End_of_file
-  [2]
+  File "no_binary_ast.ml", line 1:
+  Error: Expected a binary AST as input
+  [1]
 
 The only possible usage is [extra_args] <infile> <outfile>...
 
-  $ print_greetings some_input 2>&1 | sed 's/Usage: .*_build/Usage: (...)_build/'
-  Usage: (...)_build/default/test/driver/run_as_ppx_rewriter/print_greetings.exe [extra_args] <infile> <outfile>
+  $ print_greetings some_input
+  Usage: print_greetings.exe [extra_args] <infile> <outfile>
+  [2]
 
-[To be fixed]
 ...in particular the order between the flags and the input/output matters.
-That should get reported nicely, but isn't at the moment
 
   $ touch some_output
   $ print_greetings some_input some_output -check
-  End_of_file
+  print_greetings: anonymous arguments not accepted.
+  print_greetings.exe [extra_args] <infile> <outfile>
+    -loc-filename <string>      File name to use in locations
+    -reserve-namespace <string> Mark the given namespace as reserved
+    -no-check                   Disable checks (unsafe)
+    -check                      Enable checks
+    -no-check-on-extensions     Disable checks on extension point only
+    -check-on-extensions        Enable checks on extension point only
+    -no-locations-check         Disable locations check only
+    -locations-check            Enable locations check only
+    -apply <names>              Apply these transformations in order (comma-separated list)
+    -dont-apply <names>         Exclude these transformations
+    -no-merge                   Do not merge context free transformations (better for debugging rewriters)
+    -cookie NAME=EXPR           Set the cookie NAME to EXPR
+    --cookie                    Same as -cookie
+    -help                       Display this list of options
+    --help                      Display this list of options
   [2]
 
-[To be fixed]
-The only exception should be consulting help, but isn't at the moment
+The only exception is consulting help
 
-  $ print_greetings -help 2>&1 | sed 's/Usage: .*_build/Usage: (...)_build/'
-  Usage: (...)_build/default/test/driver/run_as_ppx_rewriter/print_greetings.exe [extra_args] <infile> <outfile>
+  $ print_greetings -help
+  print_greetings.exe [extra_args] <infile> <outfile>
+    -loc-filename <string>      File name to use in locations
+    -reserve-namespace <string> Mark the given namespace as reserved
+    -no-check                   Disable checks (unsafe)
+    -check                      Enable checks
+    -no-check-on-extensions     Disable checks on extension point only
+    -check-on-extensions        Enable checks on extension point only
+    -no-locations-check         Disable locations check only
+    -locations-check            Enable locations check only
+    -apply <names>              Apply these transformations in order (comma-separated list)
+    -dont-apply <names>         Exclude these transformations
+    -no-merge                   Do not merge context free transformations (better for debugging rewriters)
+    -cookie NAME=EXPR           Set the cookie NAME to EXPR
+    --cookie                    Same as -cookie
+    -help                       Display this list of options
+    --help                      Display this list of options
 
 [To be fixed]
 Binary AST's of any by ppxlib supported OCaml version should be supported as input;

--- a/test/driver/run_as_ppx_rewriter/test.t/run.t
+++ b/test/driver/run_as_ppx_rewriter/test.t/run.t
@@ -87,15 +87,11 @@ The only exception is consulting help
     -help                       Display this list of options
     --help                      Display this list of options
 
-[To be fixed]
-Binary AST's of any by ppxlib supported OCaml version should be supported as input;
-but at the moment, only the OCaml version the driver got compiled with is supported.
-At the moment, that test would break the CI on 4.06. In the future, it can be tested
-as follows.
+Binary AST's of any by ppxlib supported OCaml version are supported.
+The version is preserved.
 
-$ cat 406_binary_ast | print_magic_number
-Magic number: Caml1999N022
+  $ cat 406_binary_ast | print_magic_number
+  Magic number: Caml1999N022
 
-$ print_greetings 406_binary_ast /dev/stdout | print_magic_number
-(Failure "Ast_mapper: OCaml version mismatch or malformed input")
-Magic number: 
+  $ print_greetings 406_binary_ast /dev/stdout | print_magic_number
+  Magic number: Caml1999N022

--- a/test/driver/stdin_input/test.t/run.t
+++ b/test/driver/stdin_input/test.t/run.t
@@ -6,11 +6,7 @@ The driver can read from stdin. Both when the input is source code...
   > EOF
   let a = 1
 
-[to be fixed]
-...and when the input is a binary AST. At the moment the test would break
-the CI since it's variant under different versions. Once, ppxlib supports
-all supported ocaml versions in binary AST inputs, it can be tested as
-follows:
+...and when the input is a binary AST.
 
-$ cat binary_ast | identity_driver -impl -
-let b = 2
+  $ cat binary_ast | identity_driver -impl -
+  let b = 2


### PR DESCRIPTION
The two important commits are:

  - Support binary AST's of any supported version
    
    Before, the OCaml version of any binary ast input had to coincide with the version the ppxlib driver got compiled with. That was a problem for bucklescript/rescript.
    
    With this commit, all versions from the Versions module are accepted as input. The input version is preserved by ppxlib when outputting a binary AST.

- Implement `run_as_ppx_rewriter` internally
    
    Besides taking away a burden for Astlib, implementing `run_as_ppx_rewriter` internally has two advantages:
    - it allows making changes with more flexibility
    - `run_as_ppx_rewriter` gets syncronized with `standalone_run_as_ppx_rewriter`
    
    With this change, the three flags `-loc-filename`, `apply`, `dont-apply` are taken into account when given. Before, they were allowed to be passed in but not taken into account.