### PR TITLE
Fix cli cookies handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@ unreleased
 - Add Driver.V2: give access to expansion context in whole file transformation
   callbacks of `register_transformation` (#202, @pitag-ha)
 
+- Driver: take `-cookie` argument into account, also when the input is a
+  binary AST (@pitag-ha, #209)
+
 0.20.0 (16/11/2020)
 -------------------
 

--- a/test/driver/flag_cookie/run.t
+++ b/test/driver/flag_cookie/run.t
@@ -1,12 +1,10 @@
-The cookie flag is taken into account by the main standalone
+The cookie flag is taken into account, both by the main standalone
 
   $ echo "[@@@print_cookie_x]" > impl.ml
   $ print_cookie_driver -cookie x=1 impl.ml
   Value of cookie x: 1
 
-[To be fixed]
-And should also be taken into account by the `-as-ppx` standalone,
-but isn't at the moment
+...and by the `-as-ppx` standalone
 
   $ ocaml -ppx 'print_cookie_driver --as-ppx -cookie x=1' impl.ml
-  Cookie x isn't set.
+  Value of cookie x: 1


### PR DESCRIPTION
Before, cookies handed in through the cli were added to the `Ast_mapper` cookies reference right away when reading the cli arguments. But in the case of a binary AST input, that reference gets reset to only contain the cookies from the ppx context when parsing that context ([here](https://github.com/ocaml/ocaml/blob/trunk/parsing/ast_mapper.ml#L916) the reference gets reset instead of appending to it). Therefore, cli cookies were ignored for binary AST inputs.

This commit fixes that by adding the cli cookies to the `Ast_mapper` cookies reference after parsing the ppx context.

Probably related to https://github.com/janestreet/ppx_expect/issues/26 and to the last comment in https://github.com/janestreet/ppx_inline_test/issues/1