### PR TITLE
Fix ppxlib.traverse

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 unreleased
 ----------
 
+- Fix ppxlib.traverse declaration and make it a deriver and not a rewriter
+  (#213, @NathanReb)
 - Driver (important for bucklescript): handling binary AST's, accept any
   supported version as input; preserve that version (#205, @pitag-ha)
 

--- a/traverse/dune
+++ b/traverse/dune
@@ -1,7 +1,7 @@
 (library
  (name        ppxlib_traverse)
  (public_name ppxlib.traverse)
- (kind ppx_rewriter)
+ (kind ppx_deriver)
  (flags (:standard -safe-string))
  (libraries  ppxlib)
  (preprocess (pps ppxlib_metaquot)))

--- a/traverse/dune
+++ b/traverse/dune
@@ -1,6 +1,7 @@
 (library
  (name        ppxlib_traverse)
  (public_name ppxlib.traverse)
+ (kind ppx_rewriter)
  (flags (:standard -safe-string))
  (libraries  ppxlib)
  (preprocess (pps ppxlib_metaquot)))


### PR DESCRIPTION
We unintentionally broke traverse in #196 by not declaring it as a ppx anymore. This PR reverts this but also make it a deriver (which it is) instead of a rewriter.

Even though it was working perfectly well being declared as the latter, I think this will improve compat with `ppx_deriving`.