### PR TITLE
Inline skip hash bang

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -37,3 +37,5 @@
  (deps gen-compiler_specifics)
  (action
   (run %{ocaml} %{deps} %{ocaml_version} %{targets})))
+
+(ocamllex skip_hash_bang)

--- a/src/skip_hash_bang.mli
+++ b/src/skip_hash_bang.mli
@@ -1,0 +1,1 @@
+val skip_hash_bang: Lexing.lexbuf -> unit

--- a/src/skip_hash_bang.mll
+++ b/src/skip_hash_bang.mll
@@ -1,0 +1,17 @@
+{
+open Lexing
+
+let update_loc lexbuf lines_to_skip =
+  let pos = lexbuf.lex_curr_p in
+  lexbuf.lex_curr_p <- { pos with
+    pos_lnum = pos.pos_lnum + lines_to_skip;
+    pos_bol = pos.pos_cnum;
+  }
+}
+
+rule skip_hash_bang = parse
+  | "#!" [^ '\n']* '\n' [^ '\n']* "\n!#\n"
+      { update_loc lexbuf 3 }
+  | "#!" [^ '\n']* '\n'
+      { update_loc lexbuf 1 }
+  | "" { () }

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -98,7 +98,7 @@ module Ast_io = struct
         ; pos_bol   = 0
         ; pos_cnum  = 0
         };
-      Lexer.skip_hash_bang lexbuf;
+      Skip_hash_bang.skip_hash_bang lexbuf;
       let ast : Intf_or_impl.t =
         match kind with
         | Intf -> Intf (Parse.interface      lexbuf)


### PR DESCRIPTION
This was the only internal use of the Lexer module. So after this change the Lexer module can be removed from the official API.

This is to be merged after #225.