### PR TITLE
Remove Lexer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@ unreleased
 - Remove `Lexer.keyword_table`: use `Keyword.is_keyword` instead
   (#227, @pitag-ha)
 
+- Remove `Lexer` from the API: it was the same as the compiler-libs
+  `Lexer` (#228, @pitag-ha)
+
 0.22.0 (04/02/2021)
 -------------------
 

--- a/ast/import.ml
+++ b/ast/import.ml
@@ -102,10 +102,6 @@ module Location   = struct
   include Location_helper
 end
 
-module Lexer      = struct
-  include Ocaml_common.Lexer
-end
-
 module Syntaxerr  = struct
   include Ocaml_common.Syntaxerr
 end

--- a/ast/ppxlib_ast.ml
+++ b/ast/ppxlib_ast.ml
@@ -11,7 +11,6 @@ module Js             = Js
 module Find_version   = Versions.Find_version
 module Convert        = Versions.Convert
 module Extra_warnings = Warn
-module Lexer          = Lexer
 module Location_error = Location_error
 module Parse          = Parse
 module Parser         = Parser


### PR DESCRIPTION
After #227, `Lexer` was the same as the compiler-libs `Lexer`, so removing it won't do harm.

To be merged after #227.