### PR TITLE
Reduce the public API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,12 @@ unreleased
 - Remove `Lexer` from the API: it was the same as the compiler-libs
   `Lexer` (#228, @pitag-ha)
 
+- Remove the modules `Ast_magic`, `Compiler_version`, `Js`, `Find_version`,
+  `Convert`, `Extra_warnings`, `Location_error`, `Select_ast` and
+  `Import_for_core` from the API: they are meant for internal use and
+  aren't used by any current downstream user in the
+  [ppx universe](https://github.com/ocaml-ppx/ppx_universe) (#230, @pitag-ha)
+
 0.22.0 (04/02/2021)
 -------------------
 

--- a/src/ppxlib.ml
+++ b/src/ppxlib.ml
@@ -22,28 +22,17 @@ include struct
           )
 end (** @inline *)
 
-(** Expose all modules from Ppxlib_ast;
+(** Expose some modules from Ppxlib_ast;
     in particular, overwrite some of the modules above *)
-module type OCaml_version = Ppxlib_ast.OCaml_version
-
 module Ast                = Ppxlib_ast.Ast
 module Ast_helper         = Ppxlib_ast.Ast_helper
-module Ast_magic          = Ppxlib_ast.Ast_magic
 module Asttypes           = Ppxlib_ast.Asttypes
-module Compiler_version   = Ppxlib_ast.Compiler_version
-module Js                 = Ppxlib_ast.Js
-module Find_version       = Ppxlib_ast.Find_version
-module Convert            = Ppxlib_ast.Convert
-module Extra_warnings     = Ppxlib_ast.Extra_warnings
-module Location_error     = Ppxlib_ast.Location_error
 module Parse              = Ppxlib_ast.Parse
 module Parser             = Ppxlib_ast.Parser
 module Parsetree          = Ppxlib_ast.Parsetree
 module Pprintast          = Ppxlib_ast.Pprintast
-module Select_ast         = Ppxlib_ast.Select_ast
 module Selected_ast       = Ppxlib_ast.Selected_ast
 module Syntaxerr          = Ppxlib_ast.Syntaxerr
-module Import_for_core    = Ppxlib_ast.Import_for_core
 
 (** Include all the Ast definitions since we need them in every single ppx *)
 include Ast


### PR DESCRIPTION
This theoretic breaking change is not a real breaking change: none of the users in the [ppx universe](https://github.com/ocaml-ppx/ppx_universe) is using any of the modules that get removed from the API. Unless I'm missing something, those modules weren't meant for external use.

To be merged after #229.