### PR TITLE
Inline string distance to avoid using Misc

### DIFF
--- a/src/spellcheck.ml
+++ b/src/spellcheck.ml
@@ -1,5 +1,51 @@
 open! Import
 
+exception Cutoff_met
+
+(* As found here http://rosettacode.org/wiki/Levenshtein_distance#OCaml *)
+let levenshtein_distance s t cutoff =
+  let m = String.length s and n = String.length t in
+  if cutoff = 0 || abs (m - n) >= cutoff then None
+  else
+    (* for all i and j, d.(i).(j) will hold the Levenshtein distance between the
+       first i characters of s and the first j characters of t *)
+    let d = Array.make_matrix ~dimx:(m + 1) ~dimy:(n + 1) 0 in
+    for i = 0 to m do
+      (* the distance of any first string to an empty second string *)
+      d.(i).(0) <- i
+    done;
+    for j = 0 to n do
+      (* the distance of any second string to an empty first string *)
+      d.(0).(j) <- j
+    done;
+    (* the minimum of each line together with the column index will be used
+       to notice cutoff exceeding and return early in that case *)
+    let line_min = ref 0 in
+    let distance =
+      try
+        for j = 1 to n do
+          if !line_min >= cutoff - 1 && j >= cutoff - 1 then raise Cutoff_met;
+          line_min := max m n;
+          for i = 1 to m do
+            let value =
+              if Char.equal s.[i - 1] t.[j - 1] then d.(i - 1).(j - 1)
+                (* no operation required *)
+              else
+                min
+                  (d.(i - 1).(j) + 1) (* a deletion *)
+                  (min
+                     (d.(i).(j - 1) + 1) (* an insertion *)
+                     (d.(i - 1).(j - 1) + 1) (* a substitution *))
+            in
+            d.(i).(j) <- value;
+            line_min := min !line_min value
+          done
+        done;
+        if d.(m).(n) < cutoff then Some d.(m).(n) else None
+      with Cutoff_met -> None
+    in
+    distance
+
 let spellcheck names name =
   let cutoff =
     match String.length name with
@@ -11,7 +57,7 @@ let spellcheck names name =
   let _, suggestions =
     List.fold_left names ~init:(Int.max_int, [])
       ~f:(fun ((best_distance, names_at_best_distance) as acc) registered_name ->
-        match Ocaml_common.Misc.edit_distance name registered_name cutoff with
+        match levenshtein_distance name registered_name cutoff with
         | None -> acc
         | Some dist ->
           if dist < best_distance then


### PR DESCRIPTION
This implementation of the Levenshtein distance uses [this dune implementation of it](https://github.com/ocaml/dune/blob/f0ba5c23b77efd3b34ea7a14c1e18892722c2ff4/src/stdune/user_message.ml#L80) as bases. It just adds a cutoff and early return when the cutoff gets exceeded.