### PR TITLE
Clean up gen-compiler_specifics in src

### DIFF
--- a/src/gen-compiler_specifics
+++ b/src/gen-compiler_specifics
@@ -6,12 +6,9 @@ let () =
   let ver = Scanf.sscanf Sys.argv.(1) "%u.%u" (fun a b -> a, b) in
   let oc = open_out_bin Sys.argv.(2) in
   let pr fmt = fprintf oc (fmt ^^ "\n") in
-  pr "module O = Ocaml_common";
   if ver < (4, 08) then (
-    pr "let get_load_path () = !Ocaml_common.Config.load_path";
     pr "let read_clflags_from_env () = ()"
   ) else (
-    pr "let get_load_path () = Ocaml_common.Load_path.get_paths ()";
     pr "let read_clflags_from_env () = Ocaml_common.Compmisc.read_clflags_from_env ()"
   );
   close_out oc


### PR DESCRIPTION
Neither the module `O` nor the function `get_load_path` are used anywhere. Dropping  `get_load_path` will make Astlib lighter/simpler.