### PR TITLE
Add missing lower-bound constraint for Sexplib0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 unreleased
 ----------
 
+- Add a lower-bound constraint for Sexplib0 (#240, @pitag-ha)
+
 - Fix bug due to which unwanted public binaries got installed when installing
   ppxlib (#223, @pitag-ha)
 

--- a/dune-project
+++ b/dune-project
@@ -19,7 +19,7 @@
   (ocaml-compiler-libs (>= v0.11.0))
   (ocaml-migrate-parsetree (>= 2.1.0))
   (ppx_derivers (>= 1.0))
-  sexplib0
+  (sexplib0 (>= v0.12))
   stdlib-shims
   (ocamlfind :with-test)
   (re (and :with-test (>= 1.9.0)))

--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ocaml-migrate-parsetree" {>= "2.1.0"}
   "ppx_derivers" {>= "1.0"}
-  "sexplib0"
+  "sexplib0" {>= "v0.12"}
   "stdlib-shims"
   "ocamlfind" {with-test}
   "re" {with-test & >= "1.9.0"}


### PR DESCRIPTION
Sexplib0.Sexpable is used. See ocaml/opam-repository#18497

Co-Authored-By: Kate <kit.ty.kate@disroot.org>