### PR TITLE
Add a test for the Location.Error exception

### DIFF
--- a/test/location/exception/dune
+++ b/test/location/exception/dune
@@ -1,0 +1,13 @@
+(rule
+ (alias runtest)
+ (enabled_if
+  (>= %{ocaml_version} "4.08.0"))
+ (deps
+  (:test test.ml)
+  (package ppxlib))
+ (action
+  (chdir
+   %{project_root}
+   (progn
+    (run expect-test %{test})
+    (diff? %{test} %{test}.corrected)))))

--- a/test/location/exception/test.ml
+++ b/test/location/exception/test.ml
@@ -1,0 +1,17 @@
+open Ppxlib.Location
+
+let catch_as_compiler_exception =
+  try raise_errorf ~loc:none "foo" with
+  | Ocaml_common.Location.Error _ -> "caught"
+  | _ -> "uncaught"
+[%%expect{|
+val catch_as_compiler_exception : string = "caught"
+|}]
+
+let catch_as_ppxlib_exception =
+  try raise_errorf ~loc:none "foo" with
+  | Error _ -> "caught"
+  | _ -> "uncaught"
+[%%expect{|
+val catch_as_ppxlib_exception : string = "uncaught"
+|}]


### PR DESCRIPTION
The exception in the ppxlib `Location` module should be equivalnet to the exception in the compiler `Location` module, but isn't at the moment. The new test shows that.