### PR TITLE
Location: fix exception equivalence

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@ unreleased
 
 - Allow "%a" when using Location.Error.createf (#239, @mlasson)
 
+- Fix in `Location`: make `raise_errorf` exception equivalent to exception
+  `Error` (#242, @pitag-ha)
+
 0.22.0 (04/02/2021)
 -------------------
 

--- a/ast/location_error.mli
+++ b/ast/location_error.mli
@@ -1,5 +1,5 @@
 open Import
-type t
+type t = Ocaml_common.Location.error
 val of_exn : exn -> t option
 val register_error_of_exn : (exn -> t option) -> unit
 val message : t -> string

--- a/src/location.ml
+++ b/src/location.ml
@@ -85,7 +85,7 @@ module Error = struct
       (fun str -> make ~loc ~sub:[] str) fmt
 end
 
-exception Error of Error.t
+exception Error = L.Error
 
 let () =
   Caml.Printexc.register_printer (function

--- a/test/driver/error_embedding/test.t/run.t
+++ b/test/driver/error_embedding/test.t/run.t
@@ -23,7 +23,7 @@ error from the preprocessor's stderr also gets reported on the driver's stderr)
 
   $ touch file.ml
   $ ../raiser.exe -embed-errors -pp ../pp.exe file.ml | sed "s/> '.*'/> tmpfile/"
-  Fatal error: exception Location.Error(_)
+  Fatal error: exception Raising inside the preprocessor
   [%%ocaml.error
     "Error while running external preprocessor\nCommand line: ../pp.exe 'file.ml' > tmpfile\n"]
 

--- a/test/location/exception/test.ml
+++ b/test/location/exception/test.ml
@@ -13,5 +13,5 @@ let catch_as_ppxlib_exception =
   | Error _ -> "caught"
   | _ -> "uncaught"
 [%%expect{|
-val catch_as_ppxlib_exception : string = "uncaught"
+val catch_as_ppxlib_exception : string = "caught"
 |}]


### PR DESCRIPTION
`raise_errorf` raises the compiler-libs exception. This commit ensures that that's equivalent to `Location.Error`. That's important to make sure that exceptions, that are raised via `raise_errorf` and caught later, are caught correctly.

This PR is built upon #241, the PR adding the corresponding test.