### PR TITLE
Drop Syntaxerr from API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 unreleased
 ----------
 
+- Drop `Syntaxerr` from the public API. Doesn't affect any user in the
+  [ppx universe](https://github.com/ocaml-ppx/ppx_universe) (#244, @pitag-ha)
+
 - Add a lower-bound constraint for Sexplib0 (#240, @pitag-ha)
 
 - Fix bug due to which unwanted public binaries got installed when installing

--- a/ast/import.ml
+++ b/ast/import.ml
@@ -99,10 +99,6 @@ module Ast_helper = Ast_helper_lite
 
 module Location   = Ocaml_common.Location
 
-module Syntaxerr  = struct
-  include Ocaml_common.Syntaxerr
-end
-
 module Parse = struct
   include Ocaml_common.Parse
   module Of_ocaml = Versions.Convert(Ocaml)(Js)

--- a/ast/ppxlib_ast.ml
+++ b/ast/ppxlib_ast.ml
@@ -18,6 +18,5 @@ module Parsetree      = Parsetree
 module Pprintast      = Pprintast
 module Select_ast     = Select_ast
 module Selected_ast   = Selected_ast
-module Syntaxerr      = Syntaxerr
 
 module Import_for_core = Import

--- a/src/ppxlib.ml
+++ b/src/ppxlib.ml
@@ -32,7 +32,6 @@ module Parser             = Ppxlib_ast.Parser
 module Parsetree          = Ppxlib_ast.Parsetree
 module Pprintast          = Ppxlib_ast.Pprintast
 module Selected_ast       = Ppxlib_ast.Selected_ast
-module Syntaxerr          = Ppxlib_ast.Syntaxerr
 
 (** Include all the Ast definitions since we need them in every single ppx *)
 include Ast


### PR DESCRIPTION
We were leaking the compiler-libs module `Syntaxerr` through the public API. I've checked and no downstream user in the ppx universe is using it.