### PR TITLE
Add a test to show wrong parse error reporting

### DIFF
--- a/test/driver/parse_error_locations/dune
+++ b/test/driver/parse_error_locations/dune
@@ -1,0 +1,6 @@
+(executable
+ (name identity_standalone)
+ (libraries ppxlib))
+
+(cram
+ (deps identity_standalone.exe))

--- a/test/driver/parse_error_locations/identity_standalone.ml
+++ b/test/driver/parse_error_locations/identity_standalone.ml
@@ -1,0 +1,1 @@
+let _ = Ppxlib.Driver.standalone ()

--- a/test/driver/parse_error_locations/run.t
+++ b/test/driver/parse_error_locations/run.t
@@ -1,0 +1,15 @@
+Keep the error output short in order to avoid different error output between
+different compiler versions in the subsequent test
+
+  $ export OCAML_ERROR_STYLE=short
+
+Syntax errors in files parsed by ppxlib should be reported correctly, but aren't at the moment
+
+  $ cat > test.ml << EOF
+  > let x = 5
+  > let let
+  > EOF
+  $ ./identity_standalone.exe -impl test.ml
+  File "test.ml", line 1:
+  Error: Syntax error
+  [1]


### PR DESCRIPTION
The location isn't reported correctly in parse errors.
