### PR TITLE
Fix parse error location

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 unreleased
 ----------
 
+- Fix location in parse errors (#247, @pitag-ha)
+
+- `Location`: add `set_filename` and `Error.get_location` (#247, @pitag-ha)
+
 - Drop dependency on OMP (#187, @pitag-ha)
 
 - Drop `Syntaxerr` from the public API. Doesn't affect any user in the

--- a/ast/location_error.ml
+++ b/ast/location_error.ml
@@ -36,6 +36,10 @@ let make ~loc txt ~sub =
 
 let update_loc = Astlib.Location.Error.update_loc
 
+let get_location error =
+  let { Astlib.Location.loc; _ } = Astlib.Location.Error.main_msg error in
+  loc
+
 let of_exn = Astlib.Location.Error.of_exn
 
 let raise error = raise (Astlib.Location.Error error)

--- a/ast/location_error.mli
+++ b/ast/location_error.mli
@@ -8,3 +8,4 @@ val make : loc:Location.t -> string -> sub:(Location.t * string) list -> t
 val to_extension : t -> Import.Parsetree.extension
 val raise : t -> 'a
 val update_loc : t -> Location.t -> t
+val get_location : t -> Location.t

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -706,9 +706,10 @@ let load_input_run_as_ppx fn =
         ~loc:(Location.in_file fn)
         "Expected a binary AST as input"
   | Error (System_error (error, _)) | Error (Source_parse_error (error, _)) ->
-      Location.in_file fn
-      |> Location.Error.update_loc error
-      |> Location.Error.raise
+      let open Location.Error in
+      Location.set_filename (get_location error) fn
+      |> update_loc error
+      |> raise
 ;;
 
 let load_source_file fn =
@@ -917,9 +918,10 @@ let process_file (kind : Kind.t) fn ~input_name ~relocate ~output_mode ~embed_er
     | Error (error, input_version) when embed_errors ->
         (input_name, input_version, error_to_extension error ~kind)
     | Error (error, _) ->
-        Location.in_file fn
-        |> Location.Error.update_loc error
-        |> Location.Error.raise
+        let open Location.Error in
+        Location.set_filename (get_location error) fn
+        |> update_loc error
+        |> raise
   in
   Option.iter !output_metadata_filename ~f:(fun fn ->
     let metadata = File_property.dump_and_reset_all () in

--- a/src/location.ml
+++ b/src/location.ml
@@ -21,6 +21,15 @@ let in_file name =
   ; loc_ghost = true
   }
 
+let set_filename loc fn =
+  let loc_start =
+    {loc.loc_start with pos_fname = fn}
+  in
+  let loc_end =
+    {loc.loc_end with pos_fname = fn}
+  in
+  {loc with loc_start; loc_end}
+
 let none = in_file "_none_"
 
 let init lexbuf fname =

--- a/src/location.mli
+++ b/src/location.mli
@@ -14,6 +14,9 @@ type t = location =
 (** Return an empty ghost range located in a given file. *)
 val in_file : string -> t
 
+(** Set the [pos_fname] both in [loc_start] and [loc_end]. Leave the rest as is. *)
+val set_filename : t -> string -> t
+
 (** An arbitrary value of type [t]; describes an empty ghost range. *)
 val none : t
 
@@ -70,7 +73,11 @@ module Error : sig
      same as [Location.raise_errorf]. *)
   val raise : t -> 'a
 
+  (** Update where the error is located. The old location will be overwritten. *)
   val update_loc : t -> location -> t
+
+  (** Find out where the error is located. *)
+  val get_location : t -> location
 end with type location := t
 
 exception Error of Error.t

--- a/test/driver/parse_error_locations/run.t
+++ b/test/driver/parse_error_locations/run.t
@@ -3,13 +3,13 @@ different compiler versions in the subsequent test
 
   $ export OCAML_ERROR_STYLE=short
 
-Syntax errors in files parsed by ppxlib should be reported correctly, but aren't at the moment
+Syntax errors in files parsed by ppxlib are reported correctly
 
   $ cat > test.ml << EOF
   > let x = 5
   > let let
   > EOF
   $ ./identity_standalone.exe -impl test.ml
-  File "test.ml", line 1:
+  File "test.ml", line 2, characters 4-7:
   Error: Syntax error
   [1]


### PR DESCRIPTION
When there is a source parse error, the file name responsible for the error is added to the error location. That's done to report the file name even if the error is due to the file not existing. Before, that was done by overwriting the error location by an empty ghost range located in the given file and therefore messing up the start and end positions. This commit fixes that.

This should fix the problem described in #221.