### PR TITLE
Reintroduce minimal supported version in migration error messages

### DIFF
--- a/astlib/migrate_403_402.ml
+++ b/astlib/migrate_403_402.ml
@@ -35,7 +35,9 @@ let inject_predef_option label d =
 let from_loc { Location.txt = _; loc } = loc
 
 let migration_error loc missing_feature =
-  Location.raise_errorf ~loc missing_feature
+  Location.raise_errorf ~loc
+    "migration error: %s is not supported before OCaml 4.03"
+    missing_feature
 
 let rec copy_expression : From.Parsetree.expression -> To.Parsetree.expression =
  fun {
@@ -151,7 +153,7 @@ and copy_expression_desc loc :
   | From.Parsetree.Pexp_extension x0 ->
       To.Parsetree.Pexp_extension (copy_extension x0)
   | From.Parsetree.Pexp_unreachable ->
-      migration_error loc "migration error: unreachable patterns"
+      migration_error loc "unreachable patterns"
 
 and copy_direction_flag :
     From.Asttypes.direction_flag -> To.Asttypes.direction_flag = function
@@ -318,7 +320,7 @@ and copy_attribute : From.Parsetree.attribute -> To.Parsetree.attribute =
 and copy_payload loc : From.Parsetree.payload -> To.Parsetree.payload = function
   | From.Parsetree.PStr x0 -> To.Parsetree.PStr (copy_structure x0)
   | From.Parsetree.PSig _x0 ->
-      migration_error loc "migration error: signatures in attribute"
+      migration_error loc "signatures in attribute"
   | From.Parsetree.PTyp x0 -> To.Parsetree.PTyp (copy_core_type x0)
   | From.Parsetree.PPat (x0, x1) ->
       To.Parsetree.PPat (copy_pattern x0, copy_option copy_expression x1)
@@ -911,7 +913,7 @@ and copy_constructor_arguments loc :
   function
   | From.Parsetree.Pcstr_tuple x0 -> List.map copy_core_type x0
   | From.Parsetree.Pcstr_record _x0 ->
-      migration_error loc "migration error: inline records"
+      migration_error loc "inline records"
 
 and copy_label_declaration :
     From.Parsetree.label_declaration -> To.Parsetree.label_declaration =
@@ -981,14 +983,14 @@ and copy_constant loc : From.Parsetree.constant -> To.Asttypes.constant =
       | Some 'l' -> To.Asttypes.Const_int32 (Int32.of_string x0)
       | Some 'L' -> To.Asttypes.Const_int64 (Int64.of_string x0)
       | Some 'n' -> To.Asttypes.Const_nativeint (Nativeint.of_string x0)
-      | Some _ -> migration_error loc "migration error: custom integer literals"
+      | Some _ -> migration_error loc "custom integer literals"
       )
   | From.Parsetree.Pconst_char x0 -> To.Asttypes.Const_char x0
   | From.Parsetree.Pconst_string (x0, x1) -> To.Asttypes.Const_string (x0, x1)
   | From.Parsetree.Pconst_float (x0, x1) -> (
       match x1 with
       | None -> To.Asttypes.Const_float x0
-      | Some _ -> migration_error loc "migration error: custom float literals")
+      | Some _ -> migration_error loc "custom float literals")
 
 and copy_option : 'f0 'g0. ('f0 -> 'g0) -> 'f0 option -> 'g0 option =
  fun f0 -> function None -> None | Some x0 -> Some (f0 x0)

--- a/astlib/migrate_404_403.ml
+++ b/astlib/migrate_404_403.ml
@@ -20,7 +20,9 @@ module To = Ast_403
 let from_loc { Location.txt = _; loc } = loc
 
 let migration_error loc missing_feature =
-  Location.raise_errorf ~loc missing_feature
+  Location.raise_errorf ~loc
+    "migration error: %s is not supported before OCaml 4.04"
+    missing_feature
 
 let rec copy_expression : From.Parsetree.expression -> To.Parsetree.expression =
  fun {
@@ -121,7 +123,7 @@ and copy_expression_desc loc :
       To.Parsetree.Pexp_letmodule
         (copy_loc (fun x -> x) x0, copy_module_expr x1, copy_expression x2)
   | From.Parsetree.Pexp_letexception _ ->
-      migration_error loc "migration error: local exceptions"
+      migration_error loc "local exceptions"
   | From.Parsetree.Pexp_assert x0 ->
       To.Parsetree.Pexp_assert (copy_expression x0)
   | From.Parsetree.Pexp_lazy x0 -> To.Parsetree.Pexp_lazy (copy_expression x0)
@@ -221,7 +223,7 @@ and copy_pattern_desc loc :
   | From.Parsetree.Ppat_extension x0 ->
       To.Parsetree.Ppat_extension (copy_extension x0)
   | From.Parsetree.Ppat_open _ ->
-      migration_error loc "migration error: module open in patterns"
+      migration_error loc "module open in patterns"
 
 and copy_core_type : From.Parsetree.core_type -> To.Parsetree.core_type =
  fun {

--- a/astlib/migrate_406_405.ml
+++ b/astlib/migrate_406_405.ml
@@ -18,7 +18,9 @@ module From = Ast_406
 module To = Ast_405
 
 let migration_error loc missing_feature =
-  Location.raise_errorf ~loc missing_feature
+  Location.raise_errorf ~loc
+    "migration error: %s is not supported before OCaml 4.06"
+    missing_feature
 
 let rec copy_expression : From.Parsetree.expression -> To.Parsetree.expression =
  fun {
@@ -255,8 +257,7 @@ and copy_core_type_desc :
                     copy_attributes x1,
                     copy_core_type x2 )
               | From.Parsetree.Oinherit _ ->
-                  migration_error Location.none
-                    "migration error: inheritance in object type")
+                  migration_error Location.none "inheritance in object type")
             x0,
           copy_closed_flag x1 )
   | From.Parsetree.Ptyp_class (x0, x1) ->
@@ -408,8 +409,7 @@ and copy_class_expr_desc :
   | From.Parsetree.Pcl_extension x0 ->
       To.Parsetree.Pcl_extension (copy_extension x0)
   | From.Parsetree.Pcl_open (_, loc, _) ->
-      migration_error loc.Location.loc
-        "migration error: module open in class expression"
+      migration_error loc.Location.loc "module open in class expression"
 
 and copy_class_structure :
     From.Parsetree.class_structure -> To.Parsetree.class_structure =
@@ -561,11 +561,9 @@ and copy_with_constraint :
   | From.Parsetree.Pwith_modsubst ({ txt = Longident.Lident x0; loc }, x1) ->
       To.Parsetree.Pwith_modsubst ({ txt = x0; loc }, copy_loc copy_longident x1)
   | From.Parsetree.Pwith_typesubst ({ loc; _ }, _x0) ->
-      migration_error loc
-        "migration error: type substitution inside a submodule"
+      migration_error loc "type substitution inside a submodule"
   | From.Parsetree.Pwith_modsubst ({ loc; _ }, _x1) ->
-      migration_error loc
-        "migration error: module substitution inside a submodule"
+      migration_error loc "module substitution inside a submodule"
 
 and copy_signature : From.Parsetree.signature -> To.Parsetree.signature =
  fun x -> List.map copy_signature_item x
@@ -643,8 +641,7 @@ and copy_class_type_desc :
   | From.Parsetree.Pcty_extension x0 ->
       To.Parsetree.Pcty_extension (copy_extension x0)
   | From.Parsetree.Pcty_open (_, loc, _) ->
-      migration_error loc.Location.loc
-        "migration error: module open in class type"
+      migration_error loc.Location.loc "module open in class type"
 
 and copy_class_signature :
     From.Parsetree.class_signature -> To.Parsetree.class_signature =

--- a/astlib/migrate_408_407.ml
+++ b/astlib/migrate_408_407.ml
@@ -2,7 +2,9 @@ module From = Ast_408
 module To = Ast_407
 
 let migration_error loc missing_feature =
-  Location.raise_errorf ~loc missing_feature
+  Location.raise_errorf ~loc
+    "migration error: %s is not supported before OCaml 4.08"
+    missing_feature
 
 let rec copy_toplevel_phrase :
     From.Parsetree.toplevel_phrase -> To.Parsetree.toplevel_phrase = function
@@ -154,10 +156,9 @@ and copy_expression_desc :
               copy_expression x1 )
       | Pmod_structure _ | Pmod_functor _ | Pmod_apply _ | Pmod_constraint _
       | Pmod_unpack _ | Pmod_extension _ ->
-          migration_error x0.From.Parsetree.popen_loc
-            "migration error: complex open")
+          migration_error x0.From.Parsetree.popen_loc "complex open")
   | From.Parsetree.Pexp_letop { let_; ands = _; body = _ } ->
-      migration_error let_.pbop_op.loc "migration error: let operators"
+      migration_error let_.pbop_op.loc "let operators"
   | From.Parsetree.Pexp_extension x0 ->
       To.Parsetree.Pexp_extension (copy_extension x0)
   | From.Parsetree.Pexp_unreachable -> To.Parsetree.Pexp_unreachable
@@ -407,8 +408,7 @@ and copy_structure_item_desc :
             }
       | Pmod_structure _ | Pmod_functor _ | Pmod_apply _ | Pmod_constraint _
       | Pmod_unpack _ | Pmod_extension _ ->
-          migration_error x0.From.Parsetree.popen_loc
-            "migration error: complex open")
+          migration_error x0.From.Parsetree.popen_loc "complex open")
   | From.Parsetree.Pstr_class x0 ->
       To.Parsetree.Pstr_class (List.map copy_class_declaration x0)
   | From.Parsetree.Pstr_class_type x0 ->
@@ -647,7 +647,7 @@ and copy_signature_item_desc :
         | [] -> Location.none
         | { From.Parsetree.ptype_loc; _ } :: _ -> ptype_loc
       in
-      migration_error x0_loc "migration error: type substitution in signatures"
+      migration_error x0_loc "type substitution in signatures"
   | From.Parsetree.Psig_typext x0 ->
       To.Parsetree.Psig_typext (copy_type_extension x0)
   | From.Parsetree.Psig_exception x0 ->
@@ -663,8 +663,7 @@ and copy_signature_item_desc :
   | From.Parsetree.Psig_module x0 ->
       To.Parsetree.Psig_module (copy_module_declaration x0)
   | From.Parsetree.Psig_modsubst x0 ->
-      migration_error x0.pms_loc
-        "migration error: module substitution in signatures"
+      migration_error x0.pms_loc "module substitution in signatures"
   | From.Parsetree.Psig_recmodule x0 ->
       To.Parsetree.Psig_recmodule (List.map copy_module_declaration x0)
   | From.Parsetree.Psig_modtype x0 ->

--- a/astlib/migrate_410_409.ml
+++ b/astlib/migrate_410_409.ml
@@ -2,7 +2,9 @@ module From = Ast_410
 module To = Ast_409
 
 let migration_error loc missing_feature =
-  Location.raise_errorf ~loc missing_feature
+  Location.raise_errorf ~loc
+    "migration error: %s is not supported before OCaml 4.10"
+    missing_feature
 
 let map_option f x = match x with None -> None | Some x -> Some (f x)
 
@@ -154,7 +156,7 @@ and copy_expression_desc :
         ( copy_loc
             (function
               | None ->
-                  migration_error x0.loc "migration error: anonymous let module"
+                  migration_error x0.loc "anonymous let module"
               | Some x -> x)
             x0,
           copy_module_expr x1,
@@ -298,7 +300,7 @@ and copy_pattern_desc :
         (copy_loc
            (function
              | None ->
-                 migration_error x0.loc "migration error: anynymous unpack"
+                 migration_error x0.loc "anynymous unpack"
              | Some x -> x)
            x0)
   | Ast_410.Parsetree.Ppat_exception x0 ->
@@ -608,8 +610,7 @@ and copy_module_binding :
         (function
           | Some x -> x
           | None ->
-              migration_error pmb_name.loc
-                "migration error: anonymous module binding")
+              migration_error pmb_name.loc "anonymous module binding")
         pmb_name;
     Ast_409.Parsetree.pmb_expr = copy_module_expr pmb_expr;
     Ast_409.Parsetree.pmb_attributes = copy_attributes pmb_attributes;
@@ -971,8 +972,7 @@ and copy_module_declaration :
       copy_loc
         (function
           | None ->
-              migration_error pmd_name.loc
-                "migration error: anonymous module declaration"
+              migration_error pmd_name.loc "anonymous module declaration"
           | Some x -> x)
         pmd_name;
     Ast_409.Parsetree.pmd_type = copy_module_type pmd_type;


### PR DESCRIPTION
This was removed in https://github.com/ocaml-ppx/ppxlib/commit/8d54618d072f66ba7509e4a493492d8cc95524f5, however I feel like this was very helpful to know which version of OCaml the unsupported feature was introduced, to constrain it in the opam file for instance.