### PR TITLE
Make Astlib.Parser.token interchangable with Ocaml_common.Parser.token

### DIFF
--- a/astlib/parser.mli
+++ b/astlib/parser.mli
@@ -1,4 +1,4 @@
-type token
+type token = Ocaml_common.Parser.token
 
 val use_file :
   (Lexing.lexbuf -> token) -> Lexing.lexbuf -> Parsetree.toplevel_phrase list


### PR DESCRIPTION
This seems to be necessary to port https://github.com/janestreet/ppx_optcomp to ppxlib master. See in particular https://github.com/janestreet/ppx_optcomp/blob/v0.14/src/cparser.ml which contains the core of the issue.
While trying to port it I tried to change the use of `Parser.token` to `Ocaml_common.Parser` however I got stuck when `assert_no_attributes_in#structure_item` was called with the wrong type.

Feel free to discuss and/or close this as this is pure guess and I am no expert in the new astlib layer.
cc @pitag-ha 