### PR TITLE
Make OMP a conflict

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,9 @@ unreleased
 
 - `Location`: add `set_filename` and `Error.get_location` (#247, @pitag-ha)
 
-- Drop dependency on OMP (#187, @pitag-ha)
+- Drop dependency on OMP2 (#187, @pitag-ha)
+
+- Make OMP1 a conflict (#255, @kit-ty-kate)
 
 - Drop `Syntaxerr` from the public API. Doesn't affect any user in the
   [ppx universe](https://github.com/ocaml-ppx/ppx_universe) (#244, @pitag-ha)

--- a/dune-project
+++ b/dune-project
@@ -26,6 +26,8 @@
   (cinaps (and :with-test (>= v0.12.1)))
   (base :with-test)
   (stdio :with-test))
+ (conflicts
+  (ocaml-migrate-parsetree (< 2.0.0)))
  (synopsis "Standard library for ppx rewriters")
  (description "Ppxlib is the standard library for ppx rewriters and other programs
 that manipulate the in-memory reprensation of OCaml programs, a.k.a

--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -33,6 +33,9 @@ depends: [
   "stdio" {with-test}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "ocaml-migrate-parsetree" {< "2.0.0"}
+]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
Since #187 ppxlib does not depend on OMP anymore. To work around https://github.com/ocaml-ppx/ppxlib/issues/254 it needs to be a conflict instead to prevent OMP1 mixing with ppxlib

Fixes #254
Fixes #251 