### PR TITLE
Backport location fix 0.22

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 unreleased
 -------------------
 
+- Fix location in parse error reporting (#257, @pitag-ha)
+
 0.22.0 (04/02/2021)
 -------------------
 

--- a/ast/location_error.ml
+++ b/ast/location_error.ml
@@ -123,3 +123,11 @@ let update_loc_new error loc =
 let update_loc error loc =
   (*IF_NOT_AT_LEAST 408 update_loc_old error loc*)
   (*IF_AT_LEAST 408 update_loc_new error loc*)
+
+let _get_location_old { loc; _ } = loc
+
+let _get_location_new { main; _ } = main.loc
+
+let get_location error =
+  (*IF_NOT_AT_LEAST 408 _get_location_old error *)
+  (*IF_AT_LEAST 408 _get_location_new error *)

--- a/ast/location_error.mli
+++ b/ast/location_error.mli
@@ -8,3 +8,4 @@ val make : loc:Location.t -> string -> sub:(Location.t * string) list -> t
 val to_extension : t -> Import.Parsetree.extension
 val raise : t -> 'a
 val update_loc : t -> Location.t -> t
+val get_location : t -> Location.t

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -707,9 +707,10 @@ let load_input_run_as_ppx fn =
         ~loc:(Location.in_file fn)
         "Expected a binary AST as input"
   | Error (System_error (error, _)) | Error (Source_parse_error (error, _)) ->
-      Location.in_file fn
-      |> Location.Error.update_loc error
-      |> Location.Error.raise
+      let open Location.Error in
+      Location.set_filename (get_location error) fn
+      |> update_loc error
+      |> raise
 ;;
 
 let load_source_file fn =
@@ -918,9 +919,10 @@ let process_file (kind : Kind.t) fn ~input_name ~relocate ~output_mode ~embed_er
     | Error (error, input_version) when embed_errors ->
         (input_name, input_version, error_to_extension error ~kind)
     | Error (error, _) ->
-        Location.in_file fn
-        |> Location.Error.update_loc error
-        |> Location.Error.raise
+        let open Location.Error in
+        Location.set_filename (get_location error) fn
+        |> update_loc error
+        |> raise
   in
   Option.iter !output_metadata_filename ~f:(fun fn ->
     let metadata = File_property.dump_and_reset_all () in

--- a/src/location.ml
+++ b/src/location.ml
@@ -21,6 +21,15 @@ let in_file name =
   ; loc_ghost = true
   }
 
+let set_filename loc fn =
+  let loc_start =
+    {loc.loc_start with pos_fname = fn}
+  in
+  let loc_end =
+    {loc.loc_end with pos_fname = fn}
+  in
+  {loc with loc_start; loc_end}
+
 let none = in_file "_none_"
 
 let init lexbuf fname =

--- a/src/location.mli
+++ b/src/location.mli
@@ -14,6 +14,9 @@ type t = location =
 (** Return an empty ghost range located in a given file. *)
 val in_file : string -> t
 
+(** Set the [pos_fname] both in [loc_start] and [loc_end]. Leave the rest as is. *)
+val set_filename : t -> string -> t
+
 (** An arbitrary value of type [t]; describes an empty ghost range. *)
 val none : t
 
@@ -70,7 +73,11 @@ module Error : sig
      same as [Location.raise_errorf]. *)
   val raise : t -> 'a
 
+  (** Update where the error is located. The old location will be overwritten. *)
   val update_loc : t -> location -> t
+
+  (** Find out where the error is located. *)
+  val get_location : t -> location
 end with type location := t
 
 exception Error of Error.t

--- a/test/driver/parse_error_locations/dune
+++ b/test/driver/parse_error_locations/dune
@@ -1,0 +1,6 @@
+(executable
+ (name identity_standalone)
+ (libraries ppxlib))
+
+(cram
+ (deps identity_standalone.exe))

--- a/test/driver/parse_error_locations/identity_standalone.ml
+++ b/test/driver/parse_error_locations/identity_standalone.ml
@@ -1,0 +1,1 @@
+let _ = Ppxlib.Driver.standalone ()

--- a/test/driver/parse_error_locations/run.t
+++ b/test/driver/parse_error_locations/run.t
@@ -1,0 +1,15 @@
+Keep the error output short in order to avoid different error output between
+different compiler versions in the subsequent test
+
+  $ export OCAML_ERROR_STYLE=short
+
+Syntax errors in files parsed by ppxlib should be reported correctly, but aren't at the moment
+
+  $ cat > test.ml << EOF
+  > let x = 5
+  > let let
+  > EOF
+  $ ./identity_standalone.exe -impl test.ml
+  File "test.ml", line 1:
+  Error: Syntax error
+  [1]

--- a/test/driver/parse_error_locations/run.t
+++ b/test/driver/parse_error_locations/run.t
@@ -3,13 +3,13 @@ different compiler versions in the subsequent test
 
   $ export OCAML_ERROR_STYLE=short
 
-Syntax errors in files parsed by ppxlib should be reported correctly, but aren't at the moment
+Syntax errors in files parsed by ppxlib are reported correctly
 
   $ cat > test.ml << EOF
   > let x = 5
   > let let
   > EOF
   $ ./identity_standalone.exe -impl test.ml
-  File "test.ml", line 1:
+  File "test.ml", line 2, characters 4-7:
   Error: Syntax error
   [1]


### PR DESCRIPTION
There's currently a [bug due to which no parse error is reported correctly when using ppxlib](https://github.com/ocaml-ppx/ppxlib/issues/221). I'm backporting its fix to 0.22, because making a release over master is a little complicated at the moment (see [here](https://github.com/ocaml-ppx/ppxlib/issues/253#issuecomment-856169765)).