### PR TITLE
Correctly pretty print `Psig_typesubst`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,8 +39,8 @@ unreleased
 - Fix in `Location`: make `raise_errorf` exception equivalent to exception
   `Error` (#242, @pitag-ha)
 
-- Fix in `Pprintast`: correctly pretry print local type substitutions, e.g. type
-  t := ... (#261, @matthewelse)
+- Fix in `Pprintast`: correctly pretty print local type substitutions, e.g.
+  type t := ... (#261, @matthewelse)
 
 0.22.0 (04/02/2021)
 -------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,9 @@ unreleased
 - Fix in `Location`: make `raise_errorf` exception equivalent to exception
   `Error` (#242, @pitag-ha)
 
+- Fix in `Pprintast`: correctly pretry print local type substitutions, e.g. type
+  t := ... (#261, @matthewelse)
+
 0.22.0 (04/02/2021)
 -------------------
 

--- a/ast/pprintast.ml
+++ b/ast/pprintast.ml
@@ -1083,7 +1083,10 @@ and signature_item ctxt f x : unit =
   | Psig_type (rf, l) ->
       type_def_list ctxt f (rf, true, l)
   | Psig_typesubst l ->
-      type_def_list ctxt f (Nonrecursive, false, l)
+      (* Psig_typesubst is never recursive, but we specify [Recursive] here to
+         avoid printing a [nonrec] flag, which would be rejected by the parser. 
+      *)
+      type_def_list ctxt f (Recursive, false, l)
   | Psig_value vd ->
       let intro = if vd.pval_prim = [] then "val" else "external" in
       pp f "@[<2>%s@ %a@ :@ %a@]%a" intro


### PR DESCRIPTION
ppxlib was previously incorrectly pretty printing the following ast:

```ocaml
type t
type other := t
```

as 

```ocaml
type t
type nonrec other := t
```

The `nonrec` isn't required here, and will just be rejected by the OCaml compiler. This PR updates `pprintast` to correctly omit this flag.