### PR TITLE
Add `Ast_pattern.esequence`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,7 +43,7 @@ unreleased
   type t := ... (#261, @matthewelse)
 
 - Add `Ast_pattern.esequence`, for matching on any number of sequenced
-  expressions e.g. `a; b; c; d`. (#264, @matthewelse)
+  expressions e.g. `do_a (); do_b (); ...`. (#264, @matthewelse)
 
 0.22.0 (04/02/2021)
 -------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,9 @@ unreleased
 - Fix in `Pprintast`: correctly pretty print local type substitutions, e.g.
   type t := ... (#261, @matthewelse)
 
+- Add `Ast_pattern.esequence`, for matching on any number of sequenced
+  expressions e.g. `a; b; c; d`. (#???, @matthewelse)
+
 0.22.0 (04/02/2021)
 -------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,7 +43,7 @@ unreleased
   type t := ... (#261, @matthewelse)
 
 - Add `Ast_pattern.esequence`, for matching on any number of sequenced
-  expressions e.g. `a; b; c; d`. (#???, @matthewelse)
+  expressions e.g. `a; b; c; d`. (#264, @matthewelse)
 
 0.22.0 (04/02/2021)
 -------------------

--- a/src/ast_pattern.ml
+++ b/src/ast_pattern.ml
@@ -224,7 +224,7 @@ let esequence (T f) = T (fun ctx _loc e k ->
   let rec parse_seq expr acc =
     match expr.pexp_desc with
     | Pexp_sequence (expr, next) ->
-      (parse_seq next (expr :: acc))
+      parse_seq next (expr :: acc)
     | _ -> expr :: acc
   in
   k (List.rev_map (parse_seq e []) ~f:(fun expr -> f ctx expr.pexp_loc expr (fun x -> x))))

--- a/src/ast_pattern.ml
+++ b/src/ast_pattern.ml
@@ -227,8 +227,8 @@ let esequence (T f) = T (fun ctx _loc e k ->
       expr :: (parse_seq next)
     | _ -> [ expr ]
   in
-  k (List.map (parse_seq e) ~f:(fun expr -> f ctx expr.pexp_loc expr k))
-)
+  k (List.map (parse_seq e) ~f:(fun expr -> f ctx expr.pexp_loc expr (fun x -> x))))
+;;
 
 let of_func f = (T f)
 let to_func (T f) = f

--- a/src/ast_pattern.ml
+++ b/src/ast_pattern.ml
@@ -221,13 +221,13 @@ let elist (T f) = T (fun ctx _loc e k ->
 ;;
 
 let esequence (T f) = T (fun ctx _loc e k ->
-  let rec parse_seq expr =
+  let rec parse_seq expr acc =
     match expr.pexp_desc with
     | Pexp_sequence (expr, next) ->
-      expr :: (parse_seq next)
-    | _ -> [ expr ]
+      (parse_seq next (expr :: acc))
+    | _ -> expr :: acc
   in
-  k (List.map (parse_seq e) ~f:(fun expr -> f ctx expr.pexp_loc expr (fun x -> x))))
+  k (List.rev_map (parse_seq e []) ~f:(fun expr -> f ctx expr.pexp_loc expr (fun x -> x))))
 ;;
 
 let of_func f = (T f)

--- a/src/ast_pattern.ml
+++ b/src/ast_pattern.ml
@@ -220,5 +220,15 @@ let elist (T f) = T (fun ctx _loc e k ->
   k (List.map l ~f:(fun x -> f ctx x.Parsetree.pexp_loc x (fun x -> x))))
 ;;
 
+let esequence (T f) = T (fun ctx _loc e k ->
+  let rec parse_seq expr =
+    match expr.pexp_desc with
+    | Pexp_sequence (expr, next) ->
+      expr :: (parse_seq next)
+    | _ -> [ expr ]
+  in
+  k (List.map (parse_seq e) ~f:(fun expr -> f ctx expr.pexp_loc expr k))
+)
+
 let of_func f = (T f)
 let to_func (T f) = f

--- a/src/ast_pattern.mli
+++ b/src/ast_pattern.mli
@@ -219,6 +219,7 @@ val attribute : name:(string, 'a, 'b) t -> payload:(payload, 'b, 'c) t -> (attri
 val extension : (string, 'a, 'b) t -> (payload, 'b, 'c) t -> (extension, 'a, 'c) t
 
 val elist : (expression, 'a -> 'a, 'b) t -> (expression, 'b list -> 'c, 'c) t
+val esequence : (expression, 'a -> 'a, 'b) t -> (expression, 'b list -> 'c, 'c) t
 
 type context
 val of_func : (context -> Location.t -> 'a -> 'b -> 'c) -> ('a, 'b, 'c) t


### PR DESCRIPTION
This PR adds support for matching on a list of subsequent expressions that form a sequence, as a natural analogue to `Ast_builder.esequence`. 