### PR TITLE
Rename `master` to `main`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Changelog check
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![ocaml-ci status][ocaml-ci-img]][ocaml-ci] [![AppVeyor status][appveyor-img]][appveyor]
 
 [ocaml-ci]: https://ci.ocamllabs.io/github/ocaml-ppx/ppxlib
-[ocaml-ci-img]: https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Focaml-ppx%2Fppxlib%2Fmaster&logo=ocaml
-[appveyor]:       https://ci.appveyor.com/project/diml/ppxlib/branch/master
+[ocaml-ci-img]: https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Focaml-ppx%2Fppxlib%main&logo=ocaml
+[appveyor]:       https://ci.appveyor.com/project/diml/ppxlib/branch/main
 [appveyor-img]:   https://ci.appveyor.com/api/projects/status/bogbsm33uvh083jx?svg=true
 
 [User manual][man]

--- a/doc/ppx-for-plugin-authors.rst
+++ b/doc/ppx-for-plugin-authors.rst
@@ -142,7 +142,7 @@ The type of the ``expand`` function is:
 
 If you want to look at a concrete example of extension rewriter you can find one in the
 ``examples/`` folder of the ``ppxlib`` repository
-`here <https://github.com/ocaml-ppx/ppxlib/tree/master/examples/simple-extension-rewriter>`_.
+`here <https://github.com/ocaml-ppx/ppxlib/tree/main/examples/simple-extension-rewriter>`_.
 
 Writing a deriver
 ^^^^^^^^^^^^^^^^^
@@ -210,7 +210,7 @@ deriver in their ``.ml`` files instead of having to type it and maintain it them
 
 If you want to look at a concrete example of deriver you can find one in the
 ``examples/`` folder of the ``ppxlib`` repository
-`here <https://github.com/ocaml-ppx/ppxlib/tree/master/examples/simple-deriver>`_.
+`here <https://github.com/ocaml-ppx/ppxlib/tree/main/examples/simple-deriver>`_.
 
 Metaquot
 --------


### PR DESCRIPTION
This commit adapts the user manual and the CIs to rename `master` to `main`.