### PR TITLE
Move `Pprintast` into `Astlib`

### DIFF
--- a/ast/ppxlib_ast.ml
+++ b/ast/ppxlib_ast.ml
@@ -14,7 +14,7 @@ module Extra_warnings = Warn
 module Location_error = Location_error
 module Parse          = Parse
 module Parsetree      = Parsetree
-module Pprintast      = Pprintast
+module Pprintast      = Astlib.Pprintast
 module Select_ast     = Select_ast
 module Selected_ast   = Selected_ast
 

--- a/astlib/astlib.ml
+++ b/astlib/astlib.ml
@@ -72,6 +72,7 @@ module Config = Config
 module Location = Location
 module Longident = Longident
 module Parse = Parse
+module Pprintast = Pprintast
 
 let init_error_reporting_style_using_env_vars () =
   (*IF_AT_LEAST 408 Ocaml_common.Compmisc.read_clflags_from_env () *)

--- a/astlib/dune
+++ b/astlib/dune
@@ -2,6 +2,7 @@
  (name astlib)
  (public_name ppxlib.astlib)
  (libraries ocaml-compiler-libs.common compiler-libs.common)
+ (flags -w -9)
  (preprocess
   (action
    (run %{exe:pp/pp.exe} %{read:ast-version} %{input-file}))))

--- a/astlib/pprintast.ml
+++ b/astlib/pprintast.ml
@@ -21,13 +21,72 @@
 (* Extensive Rewrite: Hongbo Zhang: University of Pennsylvania *)
 (* TODO more fine-grained precedence pretty-printing *)
 
-open Import
+open Ast_412
 open Asttypes
 open Format
 open Location
 open Longident
 open Parsetree
-open Ast_helper
+
+let varify_type_constructors var_names t =
+  let check_variable vl loc v =
+    if List.mem v vl then
+      Location.raise_errorf ~loc "variable in scope syntax error: %s" v in
+  let var_names = List.map (fun v -> v.txt) var_names in
+  let rec loop t =
+    let desc =
+      match t.ptyp_desc with
+      | Ptyp_any -> Ptyp_any
+      | Ptyp_var x ->
+        check_variable var_names t.ptyp_loc x;
+        Ptyp_var x
+      | Ptyp_arrow (label,core_type,core_type') ->
+        Ptyp_arrow(label, loop core_type, loop core_type')
+      | Ptyp_tuple lst -> Ptyp_tuple (List.map loop lst)
+      | Ptyp_constr( { txt = Longident.Lident s}, [])
+        when List.mem s var_names ->
+        Ptyp_var s
+      | Ptyp_constr(longident, lst) ->
+        Ptyp_constr(longident, List.map loop lst)
+      | Ptyp_object (lst, o) ->
+        Ptyp_object (List.map loop_object_field lst, o)
+      | Ptyp_class (longident, lst) ->
+        Ptyp_class (longident, List.map loop lst)
+      | Ptyp_alias(core_type, string) ->
+        check_variable var_names t.ptyp_loc string;
+        Ptyp_alias(loop core_type, string)
+      | Ptyp_variant(row_field_list, flag, lbl_lst_option) ->
+        Ptyp_variant(List.map loop_row_field row_field_list,
+                     flag, lbl_lst_option)
+      | Ptyp_poly(string_lst, core_type) ->
+        List.iter (fun v ->
+          check_variable var_names t.ptyp_loc v.txt) string_lst;
+        Ptyp_poly(string_lst, loop core_type)
+      | Ptyp_package(longident,lst) ->
+        Ptyp_package(longident,List.map (fun (n,typ) -> (n,loop typ) ) lst)
+      | Ptyp_extension (s, arg) ->
+        Ptyp_extension (s, arg)
+    in
+    {t with ptyp_desc = desc}
+  and loop_row_field field =
+    let prf_desc = match field.prf_desc with
+      | Rtag(label,flag,lst) ->
+        Rtag(label,flag,List.map loop lst)
+      | Rinherit t ->
+        Rinherit (loop t)
+    in
+    { field with prf_desc; }
+  and loop_object_field field =
+    let pof_desc = match field.pof_desc with
+      | Otag(label, t) ->
+        Otag(label, loop t)
+      | Oinherit t ->
+        Oinherit (loop t)
+    in
+    { field with pof_desc; }
+  in
+  loop t
+
 
 let prefix_symbols  = [ '!'; '?'; '~' ] ;;
 let infix_symbols = [ '='; '<'; '>'; '@'; '^'; '|'; '&'; '+'; '-'; '*'; '/';
@@ -1249,7 +1308,7 @@ and binding ctxt f {pvb_pat=p; pvb_expr=x; _} =
     match gadt_pattern, gadt_exp with
     | Some (p, pt_tyvars, pt_ct), Some (e_tyvars, e, e_ct)
       when tyvars_str pt_tyvars = tyvars_str e_tyvars ->
-      let ety = Typ.varify_constructors e_tyvars e_ct in
+      let ety = varify_type_constructors e_tyvars e_ct in
       if ety = pt_ct then
       Some (p, pt_tyvars, e_ct, e) else None
     | _ -> None in

--- a/astlib/pprintast.mli
+++ b/astlib/pprintast.mli
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Import
+open Ast_412
 
 type space_formatter = (unit, Format.formatter, unit) format
 


### PR DESCRIPTION
Currently `Pprintast` prints the AST version that we use internally. Printing is the "reverse operation" of parsing though and it would therefore be more coherent to print the AST version that's parsed, i.e. the compiler version. To achieve that behavior on new compilers, `Pprintast` needs to be moved into the compiler `Astlib`.

If we wanted to do the same on old compilers, we'd have to write a `Pprintast` module for every internal `Astlib` AST version. Instead, for old compilers, we keep the old behavior of having one fixed `Pprintast` for our internal AST version. For coherency with the new behavior, this commit moves that module into `Astlib`. Also, `Pprintast` inside `ppxlib` can be removed when the rest of our `Astlib` copy can be removed, i.e. when we drop support for all compilers without `Astlib`.