### PR TITLE
Drop dependency on OMP

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -18,7 +18,6 @@
  (depends
   (ocaml (and (>= 4.04.1) (< 4.13)))
   (ocaml-compiler-libs (>= v0.11.0))
-  (ocaml-migrate-parsetree (>= 2.1.0))
   (ppx_derivers (>= 1.0))
   (sexplib0 (>= v0.12))
   stdlib-shims

--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -23,7 +23,6 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.04.1" & < "4.13"}
   "ocaml-compiler-libs" {>= "v0.11.0"}
-  "ocaml-migrate-parsetree" {>= "2.1.0"}
   "ppx_derivers" {>= "1.0"}
   "sexplib0" {>= "v0.12"}
   "stdlib-shims"


### PR DESCRIPTION
When Astlib was integrated, the dependency on OMP should have been dropped. That was even pointed out back then by adding a changelog entry "Drop dependency on OMP", but was simply forgotten in the opam file.

Co-Authored-By: Kate <kit.ty.kate@disroot.org>

If we merge this uncontroversial PR separately, it will be clearer that the discussion in the [PR](https://github.com/ocaml-ppx/ppxlib/pull/255) adding a conflict for OMP is only about the conflict. cc @NathanReb and @kit-ty-kate 