### PR TITLE
Expose Ast_io read for binary files. 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,7 +46,7 @@ unreleased
   expressions e.g. `do_a (); do_b (); ...`. (#264, @matthewelse)
 
 - Expose a part of `Ast_io` in order to allow reading AST values from binary
- files (#270, @arozovyk) 
+ files (#270, @arozovyk)
 
 0.22.0 (04/02/2021)
 -------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,9 @@ unreleased
 - Add `Ast_pattern.esequence`, for matching on any number of sequenced
   expressions e.g. `do_a (); do_b (); ...`. (#264, @matthewelse)
 
+- Expose a part of `Ast_io` in order to allow reading AST values from binary
+ files (#270, @arozovyk) 
+
 0.22.0 (04/02/2021)
 -------------------
 

--- a/src/ppxlib.ml
+++ b/src/ppxlib.ml
@@ -56,6 +56,7 @@ module Merlin_helpers      = Merlin_helpers
 module Reserved_namespaces = Name.Reserved_namespaces
 module Spellcheck          = Spellcheck
 module Quoter              = Quoter
+module Ast_io              = Utils.Ast_io.Read_bin 
 
 include Common
 

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -211,7 +211,7 @@ module Ast_io = struct
     | Intf of signature
     | Impl of structure
 
-    let ast_read_error_string (error : read_error) =
+    let read_error_to_string (error : read_error) =
       match error with
       | Not_a_binary_ast ->  "Error: Not a binary ast"
       | Unknown_version (s, _) ->  ("Error: Unknown version " ^ s)
@@ -227,7 +227,7 @@ module Ast_io = struct
       | Ok {ast;_} -> Ok (match ast with
         | Impl structure -> Impl structure
         | Intf signature -> Intf signature )
-      | Error e -> Error (ast_read_error_string e)
+      | Error e -> Error (read_error_to_string e)
 
   end
 end

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -211,16 +211,14 @@ module Ast_io = struct
     | Intf of signature
     | Impl of structure
 
-    type read_error' = Read_error of string
-
     let ast_read_error_string (error : read_error) =
       match error with
-      | Not_a_binary_ast -> Read_error "Error: Not a binary ast"
-      | Unknown_version (s, _) -> Read_error ("Error: Unknown version " ^ s)
+      | Not_a_binary_ast ->  "Error: Not a binary ast"
+      | Unknown_version (s, _) ->  ("Error: Unknown version " ^ s)
       | Source_parse_error (loc, _) ->
-        Read_error ("Source parse error:" ^ Location.Error.message loc)
+         ("Source parse error:" ^ Location.Error.message loc)
       | System_error (loc, _) ->
-        Read_error ("System_error: " ^ Location.Error.message loc)
+         ("System_error: " ^ Location.Error.message loc)
 
     let read_binary fn =
       match

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -73,6 +73,15 @@ module Ast_io = struct
     | Possibly_source of Kind.t * string
     | Necessarily_binary
 
+  let read_error_to_string (error : read_error) =
+    match error with
+    | Not_a_binary_ast ->  "Error: Not a binary ast"
+    | Unknown_version (s, _) ->  ("Error: Unknown version " ^ s)
+    | Source_parse_error (loc, _) ->
+      ("Source parse error:" ^ Location.Error.message loc)
+    | System_error (loc, _) ->
+      ("System error: " ^ Location.Error.message loc)
+      
   let parse_source_code ~(kind : Kind.t) ~input_name ~prefix_read_from_source ic =
     (* The input version is determined by the fact that the input will get parsed by
        the current compiler Parse module *)
@@ -211,14 +220,6 @@ module Ast_io = struct
     | Intf of signature
     | Impl of structure
 
-    let read_error_to_string (error : read_error) =
-      match error with
-      | Not_a_binary_ast ->  "Error: Not a binary ast"
-      | Unknown_version (s, _) ->  ("Error: Unknown version " ^ s)
-      | Source_parse_error (loc, _) ->
-         ("Source parse error:" ^ Location.Error.message loc)
-      | System_error (loc, _) ->
-         ("System_error: " ^ Location.Error.message loc)
 
     let read_binary fn =
       match

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -205,6 +205,11 @@ module Ast_io = struct
         output_string oc Input_version.Ast.Config.ast_impl_magic_number;
         output_value oc input_name;
         output_value oc st
+        
+  module Read_bin = struct
+    let read fn =
+      In_channel.with_file fn ~f:(from_channel ~input_kind:Necessarily_binary)
+  end
 end
 
 module System = struct

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -81,7 +81,7 @@ module Ast_io = struct
       ("Source parse error:" ^ Location.Error.message loc)
     | System_error (loc, _) ->
       ("System error: " ^ Location.Error.message loc)
-      
+
   let parse_source_code ~(kind : Kind.t) ~input_name ~prefix_read_from_source ic =
     (* The input version is determined by the fact that the input will get parsed by
        the current compiler Parse module *)
@@ -220,15 +220,24 @@ module Ast_io = struct
     | Intf of signature
     | Impl of structure
 
+    type t = {ast: ast ; input_name : string }
 
     let read_binary fn =
       match
         In_channel.with_file fn ~f:(from_channel ~input_kind:Necessarily_binary)
       with
-      | Ok {ast;_} -> Ok (match ast with
-        | Impl structure -> Impl structure
-        | Intf signature -> Intf signature )
+      | Ok { ast; input_name; _ } ->
+          let ast =
+            match ast with
+            | Impl structure -> Impl structure
+            | Intf signature -> Intf signature
+          in
+          Ok { ast; input_name }
       | Error e -> Error (read_error_to_string e)
+
+    let get_ast t = t.ast
+
+    let get_input_name t = t.input_name
 
   end
 end

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -58,9 +58,7 @@ module Ast_io : sig
       | Intf of signature
       | Impl of structure
 
-      type read_error' = Read_error of string
-
-      val read_binary : string -> (ast, read_error') result
+      val read_binary : string -> (ast, string) result
     end
 end
 

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -53,9 +53,15 @@ module Ast_io : sig
       -> (t, read_error) result
 
     val write : out_channel -> t -> add_ppx_context:bool -> unit
-    module Read_bin : sig 
-      val read : string ->(t, read_error) result
-    end 
+    module Read_bin : sig
+      type ast =
+      | Intf of signature
+      | Impl of structure
+
+      type read_error' = Read_error of string
+
+      val read_binary : string -> (ast, read_error') result
+    end
 end
 
 module System : sig

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -53,6 +53,9 @@ module Ast_io : sig
       -> (t, read_error) result
 
     val write : out_channel -> t -> add_ppx_context:bool -> unit
+    module Read_bin : sig 
+      val read : string ->(t, read_error) result
+    end 
 end
 
 module System : sig

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -58,7 +58,14 @@ module Ast_io : sig
       | Intf of signature
       | Impl of structure
 
-      val read_binary : string -> (ast, string) result
+      type t 
+
+      val read_binary : string -> (t, string) result
+
+      val get_ast : t -> ast 
+
+      val get_input_name : t -> string 
+
     end
 end
 


### PR DESCRIPTION
This PR is a follow-up on the discussion with @pitag-ha in #268 and is directly linked to [#666](https://github.com/ocamllabs/vscode-ocaml-platform/pull/666). 

It exposes only a specific part of `Utils.Ast_io` that allows reading serialized AST values from binary files. 