### PR TITLE
Add support for registering ppx_import transformation as context-free rule

### DIFF
--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -32,5 +32,6 @@ test/driver/non-compressible-suffix/test.ml
 test/driver/transformations/test.ml
 test/extensions_and_deriving/test.ml
 test/location/exception/test.ml
+test/ppx_import_support/test.ml
 test/quoter/test.ml
 test/traverse/test.ml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ unreleased
   transformation, allowing better interactions between extensions and
   derivers (#279, @NathanReb)
 
+- Add support for registering ppx_import as a pseudo context-free rule (#???, @NathanReb)
+
 0.23.0 (31/08/2021)
 -------------------
 

--- a/astlib/pprintast.ml
+++ b/astlib/pprintast.ml
@@ -1733,3 +1733,5 @@ let module_type = module_type reset_ctxt
 let signature_item = signature_item reset_ctxt
 
 let structure_item = structure_item reset_ctxt
+
+let type_declaration = type_declaration reset_ctxt

--- a/astlib/pprintast.mli
+++ b/astlib/pprintast.mli
@@ -53,3 +53,5 @@ val module_type : Format.formatter -> Parsetree.module_type -> unit
 val signature_item : Format.formatter -> Parsetree.signature_item -> unit
 
 val structure_item : Format.formatter -> Parsetree.structure_item -> unit
+
+val type_declaration : Format.formatter -> Parsetree.type_declaration -> unit

--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -378,7 +378,8 @@ class map_top_down ?(expect_mismatch_handler = Expect_mismatch_handler.nop)
   and module_type = E.filter_by_context EC.module_type extensions
   and pattern = E.filter_by_context EC.pattern extensions
   and signature_item = E.filter_by_context EC.signature_item extensions
-  and structure_item = E.filter_by_context EC.structure_item extensions in
+  and structure_item = E.filter_by_context EC.structure_item extensions
+  and ppx_import = E.filter_by_context EC.Ppx_import extensions in
 
   let attr_str_type_decls, attr_str_type_decls_expect =
     Rule.filter Attr_str_type_decl rules
@@ -535,6 +536,10 @@ class map_top_down ?(expect_mismatch_handler = Expect_mismatch_handler.nop)
           base_ctxt pcstr_fields
       in
       { pcstr_self; pcstr_fields }
+
+    method! type_declaration base_ctxt x =
+      map_node EC.Ppx_import ppx_import super#type_declaration x.ptype_loc
+        base_ctxt x
 
     method! class_signature base_ctxt { pcsig_self; pcsig_fields } =
       let pcsig_self = self#core_type base_ctxt pcsig_self in

--- a/src/extension.ml
+++ b/src/extension.ml
@@ -157,7 +157,23 @@ struct
     with_arg : bool;
   }
 
-  let declare ~with_arg name context pattern k =
+  let declare :
+      type a.
+      with_arg:bool ->
+      string ->
+      a Context.t ->
+      (payload, 'b, 'payload) Ast_pattern.t ->
+      'b Callback.t ->
+      (a, 'payload) t =
+   fun ~with_arg name context pattern k ->
+    (* Check that there is no collisions between ppx_import and core_type
+       extensions *)
+    (match context with
+    | Context.Ppx_import ->
+        Name.Registrar.check_collisions registrar (Context.T Core_type) name
+    | Context.Core_type ->
+        Name.Registrar.check_collisions registrar (Context.T Ppx_import) name
+    | _ -> ());
     Name.Registrar.register ~kind:`Extension registrar (Context.T context) name;
     {
       name = Name.Pattern.make name;

--- a/src/extension.ml
+++ b/src/extension.ml
@@ -54,7 +54,7 @@ module Context = struct
     | Pattern -> "pattern"
     | Signature_item -> "signature item"
     | Structure_item -> "structure item"
-    | Ppx_import -> "ppx_import"
+    | Ppx_import -> "type declaration"
 
   let eq : type a b. a t -> b t -> (a, b) equality =
    fun a b ->

--- a/src/extension.mli
+++ b/src/extension.mli
@@ -15,6 +15,8 @@ module Context : sig
     | Pattern : pattern t
     | Signature_item : signature_item t
     | Structure_item : structure_item t
+    | Ppx_import : type_declaration t
+        (** For ppx_import compat only, please do not use *)
 
   val class_expr : class_expr t
 
@@ -189,3 +191,8 @@ end
 (**/**)
 
 val check_context_for_inline : func:string -> 'a Context.t -> unit
+
+val __declare_ppx_import :
+  string ->
+  (ctxt:Expansion_context.Extension.t -> type_declaration -> type_declaration) ->
+  t

--- a/src/name.ml
+++ b/src/name.ml
@@ -193,7 +193,9 @@ module Registrar = struct
           | None -> ""
           | Some s -> " on " ^ s ^ "s"
         in
-        Printf.ksprintf failwith "%s '%s'%s%s matches %s '%s'%s"
+        Printf.ksprintf failwith
+          "Some ppx-es tried to register conflicting transformations: %s \
+           '%s'%s%s matches %s '%s'%s"
           (String.capitalize_ascii t.kind)
           name context (declared_at caller) t.kind e.fully_qualified_name
           (declared_at e.declared_at)

--- a/src/name.mli
+++ b/src/name.mli
@@ -49,6 +49,8 @@ module Registrar : sig
   val register :
     kind:[ `Attribute | `Extension ] -> 'context t -> 'context -> string -> unit
 
+  val check_collisions : 'context t -> 'context -> string -> unit
+
   val spellcheck :
     'context t -> 'context -> ?white_list:string list -> string -> string option
 

--- a/src/reconcile.ml
+++ b/src/reconcile.ml
@@ -23,6 +23,7 @@ module Context = struct
     | Extension Pattern -> paren Pprintast.pattern
     | Extension Signature_item -> Pprintast.signature_item
     | Extension Structure_item -> Pprintast.structure_item
+    | Extension Ppx_import -> Pprintast.type_declaration
     | Floating_attribute Structure_item -> Pprintast.structure_item
     | Floating_attribute Signature_item -> Pprintast.signature_item
     | Floating_attribute Class_field -> Pprintast.class_field

--- a/test/ppx_import_support/dune
+++ b/test/ppx_import_support/dune
@@ -1,0 +1,13 @@
+(rule
+ (alias runtest)
+ (enabled_if
+  (>= %{ocaml_version} "4.10.0"))
+ (deps
+  (:test test.ml)
+  (package ppxlib))
+ (action
+  (chdir
+   %{project_root}
+   (progn
+    (run expect-test %{test})
+    (diff? %{test} %{test}.corrected)))))

--- a/test/ppx_import_support/test.ml
+++ b/test/ppx_import_support/test.ml
@@ -5,7 +5,11 @@ open Ppxlib
 let id =
   Extension.__declare_ppx_import
     "id"
-    (fun ~ctxt:_ td -> td)
+    (fun ~ctxt:_ td ->
+       match td.ptype_manifest with
+       | Some {ptyp_desc = Ptyp_extension (_, PTyp wrapped_manifest); _} ->
+         {td with ptype_manifest = Some wrapped_manifest}
+       | _ -> assert false)
 [%%expect{|
 val id : Extension.t = <abstr>
 |}]

--- a/test/ppx_import_support/test.ml
+++ b/test/ppx_import_support/test.ml
@@ -87,3 +87,14 @@ Driver.register_transformation
 [%%expect{|
 type t = int
 |}]
+
+(* One can't have ppx_import-like and core_type extensions with the same name *)
+let id_for_core_types =
+  Extension.V3.declare
+    "id"
+    Extension.Context.core_type
+    Ast_pattern.(ptyp __)
+    (fun ~ctxt:_ core_type -> core_type)
+[%%expect{|
+Exception: (Failure "Extension 'id' on ppx_imports matches extension 'id'")
+|}]

--- a/test/ppx_import_support/test.ml
+++ b/test/ppx_import_support/test.ml
@@ -62,8 +62,28 @@ end
 module type T = sig type t = int val foo : t end
 |}]
 
-(* Extra things to test:
-   - the contxt is right
-   - the context for inner nodes is right as well *)
+(* It should be properly interpreted if it's the result of the expansion of a
+   previous node as well *)
+let gen_id =
+  Extension.V3.declare
+    "gen_id"
+    Extension.Context.structure_item
+    Ast_pattern.(pstr nil)
+    (fun ~ctxt ->
+       let loc = Expansion_context.Extension.extension_point_loc ctxt in
+       [%stri type t = [%id: int]])
 [%%expect{|
+val gen_id : Extension.t = <abstr>
+|}]
+
+Driver.register_transformation
+  ~rules:[Context_free.Rule.extension gen_id]
+  "gen_id"
+[%%expect{|
+- : unit = ()
+|}]
+
+[%%gen_id]
+[%%expect{|
+type t = int
 |}]

--- a/test/ppx_import_support/test.ml
+++ b/test/ppx_import_support/test.ml
@@ -1,0 +1,65 @@
+(* Test for the ppx_import old syntax compat support *)
+
+open Ppxlib
+
+let id =
+  Extension.__declare_ppx_import
+    "id"
+    (fun ~ctxt:_ td -> td)
+[%%expect{|
+val id : Extension.t = <abstr>
+|}]
+
+Driver.register_transformation
+  ~rules:[Context_free.Rule.extension id]
+  "id"
+[%%expect{|
+- : unit = ()
+|}]
+
+(* The expander receives the type decl with the extension point removed, it should preserve
+   attibutes *)
+type t = [%id: int]
+[%%expect{|
+type t = int
+|}]
+
+(* It also should work in signatures by default *)
+module type T = sig
+  type t = [%id: int]
+end
+[%%expect{|
+module type T = sig type t = int end
+|}]
+
+let foo =
+  Deriving.add "foo"
+    ~str_type_decl:(Deriving.Generator.make_noarg
+                      (fun ~loc ~path:_ _ -> [%str let foo = 42]))
+    ~sig_type_decl:(Deriving.Generator.make_noarg
+                      (fun ~loc ~path:_ _ -> [%sig: val foo : int]))
+[%%expect{|
+val foo : Deriving.t = <abstr>
+|}]
+
+(* It should properly compose with [@@deriving] *)
+type t = [%id: int]
+[@@deriving foo]
+[%%expect{|
+type t = int
+val foo : t = 42
+|}]
+
+module type T = sig
+  type t = [%id: int]
+  [@@deriving foo]
+end
+[%%expect{|
+module type T = sig type t = int val foo : t end
+|}]
+
+(* Extra things to test:
+   - the contxt is right
+   - the context for inner nodes is right as well *)
+[%%expect{|
+|}]

--- a/test/ppx_import_support/test.ml
+++ b/test/ppx_import_support/test.ml
@@ -96,5 +96,7 @@ let id_for_core_types =
     Ast_pattern.(ptyp __)
     (fun ~ctxt:_ core_type -> core_type)
 [%%expect{|
-Exception: (Failure "Extension 'id' on ppx_imports matches extension 'id'")
+Exception:
+(Failure
+  "Some ppx-es tried to register conflicting transformations: Extension 'id' on type declarations matches extension 'id'")
 |}]


### PR DESCRIPTION
This PR adds support for declaring ppx_import special syntax as a context-free (in the ppxlib sense) rule.

It allows registering a `type_declaration -> type_declaration` transformation rule (let's name it `ext`) that is applied whenever we find a type declaration such as:
```ocaml
type t = [%ext: <some core_type>]
```

This transformation is applied during the same pass as other context-free rules.

I had the following things in mind while working on this feature, in order of priority:
1. The feature must work and allow porting ppx_import to ppxlib without changing its behaviour
2. It must be implemented in a way that will allow factoring as much code between this syntax and the new syntax proposed for `ppx_import` that will simply use a regular structure_item or signature_item extension rewriter.
3. It must remain as hidden as possible to other users, this is a temporary solution to allow a transition period towards the new syntax. IMHO, we do not wish to expose this as a regular ppxlib feature as it needlessly complexify how we traverse the AST and apply context-free transformations.

I'm opening this as a draft as there are a few things I wish to improve and test before we can merge. Any feedback is still appreciated at this stage.

## Notes for ppx_import maintainers

### How to implement ppx_import on top of this

To use this feature you'll have to register the ppx_import type_declaration transformation using the undocumented `Extension.__declare_ppx_import`:
```ocaml
val __declare_ppx_import :
  string ->
  (ctxt: Expansion_context.Extension.t -> type_declaration -> type_declaration) ->
  t
```
instead of the regular `Extension.V3.declare`. If you're not familiar with this part of ppxlib's API yet you can read the following [section of the manual](https://ppxlib.readthedocs.io/en/latest/ppx-for-plugin-authors.html#writing-an-extension-rewriter) or take a look at the following [example](https://github.com/ocaml-ppx/ppxlib/tree/master/examples/simple-extension-rewriter).

This will work both in signatures and structures.

The expand function that you have to provide (the `ctxt: Expansion_context.Extension.t -> type_declaration -> type_declaration` part) will receive the individual type declaration surrounding the extension point.

Note that this feature is only required for type declaration and that you can already express the module type transformation as its current syntax is already context-free. You can do so using:
```ocaml
Extension.V3.declare
  "import"
  Extension.Context.module_type
  Ast_pattern.(ptyp (ptyp_package __))
  (fun ~ctxt (module_longident, with_type_list) -> ...)
```

### Preserving attributes

It's important that the expand function preserves the attributes, particularly the `[@@deriving ...]` ones from its argument. It's most likely already the case with the current implementation anyway but it's worth pointing out that ppxlib isn't taking care of this here and certaintly won't reasonably be able to do it for the new syntax.

### Pluging in the new syntax

Using this won't prevent you from also adding support for the new syntax subsequently, using the regular `Extension.V3.declare` with `Context.signature_item` and `Context.structure_item`.
The implementation will be slightly different as you will have to interpret the payload yourself to eventually narrow it down to a `type_declaration`.
Another difference to note is that for the new syntax you will have to declare one extension for `signature_item` and one for `structure_item`.

## TODO

- [x] Provide the correct `Expansion_context`, at the moment it doesn't point to the actual extension point in the source
- [x] Handle module types since ppx_import currently supports them, ~this will go through a separate `declare` function. I'll likely rename the existing one in the process to make the context explicit~ (there's nothing to do here, this part of ppx_import actually is context free!
- [x] Test composition with str/sig_item rewriters
- [x] Investigate mutually recursive type declarations and how they are handled in `ppx_import`. I don't expect it to cause troubles here but it might be a problem for the new syntax.
- [x] Specify and test the behaviour for name collisions with regular `core_type` extensions