### PR TITLE
fix typo in constr method type

### DIFF
--- a/ast/ast.ml
+++ b/ast/ast.ml
@@ -5744,7 +5744,7 @@ class virtual ['ctx] map_with_context =
 class virtual ['res] lift =
   object (self)
     method virtual  record : (string * 'res) list -> 'res
-    method virtual  constr : string -> 'res list -> 'rest
+    method virtual  constr : string -> 'res list -> 'res
     method virtual  tuple : 'res list -> 'res
     method virtual  bool : bool -> 'res
     method virtual  char : char -> 'res

--- a/traverse/ppxlib_traverse.ml
+++ b/traverse/ppxlib_traverse.ml
@@ -460,7 +460,7 @@ let lift_virtual_methods ~loc methods =
       [%stri
         class virtual blah = object
           method virtual record : (string * 'res) list -> 'res
-          method virtual constr : string -> 'res list -> 'rest
+          method virtual constr : string -> 'res list -> 'res
           method virtual tuple : 'res list -> 'res
           method virtual other : 'a. 'a -> 'res
         end


### PR DESCRIPTION
The return type of `constr` is written as `'rest` instead of `'res` in the `lift` class. Type inference sorts out the correct type, but this patch fixes the typo to make the code more readable.