### PR TITLE
Avoid warning 60

### DIFF
--- a/src/ignore_unused_warning.ml
+++ b/src/ignore_unused_warning.ml
@@ -39,31 +39,41 @@ end
 let binds_module_names = object
   inherit [bool] Ast_traverse.fold as super
 
-  method! structure_item item acc =
-    match item.pstr_desc with
-    | Pstr_module _ -> true
-    | Pstr_recmodule _ -> true
-    | _ -> super#structure_item item acc
+  method! module_binding mb acc =
+    match mb.pmb_name.txt with
+    | Some (_ : string) -> true
+    | None -> super#module_binding mb acc
 
-  method! signature_item item acc =
-    match item.psig_desc with
-    | Psig_module _ -> true
-    | Psig_modsubst _ -> true
-    | Psig_recmodule _ -> true
-    | _ -> super#signature_item item acc
+  method! module_declaration md acc =
+    match md.pmd_name.txt with
+    | Some (_ : string) -> true
+    | None -> super#module_declaration md acc
 
-  method! module_expr me acc =
-    match me.pmod_desc with
-    | Pmod_functor _ -> true
-    | _ -> super#module_expr me acc
+  method! module_substitution ms _ =
+    match ms.pms_name.txt with
+    | (_ : string) -> true
+
+  method! functor_parameter fp acc =
+    match fp with
+    | Unit -> acc
+    | Named (name, _) ->
+      match name.txt with
+      | Some (_ : string) -> true
+      | None -> super#functor_parameter fp acc
 
   method! pattern pat acc =
     match pat.ppat_desc with
-    | Ppat_unpack _ -> true
+    | Ppat_unpack name ->
+      (match name.txt with
+       | Some (_ : string) -> true
+       | None -> acc)
     | _ -> super#pattern pat acc
 
   method! expression expr acc =
     match expr.pexp_desc with
-    | Pexp_letmodule _ -> true
+    | Pexp_letmodule (name, _, _) ->
+      (match name.txt with
+       | Some (_ : string) -> true
+       | None -> super#expression expr acc)
     | _ -> super#expression expr acc
 end

--- a/src/ignore_unused_warning.ml
+++ b/src/ignore_unused_warning.ml
@@ -35,3 +35,35 @@ let add_dummy_user_for_values = object
     in
     loop (super#structure st) []
 end
+
+let binds_module_names = object
+  inherit [bool] Ast_traverse.fold as super
+
+  method! structure_item item acc =
+    match item.pstr_desc with
+    | Pstr_module _ -> true
+    | Pstr_recmodule _ -> true
+    | _ -> super#structure_item item acc
+
+  method! signature_item item acc =
+    match item.psig_desc with
+    | Psig_module _ -> true
+    | Psig_modsubst _ -> true
+    | Psig_recmodule _ -> true
+    | _ -> super#signature_item item acc
+
+  method! module_expr me acc =
+    match me.pmod_desc with
+    | Pmod_functor _ -> true
+    | _ -> super#module_expr me acc
+
+  method! pattern pat acc =
+    match pat.ppat_desc with
+    | Ppat_unpack _ -> true
+    | _ -> super#pattern pat acc
+
+  method! expression expr acc =
+    match expr.pexp_desc with
+    | Pexp_letmodule _ -> true
+    | _ -> super#expression expr acc
+end

--- a/src/ignore_unused_warning.mli
+++ b/src/ignore_unused_warning.mli
@@ -1,1 +1,2 @@
 val add_dummy_user_for_values : Ast_traverse.map
+val binds_module_names : bool Ast_traverse.fold

--- a/test/deriving/inline/example/ppx_deriving_example.ml
+++ b/test/deriving/inline/example/ppx_deriving_example.ml
@@ -1,4 +1,9 @@
 type t = A [@@deriving_inline foo]
-let _ = fun (_ : t) -> ()
-let _ = [%foo ]
+include
+  struct
+    [@@@ocaml.warning "-60"]
+    let _ = fun (_ : t) -> ()
+    module Foo = struct  end
+    let _ = [%foo ]
+  end[@@ocaml.doc "@inline"]
 [@@@deriving.end]

--- a/test/deriving/inline/foo-deriver/ppx_foo_deriver.ml
+++ b/test/deriving/inline/foo-deriver/ppx_foo_deriver.ml
@@ -23,6 +23,19 @@ let add_deriver () =
         [
           {pstr_loc = loc;
            pstr_desc =
+             Pstr_module
+               { pmb_loc = loc;
+                 pmb_name = { loc; txt = Some "Foo" };
+                 pmb_expr =
+                   { pmod_loc = loc;
+                     pmod_desc = Pmod_structure [];
+                     pmod_attributes = [];
+                   };
+                 pmb_attributes = [];
+               }
+          };
+          {pstr_loc = loc;
+           pstr_desc =
              (Pstr_value (Nonrecursive, [{
                 pvb_pat =
                   { ppat_desc = Ppat_any;


### PR DESCRIPTION
Adds code to disable warning 60 when derived code binds module names. Akin to disabling of warning 32 for unused values, and combines the warnings in one attribute when both are disabled. Did not add a version with "module _ = " bindings. It doesn't seem necessary, and not every module binding position allows that.

Added a module binding to the deriving_inline test to show the new behavior.