### PR TITLE
Disable expect tests on 4.13 compiler

### DIFF
--- a/test/base/dune
+++ b/test/base/dune
@@ -1,7 +1,9 @@
 (rule
  (alias runtest)
  (enabled_if
-  (>= %{ocaml_version} "4.09.0"))
+  (and
+   (>= %{ocaml_version} "4.09.0")
+   (< %{ocaml_version} "4.13.0")))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/code_path/dune
+++ b/test/code_path/dune
@@ -1,7 +1,9 @@
 (rule
  (alias runtest)
  (enabled_if
-  (>= %{ocaml_version} "4.08.0"))
+  (and
+   (>= %{ocaml_version} "4.08.0")
+   (< %{ocaml_version} "4.13.0")))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/deriving/dune
+++ b/test/deriving/dune
@@ -1,7 +1,9 @@
 (rule
  (alias runtest)
  (enabled_if
-  (>= %{ocaml_version} "4.10.0"))
+  (and
+   (>= %{ocaml_version} "4.10.0")
+   (< %{ocaml_version} "4.13.0")))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/driver/attributes/dune
+++ b/test/driver/attributes/dune
@@ -1,7 +1,9 @@
 (rule
  (alias runtest)
  (enabled_if
-  (>= %{ocaml_version} "4.08.0"))
+  (and
+   (>= %{ocaml_version} "4.08.0")
+   (< %{ocaml_version} "4.13.0")))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/driver/instrument/dune
+++ b/test/driver/instrument/dune
@@ -1,7 +1,9 @@
 (rule
  (alias runtest)
  (enabled_if
-  (>= %{ocaml_version} "4.08.0"))
+  (and
+   (>= %{ocaml_version} "4.08.0")
+   (< %{ocaml_version} "4.13.0")))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/driver/non-compressible-suffix/dune
+++ b/test/driver/non-compressible-suffix/dune
@@ -1,7 +1,9 @@
 (rule
  (alias runtest)
  (enabled_if
-  (>= %{ocaml_version} "4.08.0"))
+  (and
+   (>= %{ocaml_version} "4.08.0")
+   (< %{ocaml_version} "4.13.0")))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/expect/dune
+++ b/test/expect/dune
@@ -1,7 +1,9 @@
 (executable
  (name expect_test)
  (enabled_if
-  (>= %{ocaml_version} "4.08.0"))
+  (and
+   (>= %{ocaml_version} "4.08.0")
+   (< %{ocaml_version} "4.13.0")))
  (link_flags (-linkall))
  (modes byte)
  (libraries

--- a/test/extensions_and_deriving/dune
+++ b/test/extensions_and_deriving/dune
@@ -1,7 +1,9 @@
 (rule
  (alias runtest)
  (enabled_if
-  (>= %{ocaml_version} "4.10.0"))
+  (and
+   (>= %{ocaml_version} "4.10.0")
+   (< %{ocaml_version} "4.13.0")))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/location/exception/dune
+++ b/test/location/exception/dune
@@ -1,7 +1,9 @@
 (rule
  (alias runtest)
  (enabled_if
-  (>= %{ocaml_version} "4.08.0"))
+  (and
+   (>= %{ocaml_version} "4.08.0")
+   (< %{ocaml_version} "4.13.0")))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/quoter/dune
+++ b/test/quoter/dune
@@ -1,7 +1,9 @@
 (rule
  (alias runtest)
  (enabled_if
-  (>= %{ocaml_version} "4.08.0"))
+  (and
+   (>= %{ocaml_version} "4.08.0")
+   (< %{ocaml_version} "4.13.0")))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/traverse/dune
+++ b/test/traverse/dune
@@ -1,7 +1,9 @@
 (rule
  (alias runtest)
  (enabled_if
-  (>= %{ocaml_version} "4.08.0"))
+  (and
+   (>= %{ocaml_version} "4.08.0")
+   (< %{ocaml_version} "4.13.0")))
  (deps
   (:test test.ml)
   (package ppxlib))


### PR DESCRIPTION
This commit just disables the expect tests on 4.13 for now. Soon, when 4.13 is official, we'll need to decide if to do it the other way around (only enable the expect tests on 4.13 and not on older compilers) or if to add some cross-compiler logic to our local expect-test binary.