### PR TITLE
Make our expect-test version compatible with 4.13 compiler

### DIFF
--- a/test/expect/expect_test.ml
+++ b/test/expect/expect_test.ml
@@ -63,7 +63,7 @@ let main () =
     setup_printers ppf;
     Topfind.log := ignore;
 
-    Warnings.parse_options false "@a-4-29-40-41-42-44-45-48-58";
+    let _ = Warnings.parse_options false "@a-4-29-40-41-42-44-45-48-58" in
     Clflags.real_paths := false;
     Toploop.initialize_toplevel_env ();
 


### PR DESCRIPTION
The Warnings.parse_options function was returning a unit on older compilers and is returning an alert option now, but under the hood it still has the same side-effects.