### PR TITLE
Fix ocaml-ci badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![ocaml-ci status][ocaml-ci-img]][ocaml-ci] [![AppVeyor status][appveyor-img]][appveyor]
 
 [ocaml-ci]: https://ci.ocamllabs.io/github/ocaml-ppx/ppxlib
-[ocaml-ci-img]: https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Focaml-ppx%2Fppxlib%main&logo=ocaml
+[ocaml-ci-img]: https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Focaml-ppx%2Fppxlib%2Fmain&logo=ocaml
 [appveyor]:       https://ci.appveyor.com/project/diml/ppxlib/branch/main
 [appveyor-img]:   https://ci.appveyor.com/api/projects/status/bogbsm33uvh083jx?svg=true
 


### PR DESCRIPTION
This was messed up in #265.