### PR TITLE
Remove Import_for_core

### DIFF
--- a/ast/ppxlib_ast.ml
+++ b/ast/ppxlib_ast.ml
@@ -17,5 +17,3 @@ module Parsetree      = Parsetree
 module Pprintast      = Astlib.Pprintast
 module Select_ast     = Select_ast
 module Selected_ast   = Selected_ast
-
-module Import_for_core = Import


### PR DESCRIPTION
Import_for_core was meant to serve ppx_core which was kept for a while after ppxlib was made for backwards compatibility. By now, ppx_core is deprecated and Import_for_core doesn't even form part of ppxlib's public API anymore, so it can simply be fully removed.