### PR TITLE
add input_name to the Expansion_context.Extension module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ unreleased
 
 - Add support for registering ppx_import as a pseudo context-free rule (#???, @NathanReb)
 
-- Add `input_name` to the `Expansion_context.Extension` module (#284, @tatchi)
+- Add `input_name` to the `Expansion_context.Extension` and `Expansion_context.Deriver` modules (#284, @tatchi)
 
 0.23.0 (31/08/2021)
 -------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ unreleased
 
 - Add support for registering ppx_import as a pseudo context-free rule (#???, @NathanReb)
 
+- Add `input_name` to the `Expansion_context.Extension` module (#284, @tatchi)
+
 0.23.0 (31/08/2021)
 -------------------
 

--- a/src/expansion_context.ml
+++ b/src/expansion_context.ml
@@ -48,6 +48,8 @@ module Deriver = struct
 
   let code_path t = t.base.code_path
 
+  let input_name t = t.base.input_name
+
   let tool_name t = t.base.tool_name
 
   let inline t = t.inline

--- a/src/expansion_context.ml
+++ b/src/expansion_context.ml
@@ -29,6 +29,8 @@ module Extension = struct
 
   let code_path t = t.base.code_path
 
+  let input_name t = t.base.input_name
+
   let tool_name t = t.base.tool_name
 
   let with_loc_and_path f ~ctxt =

--- a/src/expansion_context.mli
+++ b/src/expansion_context.mli
@@ -51,10 +51,24 @@ module Extension : sig
   (** Return the location of the extension point being expanded *)
 
   val code_path : t -> Code_path.t
-  (** Return the code path for the given context *)
+  (** Return the code path for the given context In Driver, Deriving and
+      Extension, the context is initialized so that the [file_path] component of
+      the [code_path] is determined from the first location found in the input
+      AST. That means that:
+
+      - It's the empty string in empty structures or signatures
+      - It can be altered by line directives *)
 
   val input_name : t -> string
-  (** Return the input name for the given context *)
+  (** Return the input name for the given context. In Driver, Deriving and
+      Extension, the context argument is initialized so that the [input_name]
+      matches the input filename passed to the driver on the command line. That
+      means that:
+
+      - It has a value even for empty files
+      - It is not affected by line directives
+      - It is ["_none_"] when using [Driver.map_structure] or
+        [Driver.map_signature] *)
 
   val tool_name : t -> string
   (** Can be used within a ppx preprocessor to know which tool is calling it

--- a/src/expansion_context.mli
+++ b/src/expansion_context.mli
@@ -94,7 +94,24 @@ module Deriver : sig
   (** Return the location of the item to which the deriver is being applied *)
 
   val code_path : t -> Code_path.t
-  (** Return the code path for the given context *)
+  (** Return the code path for the given context In Driver, Deriving and
+      Extension, the context is initialized so that the [file_path] component of
+      the [code_path] is determined from the first location found in the input
+      AST. That means that:
+
+      - It's the empty string in empty structures or signatures
+      - It can be altered by line directives *)
+
+  val input_name : t -> string
+  (** Return the input name for the given context. In Driver, Deriving and
+      Extension, the context argument is initialized so that the [input_name]
+      matches the input filename passed to the driver on the command line. That
+      means that:
+
+      - It has a value even for empty files
+      - It is not affected by line directives
+      - It is ["_none_"] when using [Driver.map_structure] or
+        [Driver.map_signature] *)
 
   val tool_name : t -> string
   (** Can be used within a ppx preprocessor to know which tool is calling it

--- a/src/expansion_context.mli
+++ b/src/expansion_context.mli
@@ -53,6 +53,9 @@ module Extension : sig
   val code_path : t -> Code_path.t
   (** Return the code path for the given context *)
 
+  val input_name : t -> string
+  (** Return the input name for the given context *)
+
   val tool_name : t -> string
   (** Can be used within a ppx preprocessor to know which tool is calling it
       ["ocamlc"], ["ocamlopt"], ["ocamldep"], ["ocaml"], ... . *)


### PR DESCRIPTION
That will be needed for https://github.com/ocaml-ppx/ppx_import/pull/54

The new `Extension.__declare_ppx_import` takes an `Expansion_context.Extension.t` : https://github.com/ocaml-ppx/ppxlib/blob/main/src/extension.mli#L197

Whereas the current `ppx_import` port to ppxlib uses a `Ppxlib.Expansion_context.Base` : https://github.com/tatchi/ppx_import/blob/cfd93d7b3034a99e85133a0eba261ca77e0281ea/src/ppx_import.ml#L531

The problem is that the `Extension` module doesn't expose an `input_name` function (like the `Base` module does).