### PR TITLE
[Preview] upgrade to ocamlformat.0.20.0

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # The bulk change commit enabling ocamlformat
 427f96e126d306538eb541ac591f71b2c68e5dd4
+
+#The commit upgrading to ocamlformat 0.20.0
+50c1f3736e58be5cf18ad02debf9653799625bfc

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version=0.19.0
+version=0.20.0
 profile=conventional
 parse-docstrings=true

--- a/ast/ast.ml
+++ b/ast/ast.ml
@@ -93,15 +93,10 @@ and direction_flag = Asttypes.direction_flag = Upto | Downto
 
 (* Order matters, used in polymorphic comparison *)
 and private_flag = Asttypes.private_flag = Private | Public
-
 and mutable_flag = Asttypes.mutable_flag = Immutable | Mutable
-
 and virtual_flag = Asttypes.virtual_flag = Virtual | Concrete
-
 and override_flag = Asttypes.override_flag = Override | Fresh
-
 and closed_flag = Asttypes.closed_flag = Closed | Open
-
 and label = string
 
 and arg_label = Asttypes.arg_label =
@@ -111,7 +106,6 @@ and arg_label = Asttypes.arg_label =
 (* ?label:T -> ... *)
 
 and variance = Asttypes.variance = Covariant | Contravariant | NoVariance
-
 and injectivity = Asttypes.injectivity = Injective | NoInjectivity
 
 (** Abstract syntax tree produced by parsing *)
@@ -682,7 +676,6 @@ and 'a class_infos = 'a Parsetree.class_infos = {
 *)
 
 and class_description = class_type class_infos
-
 and class_type_declaration = class_type class_infos
 
 (* Value expressions for the class language *)
@@ -1020,15 +1013,10 @@ and cases = case list [@@deriving_inline traverse]
 class virtual map =
   object (self)
     method virtual bool : bool -> bool
-
     method virtual char : char -> char
-
     method virtual int : int -> int
-
     method virtual list : 'a. ('a -> 'a) -> 'a list -> 'a list
-
     method virtual option : 'a. ('a -> 'a) -> 'a option -> 'a option
-
     method virtual string : string -> string
 
     method position : position -> position =
@@ -1074,19 +1062,12 @@ class virtual map =
       self#loc self#longident
 
     method rec_flag : rec_flag -> rec_flag = fun x -> x
-
     method direction_flag : direction_flag -> direction_flag = fun x -> x
-
     method private_flag : private_flag -> private_flag = fun x -> x
-
     method mutable_flag : mutable_flag -> mutable_flag = fun x -> x
-
     method virtual_flag : virtual_flag -> virtual_flag = fun x -> x
-
     method override_flag : override_flag -> override_flag = fun x -> x
-
     method closed_flag : closed_flag -> closed_flag = fun x -> x
-
     method label : label -> label = self#string
 
     method arg_label : arg_label -> arg_label =
@@ -1101,7 +1082,6 @@ class virtual map =
             Optional a
 
     method variance : variance -> variance = fun x -> x
-
     method injectivity : injectivity -> injectivity = fun x -> x
 
     method constant : constant -> constant =
@@ -2286,15 +2266,10 @@ class virtual map =
 class virtual iter =
   object (self)
     method virtual bool : bool -> unit
-
     method virtual char : char -> unit
-
     method virtual int : int -> unit
-
     method virtual list : 'a. ('a -> unit) -> 'a list -> unit
-
     method virtual option : 'a. ('a -> unit) -> 'a option -> unit
-
     method virtual string : string -> unit
 
     method position : position -> unit =
@@ -2329,21 +2304,13 @@ class virtual iter =
             self#longident b
 
     method longident_loc : longident_loc -> unit = self#loc self#longident
-
     method rec_flag : rec_flag -> unit = fun _ -> ()
-
     method direction_flag : direction_flag -> unit = fun _ -> ()
-
     method private_flag : private_flag -> unit = fun _ -> ()
-
     method mutable_flag : mutable_flag -> unit = fun _ -> ()
-
     method virtual_flag : virtual_flag -> unit = fun _ -> ()
-
     method override_flag : override_flag -> unit = fun _ -> ()
-
     method closed_flag : closed_flag -> unit = fun _ -> ()
-
     method label : label -> unit = self#string
 
     method arg_label : arg_label -> unit =
@@ -2354,7 +2321,6 @@ class virtual iter =
         | Optional a -> self#string a
 
     method variance : variance -> unit = fun _ -> ()
-
     method injectivity : injectivity -> unit = fun _ -> ()
 
     method constant : constant -> unit =
@@ -3165,11 +3131,8 @@ class virtual iter =
 class virtual ['acc] fold =
   object (self)
     method virtual bool : bool -> 'acc -> 'acc
-
     method virtual char : char -> 'acc -> 'acc
-
     method virtual int : int -> 'acc -> 'acc
-
     method virtual list : 'a. ('a -> 'acc -> 'acc) -> 'a list -> 'acc -> 'acc
 
     method virtual option
@@ -3218,19 +3181,12 @@ class virtual ['acc] fold =
       self#loc self#longident
 
     method rec_flag : rec_flag -> 'acc -> 'acc = fun _ acc -> acc
-
     method direction_flag : direction_flag -> 'acc -> 'acc = fun _ acc -> acc
-
     method private_flag : private_flag -> 'acc -> 'acc = fun _ acc -> acc
-
     method mutable_flag : mutable_flag -> 'acc -> 'acc = fun _ acc -> acc
-
     method virtual_flag : virtual_flag -> 'acc -> 'acc = fun _ acc -> acc
-
     method override_flag : override_flag -> 'acc -> 'acc = fun _ acc -> acc
-
     method closed_flag : closed_flag -> 'acc -> 'acc = fun _ acc -> acc
-
     method label : label -> 'acc -> 'acc = self#string
 
     method arg_label : arg_label -> 'acc -> 'acc =
@@ -3241,7 +3197,6 @@ class virtual ['acc] fold =
         | Optional a -> self#string a acc
 
     method variance : variance -> 'acc -> 'acc = fun _ acc -> acc
-
     method injectivity : injectivity -> 'acc -> 'acc = fun _ acc -> acc
 
     method constant : constant -> 'acc -> 'acc =
@@ -4213,9 +4168,7 @@ class virtual ['acc] fold =
 class virtual ['acc] fold_map =
   object (self)
     method virtual bool : bool -> 'acc -> bool * 'acc
-
     method virtual char : char -> 'acc -> char * 'acc
-
     method virtual int : int -> 'acc -> int * 'acc
 
     method virtual list
@@ -5538,11 +5491,8 @@ class virtual ['acc] fold_map =
 class virtual ['ctx] map_with_context =
   object (self)
     method virtual bool : 'ctx -> bool -> bool
-
     method virtual char : 'ctx -> char -> char
-
     method virtual int : 'ctx -> int -> int
-
     method virtual list : 'a. ('ctx -> 'a -> 'a) -> 'ctx -> 'a list -> 'a list
 
     method virtual option
@@ -5598,16 +5548,13 @@ class virtual ['ctx] map_with_context =
       fun _ctx x -> x
 
     method private_flag : 'ctx -> private_flag -> private_flag = fun _ctx x -> x
-
     method mutable_flag : 'ctx -> mutable_flag -> mutable_flag = fun _ctx x -> x
-
     method virtual_flag : 'ctx -> virtual_flag -> virtual_flag = fun _ctx x -> x
 
     method override_flag : 'ctx -> override_flag -> override_flag =
       fun _ctx x -> x
 
     method closed_flag : 'ctx -> closed_flag -> closed_flag = fun _ctx x -> x
-
     method label : 'ctx -> label -> label = self#string
 
     method arg_label : 'ctx -> arg_label -> arg_label =
@@ -5622,7 +5569,6 @@ class virtual ['ctx] map_with_context =
             Optional a
 
     method variance : 'ctx -> variance -> variance = fun _ctx x -> x
-
     method injectivity : 'ctx -> injectivity -> injectivity = fun _ctx x -> x
 
     method constant : 'ctx -> constant -> constant =
@@ -6823,21 +6769,13 @@ class virtual ['ctx] map_with_context =
 class virtual ['res] lift =
   object (self)
     method virtual record : (string * 'res) list -> 'res
-
     method virtual constr : string -> 'res list -> 'res
-
     method virtual tuple : 'res list -> 'res
-
     method virtual bool : bool -> 'res
-
     method virtual char : char -> 'res
-
     method virtual int : int -> 'res
-
     method virtual list : 'a. ('a -> 'res) -> 'a list -> 'res
-
     method virtual option : 'a. ('a -> 'res) -> 'a option -> 'res
-
     method virtual string : string -> 'res
 
     method position : position -> 'res =

--- a/ast/ast_helper_lite.ml
+++ b/ast/ast_helper_lite.ml
@@ -25,15 +25,10 @@ open Asttypes
 open Parsetree
 
 type 'a with_loc = 'a Location.loc
-
 type loc = Location.t
-
 type lid = Longident.t with_loc
-
 type str = string with_loc
-
 type str_opt = string option with_loc
-
 type attrs = attribute list
 
 let default_loc = ref Location.none
@@ -58,17 +53,11 @@ let with_default_loc l f = protect_ref (R (default_loc, l)) f
 
 module Const = struct
   let integer ?suffix i = Pconst_integer (i, suffix)
-
   let int ?suffix i = integer ?suffix (Int.to_string i)
-
   let int32 ?(suffix = 'l') i = integer ~suffix (Int32.to_string i)
-
   let int64 ?(suffix = 'L') i = integer ~suffix (Int64.to_string i)
-
   let nativeint ?(suffix = 'n') i = integer ~suffix (Nativeint.to_string i)
-
   let float ?suffix f = Pconst_float (f, suffix)
-
   let char c = Pconst_char c
 
   let string ?quotation_delimiter ?(loc = !default_loc) s =
@@ -90,29 +79,17 @@ module Typ = struct
     }
 
   let attr d a = { d with ptyp_attributes = d.ptyp_attributes @ [ a ] }
-
   let any ?loc ?attrs () = mk ?loc ?attrs Ptyp_any
-
   let var ?loc ?attrs a = mk ?loc ?attrs (Ptyp_var a)
-
   let arrow ?loc ?attrs a b c = mk ?loc ?attrs (Ptyp_arrow (a, b, c))
-
   let tuple ?loc ?attrs a = mk ?loc ?attrs (Ptyp_tuple a)
-
   let constr ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_constr (a, b))
-
   let object_ ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_object (a, b))
-
   let class_ ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_class (a, b))
-
   let alias ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_alias (a, b))
-
   let variant ?loc ?attrs a b c = mk ?loc ?attrs (Ptyp_variant (a, b, c))
-
   let poly ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_poly (a, b))
-
   let package ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_package (a, b))
-
   let extension ?loc ?attrs a = mk ?loc ?attrs (Ptyp_extension a)
 
   let force_poly t =
@@ -188,41 +165,23 @@ module Pat = struct
     }
 
   let attr d a = { d with ppat_attributes = d.ppat_attributes @ [ a ] }
-
   let any ?loc ?attrs () = mk ?loc ?attrs Ppat_any
-
   let var ?loc ?attrs a = mk ?loc ?attrs (Ppat_var a)
-
   let alias ?loc ?attrs a b = mk ?loc ?attrs (Ppat_alias (a, b))
-
   let constant ?loc ?attrs a = mk ?loc ?attrs (Ppat_constant a)
-
   let interval ?loc ?attrs a b = mk ?loc ?attrs (Ppat_interval (a, b))
-
   let tuple ?loc ?attrs a = mk ?loc ?attrs (Ppat_tuple a)
-
   let construct ?loc ?attrs a b = mk ?loc ?attrs (Ppat_construct (a, b))
-
   let variant ?loc ?attrs a b = mk ?loc ?attrs (Ppat_variant (a, b))
-
   let record ?loc ?attrs a b = mk ?loc ?attrs (Ppat_record (a, b))
-
   let array ?loc ?attrs a = mk ?loc ?attrs (Ppat_array a)
-
   let or_ ?loc ?attrs a b = mk ?loc ?attrs (Ppat_or (a, b))
-
   let constraint_ ?loc ?attrs a b = mk ?loc ?attrs (Ppat_constraint (a, b))
-
   let type_ ?loc ?attrs a = mk ?loc ?attrs (Ppat_type a)
-
   let lazy_ ?loc ?attrs a = mk ?loc ?attrs (Ppat_lazy a)
-
   let unpack ?loc ?attrs a = mk ?loc ?attrs (Ppat_unpack a)
-
   let open_ ?loc ?attrs a b = mk ?loc ?attrs (Ppat_open (a, b))
-
   let exception_ ?loc ?attrs a = mk ?loc ?attrs (Ppat_exception a)
-
   let extension ?loc ?attrs a = mk ?loc ?attrs (Ppat_extension a)
 end
 
@@ -236,82 +195,46 @@ module Exp = struct
     }
 
   let attr d a = { d with pexp_attributes = d.pexp_attributes @ [ a ] }
-
   let ident ?loc ?attrs a = mk ?loc ?attrs (Pexp_ident a)
-
   let constant ?loc ?attrs a = mk ?loc ?attrs (Pexp_constant a)
-
   let let_ ?loc ?attrs a b c = mk ?loc ?attrs (Pexp_let (a, b, c))
-
   let fun_ ?loc ?attrs a b c d = mk ?loc ?attrs (Pexp_fun (a, b, c, d))
-
   let function_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_function a)
-
   let apply ?loc ?attrs a b = mk ?loc ?attrs (Pexp_apply (a, b))
-
   let match_ ?loc ?attrs a b = mk ?loc ?attrs (Pexp_match (a, b))
-
   let try_ ?loc ?attrs a b = mk ?loc ?attrs (Pexp_try (a, b))
-
   let tuple ?loc ?attrs a = mk ?loc ?attrs (Pexp_tuple a)
-
   let construct ?loc ?attrs a b = mk ?loc ?attrs (Pexp_construct (a, b))
-
   let variant ?loc ?attrs a b = mk ?loc ?attrs (Pexp_variant (a, b))
-
   let record ?loc ?attrs a b = mk ?loc ?attrs (Pexp_record (a, b))
-
   let field ?loc ?attrs a b = mk ?loc ?attrs (Pexp_field (a, b))
-
   let setfield ?loc ?attrs a b c = mk ?loc ?attrs (Pexp_setfield (a, b, c))
-
   let array ?loc ?attrs a = mk ?loc ?attrs (Pexp_array a)
-
   let ifthenelse ?loc ?attrs a b c = mk ?loc ?attrs (Pexp_ifthenelse (a, b, c))
-
   let sequence ?loc ?attrs a b = mk ?loc ?attrs (Pexp_sequence (a, b))
-
   let while_ ?loc ?attrs a b = mk ?loc ?attrs (Pexp_while (a, b))
-
   let for_ ?loc ?attrs a b c d e = mk ?loc ?attrs (Pexp_for (a, b, c, d, e))
-
   let constraint_ ?loc ?attrs a b = mk ?loc ?attrs (Pexp_constraint (a, b))
-
   let coerce ?loc ?attrs a b c = mk ?loc ?attrs (Pexp_coerce (a, b, c))
-
   let send ?loc ?attrs a b = mk ?loc ?attrs (Pexp_send (a, b))
-
   let new_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_new a)
-
   let setinstvar ?loc ?attrs a b = mk ?loc ?attrs (Pexp_setinstvar (a, b))
-
   let override ?loc ?attrs a = mk ?loc ?attrs (Pexp_override a)
-
   let letmodule ?loc ?attrs a b c = mk ?loc ?attrs (Pexp_letmodule (a, b, c))
-
   let letexception ?loc ?attrs a b = mk ?loc ?attrs (Pexp_letexception (a, b))
-
   let assert_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_assert a)
-
   let lazy_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_lazy a)
-
   let poly ?loc ?attrs a b = mk ?loc ?attrs (Pexp_poly (a, b))
-
   let object_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_object a)
-
   let newtype ?loc ?attrs a b = mk ?loc ?attrs (Pexp_newtype (a, b))
-
   let pack ?loc ?attrs a = mk ?loc ?attrs (Pexp_pack a)
-
   let open_ ?loc ?attrs a b = mk ?loc ?attrs (Pexp_open (a, b))
 
   let letop ?loc ?attrs let_ ands body =
     mk ?loc ?attrs (Pexp_letop { let_; ands; body })
 
   let extension ?loc ?attrs a = mk ?loc ?attrs (Pexp_extension a)
-
   let unreachable ?loc ?attrs () = mk ?loc ?attrs Pexp_unreachable
-
   let case lhs ?guard rhs = { pc_lhs = lhs; pc_guard = guard; pc_rhs = rhs }
 
   let binding_op op pat exp loc =
@@ -323,19 +246,12 @@ module Mty = struct
     { pmty_desc = d; pmty_loc = loc; pmty_attributes = attrs }
 
   let attr d a = { d with pmty_attributes = d.pmty_attributes @ [ a ] }
-
   let ident ?loc ?attrs a = mk ?loc ?attrs (Pmty_ident a)
-
   let alias ?loc ?attrs a = mk ?loc ?attrs (Pmty_alias a)
-
   let signature ?loc ?attrs a = mk ?loc ?attrs (Pmty_signature a)
-
   let functor_ ?loc ?attrs a b = mk ?loc ?attrs (Pmty_functor (a, b))
-
   let with_ ?loc ?attrs a b = mk ?loc ?attrs (Pmty_with (a, b))
-
   let typeof_ ?loc ?attrs a = mk ?loc ?attrs (Pmty_typeof a)
-
   let extension ?loc ?attrs a = mk ?loc ?attrs (Pmty_extension a)
 end
 
@@ -344,87 +260,50 @@ module Mod = struct
     { pmod_desc = d; pmod_loc = loc; pmod_attributes = attrs }
 
   let attr d a = { d with pmod_attributes = d.pmod_attributes @ [ a ] }
-
   let ident ?loc ?attrs x = mk ?loc ?attrs (Pmod_ident x)
-
   let structure ?loc ?attrs x = mk ?loc ?attrs (Pmod_structure x)
-
   let functor_ ?loc ?attrs arg body = mk ?loc ?attrs (Pmod_functor (arg, body))
-
   let apply ?loc ?attrs m1 m2 = mk ?loc ?attrs (Pmod_apply (m1, m2))
-
   let constraint_ ?loc ?attrs m mty = mk ?loc ?attrs (Pmod_constraint (m, mty))
-
   let unpack ?loc ?attrs e = mk ?loc ?attrs (Pmod_unpack e)
-
   let extension ?loc ?attrs a = mk ?loc ?attrs (Pmod_extension a)
 end
 
 module Sig = struct
   let mk ?(loc = !default_loc) d = { psig_desc = d; psig_loc = loc }
-
   let value ?loc a = mk ?loc (Psig_value a)
-
   let type_ ?loc rec_flag a = mk ?loc (Psig_type (rec_flag, a))
-
   let type_subst ?loc a = mk ?loc (Psig_typesubst a)
-
   let type_extension ?loc a = mk ?loc (Psig_typext a)
-
   let exception_ ?loc a = mk ?loc (Psig_exception a)
-
   let module_ ?loc a = mk ?loc (Psig_module a)
-
   let mod_subst ?loc a = mk ?loc (Psig_modsubst a)
-
   let rec_module ?loc a = mk ?loc (Psig_recmodule a)
-
   let modtype ?loc a = mk ?loc (Psig_modtype a)
-
   let open_ ?loc a = mk ?loc (Psig_open a)
-
   let include_ ?loc a = mk ?loc (Psig_include a)
-
   let class_ ?loc a = mk ?loc (Psig_class a)
-
   let class_type ?loc a = mk ?loc (Psig_class_type a)
-
   let extension ?loc ?(attrs = []) a = mk ?loc (Psig_extension (a, attrs))
-
   let attribute ?loc a = mk ?loc (Psig_attribute a)
 end
 
 module Str = struct
   let mk ?(loc = !default_loc) d = { pstr_desc = d; pstr_loc = loc }
-
   let eval ?loc ?(attrs = []) a = mk ?loc (Pstr_eval (a, attrs))
-
   let value ?loc a b = mk ?loc (Pstr_value (a, b))
-
   let primitive ?loc a = mk ?loc (Pstr_primitive a)
-
   let type_ ?loc rec_flag a = mk ?loc (Pstr_type (rec_flag, a))
-
   let type_extension ?loc a = mk ?loc (Pstr_typext a)
-
   let exception_ ?loc a = mk ?loc (Pstr_exception a)
-
   let module_ ?loc a = mk ?loc (Pstr_module a)
-
   let rec_module ?loc a = mk ?loc (Pstr_recmodule a)
-
   let modtype ?loc a = mk ?loc (Pstr_modtype a)
-
   let open_ ?loc a = mk ?loc (Pstr_open a)
-
   let class_ ?loc a = mk ?loc (Pstr_class a)
-
   let class_type ?loc a = mk ?loc (Pstr_class_type a)
-
   let include_ ?loc a = mk ?loc (Pstr_include a)
-
   let extension ?loc ?(attrs = []) a = mk ?loc (Pstr_extension (a, attrs))
-
   let attribute ?loc a = mk ?loc (Pstr_attribute a)
 end
 
@@ -433,21 +312,13 @@ module Cl = struct
     { pcl_desc = d; pcl_loc = loc; pcl_attributes = attrs }
 
   let attr d a = { d with pcl_attributes = d.pcl_attributes @ [ a ] }
-
   let constr ?loc ?attrs a b = mk ?loc ?attrs (Pcl_constr (a, b))
-
   let structure ?loc ?attrs a = mk ?loc ?attrs (Pcl_structure a)
-
   let fun_ ?loc ?attrs a b c d = mk ?loc ?attrs (Pcl_fun (a, b, c, d))
-
   let apply ?loc ?attrs a b = mk ?loc ?attrs (Pcl_apply (a, b))
-
   let let_ ?loc ?attrs a b c = mk ?loc ?attrs (Pcl_let (a, b, c))
-
   let constraint_ ?loc ?attrs a b = mk ?loc ?attrs (Pcl_constraint (a, b))
-
   let extension ?loc ?attrs a = mk ?loc ?attrs (Pcl_extension a)
-
   let open_ ?loc ?attrs a b = mk ?loc ?attrs (Pcl_open (a, b))
 end
 
@@ -456,15 +327,10 @@ module Cty = struct
     { pcty_desc = d; pcty_loc = loc; pcty_attributes = attrs }
 
   let attr d a = { d with pcty_attributes = d.pcty_attributes @ [ a ] }
-
   let constr ?loc ?attrs a b = mk ?loc ?attrs (Pcty_constr (a, b))
-
   let signature ?loc ?attrs a = mk ?loc ?attrs (Pcty_signature a)
-
   let arrow ?loc ?attrs a b c = mk ?loc ?attrs (Pcty_arrow (a, b, c))
-
   let extension ?loc ?attrs a = mk ?loc ?attrs (Pcty_extension a)
-
   let open_ ?loc ?attrs a b = mk ?loc ?attrs (Pcty_open (a, b))
 end
 
@@ -473,17 +339,11 @@ module Ctf = struct
     { pctf_desc = d; pctf_loc = loc; pctf_attributes = attrs }
 
   let inherit_ ?loc ?attrs a = mk ?loc ?attrs (Pctf_inherit a)
-
   let val_ ?loc ?attrs a b c d = mk ?loc ?attrs (Pctf_val (a, b, c, d))
-
   let method_ ?loc ?attrs a b c d = mk ?loc ?attrs (Pctf_method (a, b, c, d))
-
   let constraint_ ?loc ?attrs a b = mk ?loc ?attrs (Pctf_constraint (a, b))
-
   let extension ?loc ?attrs a = mk ?loc ?attrs (Pctf_extension a)
-
   let attribute ?loc a = mk ?loc (Pctf_attribute a)
-
   let attr d a = { d with pctf_attributes = d.pctf_attributes @ [ a ] }
 end
 
@@ -492,23 +352,14 @@ module Cf = struct
     { pcf_desc = d; pcf_loc = loc; pcf_attributes = attrs }
 
   let inherit_ ?loc ?attrs a b c = mk ?loc ?attrs (Pcf_inherit (a, b, c))
-
   let val_ ?loc ?attrs a b c = mk ?loc ?attrs (Pcf_val (a, b, c))
-
   let method_ ?loc ?attrs a b c = mk ?loc ?attrs (Pcf_method (a, b, c))
-
   let constraint_ ?loc ?attrs a b = mk ?loc ?attrs (Pcf_constraint (a, b))
-
   let initializer_ ?loc ?attrs a = mk ?loc ?attrs (Pcf_initializer a)
-
   let extension ?loc ?attrs a = mk ?loc ?attrs (Pcf_extension a)
-
   let attribute ?loc a = mk ?loc (Pcf_attribute a)
-
   let virtual_ ct = Cfk_virtual ct
-
   let concrete o e = Cfk_concrete (o, e)
-
   let attr d a = { d with pcf_attributes = d.pcf_attributes @ [ a ] }
 end
 
@@ -691,6 +542,5 @@ module Of = struct
     { pof_desc = desc; pof_loc = loc; pof_attributes = attrs }
 
   let tag ?loc ?attrs label ty = mk ?loc ?attrs (Otag (label, ty))
-
   let inherit_ ?loc ty = mk ?loc (Oinherit ty)
 end

--- a/ast/ast_helper_lite.mli
+++ b/ast/ast_helper_lite.mli
@@ -20,15 +20,10 @@ open Asttypes
 open Parsetree
 
 type 'a with_loc = 'a Astlib.Location.loc
-
 type loc = Astlib.Location.t
-
 type lid = Astlib.Longident.t with_loc
-
 type str = string with_loc
-
 type str_opt = string option with_loc
-
 type attrs = attribute list
 
 (** {1 Default locations} *)
@@ -44,19 +39,12 @@ val with_default_loc : loc -> (unit -> 'a) -> 'a
 
 module Const : sig
   val char : char -> constant
-
   val string : ?quotation_delimiter:string -> ?loc:loc -> string -> constant
-
   val integer : ?suffix:char -> string -> constant
-
   val int : ?suffix:char -> int -> constant
-
   val int32 : ?suffix:char -> int32 -> constant
-
   val int64 : ?suffix:char -> int64 -> constant
-
   val nativeint : ?suffix:char -> nativeint -> constant
-
   val float : ?suffix:char -> string -> constant
 end
 
@@ -70,25 +58,20 @@ end
 (** Type expressions *)
 module Typ : sig
   val mk : ?loc:loc -> ?attrs:attrs -> core_type_desc -> core_type
-
   val attr : core_type -> attribute -> core_type
-
   val any : ?loc:loc -> ?attrs:attrs -> unit -> core_type
-
   val var : ?loc:loc -> ?attrs:attrs -> string -> core_type
 
   val arrow :
     ?loc:loc -> ?attrs:attrs -> arg_label -> core_type -> core_type -> core_type
 
   val tuple : ?loc:loc -> ?attrs:attrs -> core_type list -> core_type
-
   val constr : ?loc:loc -> ?attrs:attrs -> lid -> core_type list -> core_type
 
   val object_ :
     ?loc:loc -> ?attrs:attrs -> object_field list -> closed_flag -> core_type
 
   val class_ : ?loc:loc -> ?attrs:attrs -> lid -> core_type list -> core_type
-
   val alias : ?loc:loc -> ?attrs:attrs -> core_type -> string -> core_type
 
   val variant :
@@ -105,7 +88,6 @@ module Typ : sig
     ?loc:loc -> ?attrs:attrs -> lid -> (lid * core_type) list -> core_type
 
   val extension : ?loc:loc -> ?attrs:attrs -> extension -> core_type
-
   val force_poly : core_type -> core_type
 
   val varify_constructors : str list -> core_type -> core_type
@@ -121,55 +103,35 @@ end
 (** Patterns *)
 module Pat : sig
   val mk : ?loc:loc -> ?attrs:attrs -> pattern_desc -> pattern
-
   val attr : pattern -> attribute -> pattern
-
   val any : ?loc:loc -> ?attrs:attrs -> unit -> pattern
-
   val var : ?loc:loc -> ?attrs:attrs -> str -> pattern
-
   val alias : ?loc:loc -> ?attrs:attrs -> pattern -> str -> pattern
-
   val constant : ?loc:loc -> ?attrs:attrs -> constant -> pattern
-
   val interval : ?loc:loc -> ?attrs:attrs -> constant -> constant -> pattern
-
   val tuple : ?loc:loc -> ?attrs:attrs -> pattern list -> pattern
-
   val construct : ?loc:loc -> ?attrs:attrs -> lid -> pattern option -> pattern
-
   val variant : ?loc:loc -> ?attrs:attrs -> label -> pattern option -> pattern
 
   val record :
     ?loc:loc -> ?attrs:attrs -> (lid * pattern) list -> closed_flag -> pattern
 
   val array : ?loc:loc -> ?attrs:attrs -> pattern list -> pattern
-
   val or_ : ?loc:loc -> ?attrs:attrs -> pattern -> pattern -> pattern
-
   val constraint_ : ?loc:loc -> ?attrs:attrs -> pattern -> core_type -> pattern
-
   val type_ : ?loc:loc -> ?attrs:attrs -> lid -> pattern
-
   val lazy_ : ?loc:loc -> ?attrs:attrs -> pattern -> pattern
-
   val unpack : ?loc:loc -> ?attrs:attrs -> str_opt -> pattern
-
   val open_ : ?loc:loc -> ?attrs:attrs -> lid -> pattern -> pattern
-
   val exception_ : ?loc:loc -> ?attrs:attrs -> pattern -> pattern
-
   val extension : ?loc:loc -> ?attrs:attrs -> extension -> pattern
 end
 
 (** Expressions *)
 module Exp : sig
   val mk : ?loc:loc -> ?attrs:attrs -> expression_desc -> expression
-
   val attr : expression -> attribute -> expression
-
   val ident : ?loc:loc -> ?attrs:attrs -> lid -> expression
-
   val constant : ?loc:loc -> ?attrs:attrs -> constant -> expression
 
   val let_ :
@@ -199,9 +161,7 @@ module Exp : sig
     expression
 
   val match_ : ?loc:loc -> ?attrs:attrs -> expression -> case list -> expression
-
   val try_ : ?loc:loc -> ?attrs:attrs -> expression -> case list -> expression
-
   val tuple : ?loc:loc -> ?attrs:attrs -> expression list -> expression
 
   val construct :
@@ -260,9 +220,7 @@ module Exp : sig
     ?loc:loc -> ?attrs:attrs -> expression -> core_type -> expression
 
   val send : ?loc:loc -> ?attrs:attrs -> expression -> str -> expression
-
   val new_ : ?loc:loc -> ?attrs:attrs -> lid -> expression
-
   val setinstvar : ?loc:loc -> ?attrs:attrs -> str -> expression -> expression
 
   val override :
@@ -284,16 +242,13 @@ module Exp : sig
     expression
 
   val assert_ : ?loc:loc -> ?attrs:attrs -> expression -> expression
-
   val lazy_ : ?loc:loc -> ?attrs:attrs -> expression -> expression
 
   val poly :
     ?loc:loc -> ?attrs:attrs -> expression -> core_type option -> expression
 
   val object_ : ?loc:loc -> ?attrs:attrs -> class_structure -> expression
-
   val newtype : ?loc:loc -> ?attrs:attrs -> str -> expression -> expression
-
   val pack : ?loc:loc -> ?attrs:attrs -> module_expr -> expression
 
   val open_ :
@@ -308,11 +263,8 @@ module Exp : sig
     expression
 
   val extension : ?loc:loc -> ?attrs:attrs -> extension -> expression
-
   val unreachable : ?loc:loc -> ?attrs:attrs -> unit -> expression
-
   val case : pattern -> ?guard:expression -> expression -> case
-
   val binding_op : str -> pattern -> expression -> loc -> binding_op
 end
 
@@ -394,13 +346,9 @@ end
 (** Module type expressions *)
 module Mty : sig
   val mk : ?loc:loc -> ?attrs:attrs -> module_type_desc -> module_type
-
   val attr : module_type -> attribute -> module_type
-
   val ident : ?loc:loc -> ?attrs:attrs -> lid -> module_type
-
   val alias : ?loc:loc -> ?attrs:attrs -> lid -> module_type
-
   val signature : ?loc:loc -> ?attrs:attrs -> signature -> module_type
 
   val functor_ :
@@ -414,18 +362,14 @@ module Mty : sig
     module_type
 
   val typeof_ : ?loc:loc -> ?attrs:attrs -> module_expr -> module_type
-
   val extension : ?loc:loc -> ?attrs:attrs -> extension -> module_type
 end
 
 (** Module expressions *)
 module Mod : sig
   val mk : ?loc:loc -> ?attrs:attrs -> module_expr_desc -> module_expr
-
   val attr : module_expr -> attribute -> module_expr
-
   val ident : ?loc:loc -> ?attrs:attrs -> lid -> module_expr
-
   val structure : ?loc:loc -> ?attrs:attrs -> structure -> module_expr
 
   val functor_ :
@@ -438,77 +382,46 @@ module Mod : sig
     ?loc:loc -> ?attrs:attrs -> module_expr -> module_type -> module_expr
 
   val unpack : ?loc:loc -> ?attrs:attrs -> expression -> module_expr
-
   val extension : ?loc:loc -> ?attrs:attrs -> extension -> module_expr
 end
 
 (** Signature items *)
 module Sig : sig
   val mk : ?loc:loc -> signature_item_desc -> signature_item
-
   val value : ?loc:loc -> value_description -> signature_item
-
   val type_ : ?loc:loc -> rec_flag -> type_declaration list -> signature_item
-
   val type_subst : ?loc:loc -> type_declaration list -> signature_item
-
   val type_extension : ?loc:loc -> type_extension -> signature_item
-
   val exception_ : ?loc:loc -> type_exception -> signature_item
-
   val module_ : ?loc:loc -> module_declaration -> signature_item
-
   val mod_subst : ?loc:loc -> module_substitution -> signature_item
-
   val rec_module : ?loc:loc -> module_declaration list -> signature_item
-
   val modtype : ?loc:loc -> module_type_declaration -> signature_item
-
   val open_ : ?loc:loc -> open_description -> signature_item
-
   val include_ : ?loc:loc -> include_description -> signature_item
-
   val class_ : ?loc:loc -> class_description list -> signature_item
-
   val class_type : ?loc:loc -> class_type_declaration list -> signature_item
-
   val extension : ?loc:loc -> ?attrs:attrs -> extension -> signature_item
-
   val attribute : ?loc:loc -> attribute -> signature_item
 end
 
 (** Structure items *)
 module Str : sig
   val mk : ?loc:loc -> structure_item_desc -> structure_item
-
   val eval : ?loc:loc -> ?attrs:attributes -> expression -> structure_item
-
   val value : ?loc:loc -> rec_flag -> value_binding list -> structure_item
-
   val primitive : ?loc:loc -> value_description -> structure_item
-
   val type_ : ?loc:loc -> rec_flag -> type_declaration list -> structure_item
-
   val type_extension : ?loc:loc -> type_extension -> structure_item
-
   val exception_ : ?loc:loc -> type_exception -> structure_item
-
   val module_ : ?loc:loc -> module_binding -> structure_item
-
   val rec_module : ?loc:loc -> module_binding list -> structure_item
-
   val modtype : ?loc:loc -> module_type_declaration -> structure_item
-
   val open_ : ?loc:loc -> open_declaration -> structure_item
-
   val class_ : ?loc:loc -> class_declaration list -> structure_item
-
   val class_type : ?loc:loc -> class_type_declaration list -> structure_item
-
   val include_ : ?loc:loc -> include_declaration -> structure_item
-
   val extension : ?loc:loc -> ?attrs:attrs -> extension -> structure_item
-
   val attribute : ?loc:loc -> attribute -> structure_item
 end
 
@@ -559,11 +472,8 @@ end
 (** Class type expressions *)
 module Cty : sig
   val mk : ?loc:loc -> ?attrs:attrs -> class_type_desc -> class_type
-
   val attr : class_type -> attribute -> class_type
-
   val constr : ?loc:loc -> ?attrs:attrs -> lid -> core_type list -> class_type
-
   val signature : ?loc:loc -> ?attrs:attrs -> class_signature -> class_type
 
   val arrow :
@@ -583,9 +493,7 @@ end
 (** Class type fields *)
 module Ctf : sig
   val mk : ?loc:loc -> ?attrs:attrs -> class_type_field_desc -> class_type_field
-
   val attr : class_type_field -> attribute -> class_type_field
-
   val inherit_ : ?loc:loc -> ?attrs:attrs -> class_type -> class_type_field
 
   val val_ :
@@ -610,18 +518,14 @@ module Ctf : sig
     ?loc:loc -> ?attrs:attrs -> core_type -> core_type -> class_type_field
 
   val extension : ?loc:loc -> ?attrs:attrs -> extension -> class_type_field
-
   val attribute : ?loc:loc -> attribute -> class_type_field
 end
 
 (** Class expressions *)
 module Cl : sig
   val mk : ?loc:loc -> ?attrs:attrs -> class_expr_desc -> class_expr
-
   val attr : class_expr -> attribute -> class_expr
-
   val constr : ?loc:loc -> ?attrs:attrs -> lid -> core_type list -> class_expr
-
   val structure : ?loc:loc -> ?attrs:attrs -> class_structure -> class_expr
 
   val fun_ :
@@ -660,7 +564,6 @@ end
 (** Class fields *)
 module Cf : sig
   val mk : ?loc:loc -> ?attrs:attrs -> class_field_desc -> class_field
-
   val attr : class_field -> attribute -> class_field
 
   val inherit_ :
@@ -691,13 +594,9 @@ module Cf : sig
     ?loc:loc -> ?attrs:attrs -> core_type -> core_type -> class_field
 
   val initializer_ : ?loc:loc -> ?attrs:attrs -> expression -> class_field
-
   val extension : ?loc:loc -> ?attrs:attrs -> extension -> class_field
-
   val attribute : ?loc:loc -> attribute -> class_field
-
   val virtual_ : core_type -> class_field_kind
-
   val concrete : override_flag -> expression -> class_field_kind
 end
 

--- a/ast/import.ml
+++ b/ast/import.ml
@@ -81,7 +81,6 @@ module Select_ast (Ocaml : Versions.OCaml_version) = struct
           fun (x, y) -> (f x, g y)
 
   let of_ocaml_mapper item f ctxt x = to_ocaml item x |> f ctxt |> of_ocaml item
-
   let to_ocaml_mapper item f ctxt x = of_ocaml item x |> f ctxt |> to_ocaml item
 end
 
@@ -101,7 +100,6 @@ module Parse = struct
   module Of_ocaml = Versions.Convert (Ocaml) (Js)
 
   let implementation lexbuf = implementation lexbuf |> Of_ocaml.copy_structure
-
   let interface lexbuf = interface lexbuf |> Of_ocaml.copy_signature
 
   let toplevel_phrase lexbuf =
@@ -111,8 +109,6 @@ module Parse = struct
     use_file lexbuf |> List.map Of_ocaml.copy_toplevel_phrase
 
   let core_type lexbuf = core_type lexbuf |> Of_ocaml.copy_core_type
-
   let expression lexbuf = expression lexbuf |> Of_ocaml.copy_expression
-
   let pattern lexbuf = pattern lexbuf |> Of_ocaml.copy_pattern
 end

--- a/ast/location_error.ml
+++ b/ast/location_error.ml
@@ -39,5 +39,4 @@ let get_location error =
   loc
 
 let of_exn = Astlib.Location.Error.of_exn
-
 let raise error = raise (Astlib.Location.Error error)

--- a/ast/location_error.mli
+++ b/ast/location_error.mli
@@ -3,19 +3,11 @@ open Import
 type t = Astlib.Location.Error.t
 
 val of_exn : exn -> t option
-
 val register_error_of_exn : (exn -> t option) -> unit
-
 val message : t -> string
-
 val set_message : t -> string -> t
-
 val make : loc:Location.t -> string -> sub:(Location.t * string) list -> t
-
 val to_extension : t -> Import.Parsetree.extension
-
 val raise : t -> 'a
-
 val update_loc : t -> Location.t -> t
-
 val get_location : t -> Location.t

--- a/ast/supported_version/supported_version.ml
+++ b/ast/supported_version/supported_version.ml
@@ -18,7 +18,6 @@ let all =
   ]
 
 let to_string (a, b) = Printf.sprintf "%d.%02d" a b
-
 let to_int (a, b) = (a * 100) + b
 
 let of_string s =

--- a/ast/warn.ml
+++ b/ast/warn.ml
@@ -1,9 +1,6 @@
 open! Import
 
 let default_print_warning _loc = ()
-
 let about_ite_branch_ref = ref default_print_warning
-
 let care_about_ite_branch = ref false
-
 let about_ite_branch loc = !about_ite_branch_ref loc

--- a/astlib/migrate_402_403.ml
+++ b/astlib/migrate_402_403.ml
@@ -988,7 +988,6 @@ and copy_loc :
   { To.Asttypes.txt = f0 txt; To.Asttypes.loc = copy_location loc }
 
 and copy_location : Location.t -> Location.t = fun x -> x
-
 and copy_bool : bool -> bool = function false -> false | true -> true
 
 and type_declarations types =
@@ -1017,9 +1016,6 @@ and copy_directive_argument :
   | From.Parsetree.Pdir_bool x0 -> To.Parsetree.Pdir_bool (copy_bool x0)
 
 let copy_cases x = List.map copy_case x
-
 let copy_pat = copy_pattern
-
 let copy_expr = copy_expression
-
 let copy_typ = copy_core_type

--- a/astlib/migrate_403_402.ml
+++ b/astlib/migrate_403_402.ml
@@ -1003,7 +1003,6 @@ and copy_loc :
   { To.Asttypes.txt = f0 txt; To.Asttypes.loc = copy_location loc }
 
 and copy_location : Location.t -> Location.t = fun x -> x
-
 and copy_bool : bool -> bool = function false -> false | true -> true
 
 and type_declarations recflag types =
@@ -1043,9 +1042,6 @@ and copy_directive_argument :
   | From.Parsetree.Pdir_bool x0 -> To.Parsetree.Pdir_bool (copy_bool x0)
 
 let copy_cases x = List.map copy_case x
-
 let copy_pat = copy_pattern
-
 let copy_expr = copy_expression
-
 let copy_typ = copy_core_type

--- a/astlib/migrate_403_404.ml
+++ b/astlib/migrate_403_404.ml
@@ -972,7 +972,6 @@ and copy_loc :
   { To.Asttypes.txt = f0 txt; To.Asttypes.loc = copy_location loc }
 
 and copy_location : Location.t -> Location.t = fun x -> x
-
 and copy_bool : bool -> bool = function false -> false | true -> true
 
 let rec copy_toplevel_phrase :
@@ -992,9 +991,6 @@ and copy_directive_argument :
   | From.Parsetree.Pdir_bool x0 -> To.Parsetree.Pdir_bool (copy_bool x0)
 
 let copy_cases x = List.map copy_case x
-
 let copy_pat = copy_pattern
-
 let copy_expr = copy_expression
-
 let copy_typ = copy_core_type

--- a/astlib/migrate_404_403.ml
+++ b/astlib/migrate_404_403.ml
@@ -980,7 +980,6 @@ and copy_loc :
   { To.Asttypes.txt = f0 txt; To.Asttypes.loc = copy_location loc }
 
 and copy_location : Location.t -> Location.t = fun x -> x
-
 and copy_bool : bool -> bool = function false -> false | true -> true
 
 let rec copy_toplevel_phrase :
@@ -1000,9 +999,6 @@ and copy_directive_argument :
   | From.Parsetree.Pdir_bool x0 -> To.Parsetree.Pdir_bool (copy_bool x0)
 
 let copy_cases x = List.map copy_case x
-
 let copy_pat = copy_pattern
-
 let copy_expr = copy_expression
-
 let copy_typ = copy_core_type

--- a/astlib/migrate_404_405.ml
+++ b/astlib/migrate_404_405.ml
@@ -987,7 +987,6 @@ and copy_loc :
   { To.Asttypes.txt = f0 txt; To.Asttypes.loc = copy_location loc }
 
 and copy_location : Location.t -> Location.t = fun x -> x
-
 and copy_bool : bool -> bool = function false -> false | true -> true
 
 let rec copy_toplevel_phrase :
@@ -1007,9 +1006,6 @@ and copy_directive_argument :
   | From.Parsetree.Pdir_bool x0 -> To.Parsetree.Pdir_bool (copy_bool x0)
 
 let copy_cases x = List.map copy_case x
-
 let copy_pat = copy_pattern
-
 let copy_expr = copy_expression
-
 let copy_typ = copy_core_type

--- a/astlib/migrate_405_404.ml
+++ b/astlib/migrate_405_404.ml
@@ -986,7 +986,6 @@ and copy_loc :
   { To.Asttypes.txt = f0 txt; To.Asttypes.loc = copy_location loc }
 
 and copy_location : Location.t -> Location.t = fun x -> x
-
 and copy_bool : bool -> bool = function false -> false | true -> true
 
 let rec copy_toplevel_phrase :
@@ -1006,9 +1005,6 @@ and copy_directive_argument :
   | From.Parsetree.Pdir_bool x0 -> To.Parsetree.Pdir_bool (copy_bool x0)
 
 let copy_cases x = List.map copy_case x
-
 let copy_pat = copy_pattern
-
 let copy_expr = copy_expression
-
 let copy_typ = copy_core_type

--- a/astlib/migrate_405_406.ml
+++ b/astlib/migrate_405_406.ml
@@ -989,7 +989,6 @@ and copy_loc :
   { To.Asttypes.txt = f0 txt; To.Asttypes.loc = copy_location loc }
 
 and copy_location : Location.t -> Location.t = fun x -> x
-
 and copy_bool : bool -> bool = function false -> false | true -> true
 
 let rec copy_toplevel_phrase :
@@ -1009,9 +1008,6 @@ and copy_directive_argument :
   | From.Parsetree.Pdir_bool x0 -> To.Parsetree.Pdir_bool (copy_bool x0)
 
 let copy_cases x = List.map copy_case x
-
 let copy_pat = copy_pattern
-
 let copy_expr = copy_expression
-
 let copy_typ = copy_core_type

--- a/astlib/migrate_406_405.ml
+++ b/astlib/migrate_406_405.ml
@@ -1001,7 +1001,6 @@ and copy_loc :
   { To.Asttypes.txt = f0 txt; To.Asttypes.loc = copy_location loc }
 
 and copy_location : Location.t -> Location.t = fun x -> x
-
 and copy_bool : bool -> bool = function false -> false | true -> true
 
 let rec copy_toplevel_phrase :
@@ -1021,9 +1020,6 @@ and copy_directive_argument :
   | From.Parsetree.Pdir_bool x0 -> To.Parsetree.Pdir_bool (copy_bool x0)
 
 let copy_cases x = List.map copy_case x
-
 let copy_pat = copy_pattern
-
 let copy_expr = copy_expression
-
 let copy_typ = copy_core_type

--- a/astlib/migrate_406_407.ml
+++ b/astlib/migrate_406_407.ml
@@ -997,7 +997,6 @@ and copy_loc :
   { To.Asttypes.txt = f0 txt; To.Asttypes.loc = copy_location loc }
 
 and copy_location : Location.t -> Location.t = fun x -> x
-
 and copy_bool : bool -> bool = function false -> false | true -> true
 
 let rec copy_toplevel_phrase :
@@ -1017,9 +1016,6 @@ and copy_directive_argument :
   | From.Parsetree.Pdir_bool x0 -> To.Parsetree.Pdir_bool (copy_bool x0)
 
 let copy_cases x = List.map copy_case x
-
 let copy_pat = copy_pattern
-
 let copy_expr = copy_expression
-
 let copy_typ = copy_core_type

--- a/astlib/migrate_407_406.ml
+++ b/astlib/migrate_407_406.ml
@@ -997,7 +997,6 @@ and copy_loc :
   { To.Asttypes.txt = f0 txt; To.Asttypes.loc = copy_location loc }
 
 and copy_location : Location.t -> Location.t = fun x -> x
-
 and copy_bool : bool -> bool = function false -> false | true -> true
 
 let rec copy_toplevel_phrase :
@@ -1017,9 +1016,6 @@ and copy_directive_argument :
   | From.Parsetree.Pdir_bool x0 -> To.Parsetree.Pdir_bool (copy_bool x0)
 
 let copy_cases x = List.map copy_case x
-
 let copy_pat = copy_pattern
-
 let copy_expr = copy_expression
-
 let copy_typ = copy_core_type

--- a/astlib/migrate_407_408.ml
+++ b/astlib/migrate_407_408.ml
@@ -1119,13 +1119,9 @@ and copy_loc :
   { To.Asttypes.txt = f0 txt; To.Asttypes.loc = copy_location loc }
 
 and copy_location : Location.t -> Location.t = fun x -> x
-
 and copy_bool : bool -> bool = function false -> false | true -> true
 
 let copy_cases x = List.map copy_case x
-
 let copy_pat = copy_pattern
-
 let copy_expr = copy_expression
-
 let copy_typ = copy_core_type

--- a/astlib/migrate_408_407.ml
+++ b/astlib/migrate_408_407.ml
@@ -1101,13 +1101,9 @@ and copy_loc :
   { To.Asttypes.txt = f0 txt; To.Asttypes.loc = copy_location loc }
 
 and copy_location : Location.t -> Location.t = fun x -> x
-
 and copy_bool : bool -> bool = function false -> false | true -> true
 
 let copy_cases x = List.map copy_case x
-
 let copy_pat = copy_pattern
-
 let copy_expr = copy_expression
-
 let copy_typ = copy_core_type

--- a/astlib/migrate_409_410.ml
+++ b/astlib/migrate_409_410.ml
@@ -1187,7 +1187,5 @@ and copy_loc :
 and copy_location : Location.t -> Location.t = fun x -> x
 
 let copy_expr = copy_expression
-
 let copy_pat = copy_pattern
-
 let copy_typ = copy_core_type

--- a/astlib/migrate_410_409.ml
+++ b/astlib/migrate_410_409.ml
@@ -1209,7 +1209,5 @@ and copy_loc :
 and copy_location : Location.t -> Location.t = fun x -> x
 
 let copy_expr = copy_expression
-
 let copy_pat = copy_pattern
-
 let copy_typ = copy_core_type

--- a/astlib/pprintast.ml
+++ b/astlib/pprintast.ml
@@ -128,15 +128,10 @@ let view_fixity_of_exp = function
   | _ -> `Normal
 
 let is_infix = function `Infix _ -> true | _ -> false
-
 let is_mixfix = function `Mixfix _ -> true | _ -> false
-
 let is_kwdop = function `Letop _ | `Andop _ -> true | _ -> false
-
 let first_is c str = str <> "" && str.[0] = c
-
 let last_is c str = str <> "" && str.[String.length str - 1] = c
-
 let first_is_in cs str = str <> "" && List.mem str.[0] cs
 
 (* which identifiers are in fact operators needing parentheses *)
@@ -223,11 +218,8 @@ let pp = fprintf
 type ctxt = { pipe : bool; semi : bool; ifthenelse : bool }
 
 let reset_ctxt = { pipe = false; semi = false; ifthenelse = false }
-
 let under_pipe ctxt = { ctxt with pipe = true }
-
 let under_semi ctxt = { ctxt with semi = true }
-
 let under_ifthenelse ctxt = { ctxt with ifthenelse = true }
 (*
 let reset_semi ctxt = { ctxt with semi=false }
@@ -322,7 +314,6 @@ let constant f = function
 
 (* trailing space*)
 let mutable_flag f = function Immutable -> () | Mutable -> pp f "mutable@;"
-
 let virtual_flag f = function Concrete -> () | Virtual -> pp f "virtual@;"
 
 (* trailing space added *)
@@ -337,9 +328,7 @@ let direction_flag f = function
   | Downto -> pp f "downto@ "
 
 let private_flag f = function Public -> () | Private -> pp f "private@ "
-
 let iter_loc f ctxt { txt; loc = _ } = f ctxt txt
-
 let constant_string f s = pp f "%S" s
 
 let tyvar ppf s =
@@ -350,7 +339,6 @@ let tyvar ppf s =
   else Format.fprintf ppf "'%s" s
 
 let tyvar_loc f str = tyvar f str.txt
-
 let string_quot f x = pp f "`%s" x
 
 (* c ['a,'b] *)
@@ -907,7 +895,6 @@ and simple_expr ctxt f x =
     | _ -> paren true (expression ctxt) f x
 
 and attributes ctxt f l = List.iter (attribute ctxt f) l
-
 and item_attributes ctxt f l = List.iter (item_attribute ctxt f) l
 
 and attribute ctxt f a =
@@ -1709,29 +1696,16 @@ let top_phrase f x =
   pp_print_newline f ()
 
 let core_type = core_type reset_ctxt
-
 let pattern = pattern reset_ctxt
-
 let signature = signature reset_ctxt
-
 let structure = structure reset_ctxt
-
 let class_expr = class_expr reset_ctxt
-
 let class_field = class_field reset_ctxt
-
 let class_type = class_type reset_ctxt
-
 let class_signature = class_signature reset_ctxt
-
 let class_type_field = class_type_field reset_ctxt
-
 let module_expr = module_expr reset_ctxt
-
 let module_type = module_type reset_ctxt
-
 let signature_item = signature_item reset_ctxt
-
 let structure_item = structure_item reset_ctxt
-
 let type_declaration = type_declaration reset_ctxt

--- a/astlib/pprintast.mli
+++ b/astlib/pprintast.mli
@@ -18,40 +18,23 @@ open Ast_412
 type space_formatter = (unit, Format.formatter, unit) format
 
 val toplevel_phrase : Format.formatter -> Parsetree.toplevel_phrase -> unit
-
 val expression : Format.formatter -> Parsetree.expression -> unit
-
 val string_of_expression : Parsetree.expression -> string
-
 val top_phrase : Format.formatter -> Parsetree.toplevel_phrase -> unit
-
 val core_type : Format.formatter -> Parsetree.core_type -> unit
-
 val pattern : Format.formatter -> Parsetree.pattern -> unit
-
 val signature : Format.formatter -> Parsetree.signature -> unit
-
 val structure : Format.formatter -> Parsetree.structure -> unit
-
 val string_of_structure : Parsetree.structure -> string
 
 (* Added in the ppxlib copy *)
 val class_expr : Format.formatter -> Parsetree.class_expr -> unit
-
 val class_field : Format.formatter -> Parsetree.class_field -> unit
-
 val class_type : Format.formatter -> Parsetree.class_type -> unit
-
 val class_signature : Format.formatter -> Parsetree.class_signature -> unit
-
 val class_type_field : Format.formatter -> Parsetree.class_type_field -> unit
-
 val module_expr : Format.formatter -> Parsetree.module_expr -> unit
-
 val module_type : Format.formatter -> Parsetree.module_type -> unit
-
 val signature_item : Format.formatter -> Parsetree.signature_item -> unit
-
 val structure_item : Format.formatter -> Parsetree.structure_item -> unit
-
 val type_declaration : Format.formatter -> Parsetree.type_declaration -> unit

--- a/examples/simple-deriver/ppx_deriving_accessors.ml
+++ b/examples/simple-deriver/ppx_deriving_accessors.ml
@@ -70,7 +70,6 @@ let generate_intf ~ctxt (_rec_flag, type_declarations) =
   |> List.concat
 
 let impl_generator = Deriving.Generator.V2.make_noarg generate_impl
-
 let intf_generator = Deriving.Generator.V2.make_noarg generate_intf
 
 let my_deriver =

--- a/examples/simple-extension-rewriter/ppx_get_env.ml
+++ b/examples/simple-extension-rewriter/ppx_get_env.ml
@@ -17,5 +17,4 @@ let my_extension =
     expand
 
 let rule = Ppxlib.Context_free.Rule.extension my_extension
-
 let () = Driver.register_transformation ~rules:[ rule ] "get_env"

--- a/metaquot/ppxlib_metaquot.ml
+++ b/metaquot/ppxlib_metaquot.ml
@@ -7,11 +7,8 @@ module Make (M : sig
   type result
 
   val cast : extension -> result
-
   val location : location -> result
-
   val location_stack : (location -> result) option
-
   val attributes : (location -> result) option
 
   class std_lifters : location -> [result] Ppxlib_traverse_builtins.std_lifters
@@ -20,7 +17,6 @@ struct
   let lift loc =
     object
       inherit [M.result] Ast_traverse.lift as super
-
       inherit! M.std_lifters loc
 
       method! attribute x =
@@ -86,9 +82,7 @@ module Expr = Make (struct
   type result = expression
 
   let location loc = evar ~loc:{ loc with loc_ghost = true } "loc"
-
   let location_stack = None
-
   let attributes = None
 
   class std_lifters = Ppxlib_metaquot_lifters.expression_lifters

--- a/metaquot_lifters/ppxlib_metaquot_lifters.ml
+++ b/metaquot_lifters/ppxlib_metaquot_lifters.ml
@@ -17,28 +17,19 @@ class expression_lifters loc =
         (match args with [] -> None | l -> Some (pexp_tuple ~loc l))
 
     method tuple l = pexp_tuple ~loc l
-
     method int i = eint ~loc i
-
     method int32 i = eint32 ~loc i
-
     method int64 i = eint64 ~loc i
-
     method nativeint i = enativeint ~loc i
-
     method float f = efloat ~loc (Float.to_string f)
-
     method string s = estring ~loc s
-
     method char c = echar ~loc c
-
     method bool b = ebool ~loc b
 
     method array : 'a. ('a -> expression) -> 'a array -> expression =
       fun f a -> pexp_array ~loc (List.map (Array.to_list a) ~f)
 
     method unit () = eunit ~loc
-
     method other : 'a. 'a -> expression = fun _ -> failwith "not supported"
   end
 
@@ -57,27 +48,18 @@ class pattern_lifters loc =
         (match args with [] -> None | l -> Some (ppat_tuple ~loc l))
 
     method tuple l = ppat_tuple ~loc l
-
     method int i = pint ~loc i
-
     method int32 i = pint32 ~loc i
-
     method int64 i = pint64 ~loc i
-
     method nativeint i = pnativeint ~loc i
-
     method float f = pfloat ~loc (Float.to_string f)
-
     method string s = pstring ~loc s
-
     method char c = pchar ~loc c
-
     method bool b = pbool ~loc b
 
     method array : 'a. ('a -> pattern) -> 'a array -> pattern =
       fun f a -> ppat_array ~loc (List.map (Array.to_list a) ~f)
 
     method unit () = punit ~loc
-
     method other : 'a. 'a -> pattern = fun _ -> failwith "not supported"
   end

--- a/src/ast_builder.ml
+++ b/src/ast_builder.ml
@@ -5,13 +5,9 @@ module Default = struct
     type 'a t = 'a Loc.t
 
     let loc (x : _ t) = x.loc
-
     let mk ~loc x = { loc; txt = x }
-
     let map f t = { t with txt = f t.txt }
-
     let map_lident x = map (fun x -> Longident.Lident x) x
-
     let lident ~loc x = mk ~loc (Longident.parse x)
   end
 
@@ -27,11 +23,8 @@ module Default = struct
       "Ppxlib.Ast_builder.nonrec_type_declaration: don't use this function"
 
   let eint ~loc t = pexp_constant ~loc (Pconst_integer (Int.to_string t, None))
-
   let echar ~loc t = pexp_constant ~loc (Pconst_char t)
-
   let estring ~loc t = pexp_constant ~loc (Pconst_string (t, loc, None))
-
   let efloat ~loc t = pexp_constant ~loc (Pconst_float (t, None))
 
   let eint32 ~loc t =
@@ -44,11 +37,8 @@ module Default = struct
     pexp_constant ~loc (Pconst_integer (Nativeint.to_string t, Some 'n'))
 
   let pint ~loc t = ppat_constant ~loc (Pconst_integer (Int.to_string t, None))
-
   let pchar ~loc t = ppat_constant ~loc (Pconst_char t)
-
   let pstring ~loc t = ppat_constant ~loc (Pconst_string (t, loc, None))
-
   let pfloat ~loc t = ppat_constant ~loc (Pconst_float (t, None))
 
   let pint32 ~loc t =
@@ -67,17 +57,11 @@ module Default = struct
     ppat_construct ~loc (Located.lident ~loc (Bool.to_string t)) None
 
   let evar ~loc v = pexp_ident ~loc (Located.mk ~loc (Longident.parse v))
-
   let pvar ~loc v = ppat_var ~loc (Located.mk ~loc v)
-
   let eunit ~loc = pexp_construct ~loc (Located.lident ~loc "()") None
-
   let punit ~loc = ppat_construct ~loc (Located.lident ~loc "()") None
-
   let pexp_tuple ~loc l = match l with [ x ] -> x | _ -> pexp_tuple ~loc l
-
   let ppat_tuple ~loc l = match l with [ x ] -> x | _ -> ppat_tuple ~loc l
-
   let ptyp_tuple ~loc l = match l with [ x ] -> x | _ -> ptyp_tuple ~loc l
 
   let pexp_tuple_opt ~loc l =
@@ -268,7 +252,6 @@ module Default = struct
 end
 
 module type Loc = Ast_builder_intf.Loc
-
 module type S = Ast_builder_intf.S
 
 module Make (Loc : sig
@@ -286,78 +269,43 @@ end) : S = struct
     include Default.Located
 
     let loc _ = Loc.loc
-
     let mk x = mk ~loc:Loc.loc x
-
     let lident x = lident ~loc:Loc.loc x
   end
 
   let pexp_tuple l = Default.pexp_tuple ~loc l
-
   let ppat_tuple l = Default.ppat_tuple ~loc l
-
   let ptyp_tuple l = Default.ptyp_tuple ~loc l
-
   let pexp_tuple_opt l = Default.pexp_tuple_opt ~loc l
-
   let ppat_tuple_opt l = Default.ppat_tuple_opt ~loc l
-
   let ptyp_poly vars ty = Default.ptyp_poly ~loc vars ty
-
   let pexp_apply e el = Default.pexp_apply ~loc e el
-
   let eint t = Default.eint ~loc t
-
   let echar t = Default.echar ~loc t
-
   let estring t = Default.estring ~loc t
-
   let efloat t = Default.efloat ~loc t
-
   let eint32 t = Default.eint32 ~loc t
-
   let eint64 t = Default.eint64 ~loc t
-
   let enativeint t = Default.enativeint ~loc t
-
   let ebool t = Default.ebool ~loc t
-
   let evar t = Default.evar ~loc t
-
   let pint t = Default.pint ~loc t
-
   let pchar t = Default.pchar ~loc t
-
   let pstring t = Default.pstring ~loc t
-
   let pfloat t = Default.pfloat ~loc t
-
   let pint32 t = Default.pint32 ~loc t
-
   let pint64 t = Default.pint64 ~loc t
-
   let pnativeint t = Default.pnativeint ~loc t
-
   let pbool t = Default.pbool ~loc t
-
   let pvar t = Default.pvar ~loc t
-
   let eunit = Default.eunit ~loc
-
   let punit = Default.punit ~loc
-
   let econstruct = Default.econstruct
-
   let pconstruct = Default.pconstruct
-
   let eapply e el = Default.eapply ~loc e el
-
   let eabstract ps e = Default.eabstract ~loc ps e
-
   let esequence el = Default.esequence ~loc el
-
   let elist l = Default.elist ~loc l
-
   let plist l = Default.plist ~loc l
 
   let type_constr_conv ident ~f args =
@@ -367,7 +315,6 @@ end) : S = struct
     Default.unapplied_type_constr_conv ~loc ident ~f
 
   let eta_reduce = Default.eta_reduce
-
   let eta_reduce_if_possible = Default.eta_reduce_if_possible
 
   let eta_reduce_if_possible_and_nonrec =

--- a/src/ast_builder.mli
+++ b/src/ast_builder.mli
@@ -92,7 +92,6 @@ module Default : sig
 end
 
 module type Loc = Ast_builder_intf.Loc
-
 module type S = Ast_builder_intf.S
 
 (** Build Ast helpers with the location argument factorized. *)

--- a/src/ast_builder_intf.ml
+++ b/src/ast_builder_intf.ml
@@ -8,39 +8,22 @@ module type Additional_helpers = sig
   type 'a with_loc
 
   val eint : (int -> expression) with_loc
-
   val echar : (char -> expression) with_loc
-
   val estring : (string -> expression) with_loc
-
   val efloat : (string -> expression) with_loc
-
   val eint32 : (int32 -> expression) with_loc
-
   val eint64 : (int64 -> expression) with_loc
-
   val enativeint : (nativeint -> expression) with_loc
-
   val ebool : (bool -> expression) with_loc
-
   val pint : (int -> pattern) with_loc
-
   val pchar : (char -> pattern) with_loc
-
   val pstring : (string -> pattern) with_loc
-
   val pfloat : (string -> pattern) with_loc
-
   val pint32 : (int32 -> pattern) with_loc
-
   val pint64 : (int64 -> pattern) with_loc
-
   val pnativeint : (nativeint -> pattern) with_loc
-
   val pbool : (bool -> pattern) with_loc
-
   val eunit : expression with_loc
-
   val punit : pattern with_loc
 
   val evar : (string -> expression) with_loc
@@ -54,19 +37,12 @@ module type Additional_helpers = sig
   (** Same as pexp_apply but without labels *)
 
   val eabstract : (pattern list -> expression -> expression) with_loc
-
   val esequence : (expression list -> expression) with_loc
-
   val ppat_tuple_opt : (pattern list -> pattern option) with_loc
-
   val pexp_tuple_opt : (expression list -> expression option) with_loc
-
   val pconstruct : constructor_declaration -> pattern option -> pattern
-
   val econstruct : constructor_declaration -> expression option -> expression
-
   val elist : (expression list -> expression) with_loc
-
   val plist : (pattern list -> pattern) with_loc
 
   val pstr_value_list :
@@ -138,22 +114,16 @@ end
 
 module type Located = sig
   type 'a with_loc
-
   type 'a t = 'a Loc.t
 
   val loc : _ t -> Location.t
-
   val mk : ('a -> 'a t) with_loc
-
   val map : ('a -> 'b) -> 'a t -> 'b t
-
   val map_lident : string t -> Longident.t t
-
   val lident : (string -> Longident.t t) with_loc
 end
 
 type 'a without_location = 'a
-
 type 'a with_location = loc:Location.t -> 'a
 
 module type S = sig

--- a/src/ast_pattern.ml
+++ b/src/ast_pattern.ml
@@ -2,9 +2,7 @@ open! Import
 include Ast_pattern0
 
 let save_context ctx = ctx.matched
-
 let restore_context ctx backup = ctx.matched <- backup
-
 let incr_matched c = c.matched <- c.matched + 1
 
 let parse (T f) loc ?on_error x k =
@@ -18,7 +16,6 @@ module Packed = struct
   type ('a, 'b) t = T : ('a, 'b, 'c) Ast_pattern0.t * 'b -> ('a, 'c) t
 
   let create t f = T (t, f)
-
   let parse (T (t, f)) loc x = parse t loc x f
 end
 
@@ -55,19 +52,12 @@ let cst ~to_string ?(equal = Poly.equal) v =
       else fail loc (to_string v))
 
 let int v = cst ~to_string:Int.to_string v
-
 let char v = cst ~to_string:(Printf.sprintf "%C") v
-
 let string v = cst ~to_string:(Printf.sprintf "%S") v
-
 let float v = cst ~to_string:Float.to_string v
-
 let int32 v = cst ~to_string:Int32.to_string v
-
 let int64 v = cst ~to_string:Int64.to_string v
-
 let nativeint v = cst ~to_string:Nativeint.to_string v
-
 let bool v = cst ~to_string:Bool.to_string v
 
 let false_ =
@@ -161,17 +151,11 @@ let alt (T f1) (T f2) =
           else raise e2))
 
 let ( ||| ) = alt
-
 let map (T func) ~f = T (fun ctx loc x k -> func ctx loc x (f k))
-
 let map' (T func) ~f = T (fun ctx loc x k -> func ctx loc x (f loc k))
-
 let map_result (T func) ~f = T (fun ctx loc x k -> f (func ctx loc x k))
-
 let ( >>| ) t f = map t ~f
-
 let map0 (T func) ~f = T (fun ctx loc x k -> func ctx loc x (k f))
-
 let map1 (T func) ~f = T (fun ctx loc x k -> func ctx loc x (fun a -> k (f a)))
 
 let map2 (T func) ~f =
@@ -192,62 +176,38 @@ let many (T f) =
   T (fun ctx loc l k -> k (List.map l ~f:(fun x -> f ctx loc x (fun x -> x))))
 
 let loc (T f) = T (fun ctx _loc (x : _ Loc.t) k -> f ctx x.loc x.txt k)
-
 let pack0 t = map t ~f:(fun f -> f ())
-
 let pack2 t = map t ~f:(fun f x y -> f (x, y))
-
 let pack3 t = map t ~f:(fun f x y z -> f (x, y, z))
 
 include Ast_pattern_generated
 
 let echar t = pexp_constant (pconst_char t)
-
 let estring t = pexp_constant (pconst_string t drop drop)
-
 let efloat t = pexp_constant (pconst_float t drop)
-
 let pchar t = ppat_constant (pconst_char t)
-
 let pstring t = ppat_constant (pconst_string t drop drop)
-
 let pfloat t = ppat_constant (pconst_float t drop)
-
 let int' (T f) = T (fun ctx loc x k -> f ctx loc (int_of_string x) k)
-
 let int32' (T f) = T (fun ctx loc x k -> f ctx loc (Int32.of_string x) k)
-
 let int64' (T f) = T (fun ctx loc x k -> f ctx loc (Int64.of_string x) k)
 
 let nativeint' (T f) =
   T (fun ctx loc x k -> f ctx loc (Nativeint.of_string x) k)
 
 let const_int t = pconst_integer (int' t) none
-
 let const_int32 t = pconst_integer (int32' t) (some (char 'l'))
-
 let const_int64 t = pconst_integer (int64' t) (some (char 'L'))
-
 let const_nativeint t = pconst_integer (nativeint' t) (some (char 'n'))
-
 let eint t = pexp_constant (const_int t)
-
 let eint32 t = pexp_constant (const_int32 t)
-
 let eint64 t = pexp_constant (const_int64 t)
-
 let enativeint t = pexp_constant (const_nativeint t)
-
 let pint t = ppat_constant (const_int t)
-
 let pint32 t = ppat_constant (const_int32 t)
-
 let pint64 t = ppat_constant (const_int64 t)
-
 let pnativeint t = ppat_constant (const_nativeint t)
-
 let single_expr_payload t = pstr (pstr_eval t nil ^:: nil)
-
 let no_label t = cst Asttypes.Nolabel ~to_string:(fun _ -> "Nolabel") ** t
 
 let extension (T f1) (T f2) =
@@ -288,5 +248,4 @@ let esequence (T f) =
              f ctx expr.pexp_loc expr (fun x -> x))))
 
 let of_func f = T f
-
 let to_func (T f) = f

--- a/src/ast_pattern.mli
+++ b/src/ast_pattern.mli
@@ -82,11 +82,9 @@ val parse :
 
 module Packed : sig
   type ('a, 'b, 'c) pattern = ('a, 'b, 'c) t
-
   type ('a, 'b) t
 
   val create : ('a, 'b, 'c) pattern -> 'b -> ('a, 'c) t
-
   val parse : ('a, 'b) t -> Location.t -> 'a -> 'b
 end
 with type ('a, 'b, 'c) pattern := ('a, 'b, 'c) t
@@ -135,16 +133,13 @@ val ( ||| ) : ('a, 'b, 'c) t -> ('a, 'b, 'c) t -> ('a, 'b, 'c) t
 (** Same as [alt] *)
 
 val map : ('a, 'b, 'c) t -> f:('d -> 'b) -> ('a, 'd, 'c) t
-
 val map' : ('a, 'b, 'c) t -> f:(Location.t -> 'd -> 'b) -> ('a, 'd, 'c) t
-
 val map_result : ('a, 'b, 'c) t -> f:('c -> 'd) -> ('a, 'b, 'd) t
 
 val ( >>| ) : ('a, 'b, 'c) t -> ('d -> 'b) -> ('a, 'd, 'c) t
 (** Same as [map] *)
 
 val map0 : ('a, 'b, 'c) t -> f:'v -> ('a, 'v -> 'b, 'c) t
-
 val map1 : ('a, 'v1 -> 'b, 'c) t -> f:('v1 -> 'v) -> ('a, 'v -> 'b, 'c) t
 
 val map2 :
@@ -161,36 +156,23 @@ val map2' :
   ('a, 'v -> 'b, 'c) t
 
 val nil : (_ list, 'a, 'a) t
-
 val ( ^:: ) : ('a, 'b, 'c) t -> ('a list, 'c, 'd) t -> ('a list, 'b, 'd) t
-
 val many : ('a, 'b -> 'b, 'c) t -> ('a list, 'c list -> 'd, 'd) t
-
 val int : int -> (int, 'a, 'a) t
-
 val char : char -> (char, 'a, 'a) t
-
 val string : string -> (string, 'a, 'a) t
-
 val float : float -> (float, 'a, 'a) t
-
 val int32 : int32 -> (int32, 'a, 'a) t
-
 val int64 : int64 -> (int64, 'a, 'a) t
-
 val nativeint : nativeint -> (nativeint, 'a, 'a) t
-
 val bool : bool -> (bool, 'a, 'a) t
 
 val cst :
   to_string:('a -> string) -> ?equal:('a -> 'a -> bool) -> 'a -> ('a, 'b, 'b) t
 
 val none : (_ option, 'a, 'a) t
-
 val some : ('a, 'b, 'c) t -> ('a option, 'b, 'c) t
-
 val pair : ('a1, 'b, 'c) t -> ('a2, 'c, 'd) t -> ('a1 * 'a2, 'b, 'd) t
-
 val ( ** ) : ('a1, 'b, 'c) t -> ('a2, 'c, 'd) t -> ('a1 * 'a2, 'b, 'd) t
 
 val triple :
@@ -200,11 +182,8 @@ val triple :
   ('a1 * 'a2 * 'a3, 'b, 'e) t
 
 val loc : ('a, 'b, 'c) t -> ('a Loc.t, 'b, 'c) t
-
 val pack0 : ('a, 'b, 'c) t -> ('a, unit -> 'b, 'c) t
-
 val pack2 : ('a, 'b -> 'c -> 'd, 'e) t -> ('a, 'b * 'c -> 'd, 'e) t
-
 val pack3 : ('a, 'b -> 'c -> 'd -> 'e, 'f) t -> ('a, 'b * 'c * 'd -> 'e, 'f) t
 
 include module type of Ast_pattern_generated
@@ -226,37 +205,21 @@ include module type of Ast_pattern_generated
     ]} *)
 
 val true_ : (bool, 'a, 'a) t
-
 val false_ : (bool, 'a, 'a) t
-
 val eint : (int, 'a, 'b) t -> (expression, 'a, 'b) t
-
 val echar : (char, 'a, 'b) t -> (expression, 'a, 'b) t
-
 val estring : (string, 'a, 'b) t -> (expression, 'a, 'b) t
-
 val efloat : (string, 'a, 'b) t -> (expression, 'a, 'b) t
-
 val eint32 : (int32, 'a, 'b) t -> (expression, 'a, 'b) t
-
 val eint64 : (int64, 'a, 'b) t -> (expression, 'a, 'b) t
-
 val enativeint : (nativeint, 'a, 'b) t -> (expression, 'a, 'b) t
-
 val pint : (int, 'a, 'b) t -> (pattern, 'a, 'b) t
-
 val pchar : (char, 'a, 'b) t -> (pattern, 'a, 'b) t
-
 val pstring : (string, 'a, 'b) t -> (pattern, 'a, 'b) t
-
 val pfloat : (string, 'a, 'b) t -> (pattern, 'a, 'b) t
-
 val pint32 : (int32, 'a, 'b) t -> (pattern, 'a, 'b) t
-
 val pint64 : (int64, 'a, 'b) t -> (pattern, 'a, 'b) t
-
 val pnativeint : (nativeint, 'a, 'b) t -> (pattern, 'a, 'b) t
-
 val single_expr_payload : (expression, 'a, 'b) t -> (payload, 'a, 'b) t
 
 val no_label :
@@ -278,5 +241,4 @@ val esequence :
 type context
 
 val of_func : (context -> Location.t -> 'a -> 'b -> 'c) -> ('a, 'b, 'c) t
-
 val to_func : ('a, 'b, 'c) t -> context -> Location.t -> 'a -> 'b -> 'c

--- a/src/ast_traverse.ml
+++ b/src/ast_traverse.ml
@@ -3,49 +3,41 @@ open! Import
 class map =
   object
     inherit Ppxlib_traverse_builtins.map
-
     inherit Ast.map
   end
 
 class iter =
   object
     inherit Ppxlib_traverse_builtins.iter
-
     inherit Ast.iter
   end
 
 class ['acc] fold =
   object
     inherit ['acc] Ppxlib_traverse_builtins.fold
-
     inherit ['acc] Ast.fold
   end
 
 class ['acc] fold_map =
   object
     inherit ['acc] Ppxlib_traverse_builtins.fold_map
-
     inherit ['acc] Ast.fold_map
   end
 
 class ['ctx] map_with_context =
   object
     inherit ['ctx] Ppxlib_traverse_builtins.map_with_context
-
     inherit ['ctx] Ast.map_with_context
   end
 
 class virtual ['res] lift =
   object
     inherit ['res] Ppxlib_traverse_builtins.lift
-
     inherit ['res] Ast.lift
   end
 
 let module_name = function None -> "_" | Some name -> name
-
 let enter name path = if String.is_empty path then name else path ^ "." ^ name
-
 let enter_opt name_opt path = enter (module_name name_opt) path
 
 class map_with_path =
@@ -146,31 +138,18 @@ class map_with_expansion_context =
 class sexp_of =
   object
     inherit [Sexp.t] Ast.lift
-
     method int = sexp_of_int
-
     method string = sexp_of_string
-
     method bool = sexp_of_bool
-
     method char = sexp_of_char
-
     method float = sexp_of_float
-
     method int32 = sexp_of_int32
-
     method int64 = sexp_of_int64
-
     method nativeint = sexp_of_nativeint
-
     method unit = sexp_of_unit
-
     method option = sexp_of_option
-
     method list = sexp_of_list
-
     method array : 'a. ('a -> Sexp.t) -> 'a array -> Sexp.t = sexp_of_array
-
     method other : 'a. 'a -> Sexp.t = fun _ -> Sexp.Atom "_"
 
     method record fields =

--- a/src/ast_traverse.mli
+++ b/src/ast_traverse.mli
@@ -30,53 +30,45 @@ open! Import
 class map :
   object
     inherit Ppxlib_traverse_builtins.map
-
     inherit Ast.map
   end
 
 class iter :
   object
     inherit Ppxlib_traverse_builtins.iter
-
     inherit Ast.iter
   end
 
 class ['acc] fold :
   object
     inherit ['acc] Ppxlib_traverse_builtins.fold
-
     inherit ['acc] Ast.fold
   end
 
 class ['acc] fold_map :
   object
     inherit ['acc] Ppxlib_traverse_builtins.fold_map
-
     inherit ['acc] Ast.fold_map
   end
 
 class ['ctx] map_with_context :
   object
     inherit ['ctx] Ppxlib_traverse_builtins.map_with_context
-
     inherit ['ctx] Ast.map_with_context
   end
 
 class map_with_path : [string] map_with_context
-
 class map_with_expansion_context : [Expansion_context.Base.t] map_with_context
 
 class virtual ['res] lift :
   object
     inherit ['res] Ppxlib_traverse_builtins.lift
-
     inherit ['res] Ast.lift
   end
 
 class sexp_of :
   object
     inherit [Sexp.t] Ppxlib_traverse_builtins.std_lifters
-
     inherit [Sexp.t] Ast.lift
   end
 

--- a/src/attribute.ml
+++ b/src/attribute.ml
@@ -40,59 +40,32 @@ module Context = struct
     | Object_type_field : object_field t
 
   let label_declaration = Label_declaration
-
   let constructor_declaration = Constructor_declaration
-
   let type_declaration = Type_declaration
-
   let type_extension = Type_extension
-
   let type_exception = Type_exception
-
   let extension_constructor = Extension_constructor
-
   let pattern = Pattern
-
   let core_type = Core_type
-
   let expression = Expression
-
   let value_description = Value_description
-
   let class_type = Class_type
-
   let class_type_field = Class_type_field
-
   let class_infos = Class_infos
-
   let class_expr = Class_expr
-
   let class_field = Class_field
-
   let module_type = Module_type
-
   let module_declaration = Module_declaration
-
   let module_type_declaration = Module_type_declaration
-
   let open_description = Open_description
-
   let include_infos = Include_infos
-
   let module_expr = Module_expr
-
   let value_binding = Value_binding
-
   let module_binding = Module_binding
-
   let pstr_eval = Pstr_eval
-
   let pstr_extension = Pstr_extension
-
   let psig_extension = Psig_extension
-
   let rtag = Rtag
-
   let object_type_field = Object_type_field
 
   let get_pstr_eval st =
@@ -242,11 +215,8 @@ module Floating_context = struct
     | Class_type_field : class_type_field t
 
   let structure_item = Structure_item
-
   let signature_item = Signature_item
-
   let class_field = Class_field
-
   let class_type_field = Class_type_field
 
   let get_attribute_if_is_floating_node : type a. a t -> a -> attribute option =
@@ -299,7 +269,6 @@ type ('a, 'b) t = {
 type packed = T : (_, _) t -> packed
 
 let name t = Name.Pattern.name t.name
-
 let context t = t.context
 
 let registrar =
@@ -323,20 +292,16 @@ module Attribute_table = Caml.Hashtbl.Make (struct
   type t = string loc
 
   let hash : t -> int = Hashtbl.hash
-
   let equal : t -> t -> bool = Poly.equal
 end)
 
 let not_seen = Attribute_table.create 128
-
 let mark_as_seen { attr_name; _ } = Attribute_table.remove not_seen attr_name
-
 let mark_as_handled_manually = mark_as_seen
 
 let explicitly_drop =
   object
     inherit Ast_traverse.iter
-
     method! attribute = mark_as_seen
   end
 
@@ -513,9 +478,7 @@ let check_unused =
       super#extension_constructor (self#check_node Extension_constructor x)
 
     method! pattern x = super#pattern (self#check_node Pattern x)
-
     method! core_type x = super#core_type (self#check_node Core_type x)
-
     method! expression x = super#expression (self#check_node Expression x)
 
     method! value_description x =
@@ -527,7 +490,6 @@ let check_unused =
       super#class_infos f (self#check_node Class_infos x)
 
     method! class_expr x = super#class_expr (self#check_node Class_expr x)
-
     method! module_type x = super#module_type (self#check_node Module_type x)
 
     method! module_declaration x =

--- a/src/attribute.mli
+++ b/src/attribute.mli
@@ -48,59 +48,32 @@ module Context : sig
     | Object_type_field : object_field t
 
   val label_declaration : label_declaration t
-
   val constructor_declaration : constructor_declaration t
-
   val type_declaration : type_declaration t
-
   val type_extension : type_extension t
-
   val type_exception : type_exception t
-
   val extension_constructor : extension_constructor t
-
   val pattern : pattern t
-
   val core_type : core_type t
-
   val expression : expression t
-
   val value_description : value_description t
-
   val class_type : class_type t
-
   val class_type_field : class_type_field t
-
   val class_infos : _ class_infos t
-
   val class_expr : class_expr t
-
   val class_field : class_field t
-
   val module_type : module_type t
-
   val module_declaration : module_declaration t
-
   val module_type_declaration : module_type_declaration t
-
   val open_description : open_description t
-
   val include_infos : _ include_infos t
-
   val module_expr : module_expr t
-
   val value_binding : value_binding t
-
   val module_binding : module_binding t
-
   val pstr_eval : structure_item t
-
   val pstr_extension : structure_item t
-
   val psig_extension : signature_item t
-
   val rtag : row_field t
-
   val object_type_field : object_field t
 end
 
@@ -155,7 +128,6 @@ val declare_with_name_loc :
     attribute. *)
 
 val name : _ t -> string
-
 val context : ('a, _) t -> 'a Context.t
 
 val get :
@@ -182,11 +154,8 @@ module Floating : sig
       | Class_type_field : class_type_field t
 
     val structure_item : structure_item t
-
     val signature_item : signature_item t
-
     val class_field : class_field t
-
     val class_type_field : class_type_field t
   end
 
@@ -198,7 +167,6 @@ module Floating : sig
     ('a, 'c) t
 
   val name : _ t -> string
-
   val convert : ('a, 'b) t list -> 'a -> 'b option
 end
 
@@ -231,7 +199,6 @@ val dropped_so_far_structure : structure -> string Loc.t list
     debug extensions that drop attributes. *)
 
 val dropped_so_far_signature : signature -> string Loc.t list
-
 val reset_checks : unit -> unit
 
 val pattern :

--- a/src/code_matcher.ml
+++ b/src/code_matcher.ml
@@ -22,7 +22,6 @@ module Make (M : sig
   type t
 
   val get_loc : t -> Location.t
-
   val end_marker : (t, unit) Attribute.Floating.t
 
   module Transform (T : T1) : sig
@@ -34,9 +33,7 @@ module Make (M : sig
   end
 
   val parse : Lexing.lexbuf -> t list
-
   val pp : Format.formatter -> t -> unit
-
   val to_sexp : t -> Sexp.t
 end) =
 struct
@@ -59,9 +56,7 @@ struct
   let remove_loc =
     object
       inherit Ast_traverse.map
-
       method! location _ = Location.none
-
       method! location_stack _ = []
     end
 
@@ -70,7 +65,6 @@ struct
   end)
 
   let remove_loc x = M_map.apply remove_loc x
-
   let rec last prev = function [] -> prev | x :: l -> last x l
 
   let diff_asts ~generated ~round_trip =
@@ -153,7 +147,6 @@ module Str = Make (struct
   type t = structure_item
 
   let get_loc x = x.pstr_loc
-
   let end_marker = end_marker_str
 
   module Transform (T : T1) = struct
@@ -161,9 +154,7 @@ module Str = Make (struct
   end
 
   let parse = Parse.implementation
-
   let pp = Pprintast.structure_item
-
   let to_sexp = Ast_traverse.sexp_of#structure_item
 end)
 
@@ -172,7 +163,6 @@ module Sig = Make (struct
   type t = signature_item
 
   let get_loc x = x.psig_loc
-
   let end_marker = end_marker_sig
 
   module Transform (T : T1) = struct
@@ -180,14 +170,11 @@ module Sig = Make (struct
   end
 
   let parse = Parse.interface
-
   let pp = Pprintast.signature_item
-
   let to_sexp = Ast_traverse.sexp_of#signature_item
 end)
 
 (*$*)
 
 let match_structure = Str.do_match
-
 let match_signature = Sig.do_match

--- a/src/code_path.ml
+++ b/src/code_path.ml
@@ -22,7 +22,6 @@ let top_level ~file_path =
   }
 
 let file_path t = t.file_path
-
 let main_module_name t = t.main_module_name
 
 let submodule_path t =
@@ -49,7 +48,6 @@ let enter_value ~loc value_name t =
   if t.in_expr then t else { t with value = Some { txt = value_name; loc } }
 
 let to_string_path t = String.concat ~sep:"." (t.file_path :: submodule_path t)
-
 let with_string_path f ~loc ~path = f ~loc ~path:(to_string_path path);;
 
 let module M = struct

--- a/src/common.ml
+++ b/src/common.ml
@@ -81,9 +81,7 @@ exception Type_is_recursive
 class type_is_recursive rec_flag tds =
   object (self)
     inherit Ast_traverse.iter as super
-
     val type_names : string list = List.map tds ~f:(fun td -> td.ptype_name.txt)
-
     method return_true () = raise_notrace Type_is_recursive
 
     method! core_type ctype =
@@ -113,7 +111,6 @@ class type_is_recursive rec_flag tds =
   end
 
 let really_recursive rec_flag tds = (new type_is_recursive rec_flag tds)#go ()
-
 let rec last x l = match l with [] -> x | x :: l -> last x l
 
 let loc_of_name_and_payload name payload =
@@ -172,7 +169,6 @@ let rec assert_no_attributes = function
 let assert_no_attributes_in =
   object
     inherit Ast_traverse.iter
-
     method! attribute a = assert_no_attributes [ a ]
   end
 

--- a/src/common.mli
+++ b/src/common.mli
@@ -1,9 +1,7 @@
 open! Import
 
 val lident : string -> Longident.t
-
 val core_type_of_type_declaration : type_declaration -> core_type
-
 val name_type_params_in_td : type_declaration -> type_declaration
 
 val combinator_type_of_type_declaration :
@@ -15,9 +13,7 @@ val gen_symbol : ?prefix:string -> unit -> string
     @param prefix default = "_x" *)
 
 val string_of_core_type : core_type -> string
-
 val assert_no_attributes : attributes -> unit
-
 val assert_no_attributes_in : Ast_traverse.iter
 
 val get_type_param_name : core_type * (variance * injectivity) -> string Loc.t
@@ -33,11 +29,8 @@ class type_is_recursive :
   -> type_declaration list
   -> object
        inherit Ast_traverse.iter
-
        val type_names : string list
-
        method return_true : unit -> unit
-
        method go : unit -> rec_flag
      end
 
@@ -45,9 +38,7 @@ val really_recursive : rec_flag -> type_declaration list -> rec_flag
 (** [really_recursive rec_flag tds = (new type_is_recursive rec_flag tds)#go ()] *)
 
 val loc_of_payload : attribute -> Location.t
-
 val loc_of_attribute : attribute -> Location.t
-
 val loc_of_extension : extension -> Location.t
 
 val curry_applications : expression -> expression

--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -188,7 +188,6 @@ module Generated_code_hook = struct
   }
 
   let nop = { f = (fun _ _ _ -> ()) }
-
   let replace t context loc x = t.f context loc x
 
   let insert_after t context (loc : Location.t) x =

--- a/src/context_free.mli
+++ b/src/context_free.mli
@@ -101,15 +101,10 @@ module Rule : sig
     (signature_item, module_type_declaration, _) attr_inline
 
   val attr_str_type_ext : (structure_item, type_extension, _) attr_inline
-
   val attr_sig_type_ext : (signature_item, type_extension, _) attr_inline
-
   val attr_str_type_ext_expect : (structure_item, type_extension, _) attr_inline
-
   val attr_sig_type_ext_expect : (signature_item, type_extension, _) attr_inline
-
   val attr_str_exception : (structure_item, type_exception, _) attr_inline
-
   val attr_sig_exception : (signature_item, type_exception, _) attr_inline
 
   val attr_str_exception_expect :

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -5,9 +5,7 @@ open Ast_builder.Default
    contains compiler attribute to disable unused warnings, instead of
    inserting [let _ = ... ]. *)
 let do_insert_unused_warning_attribute = ref false
-
 let keep_w32_impl = ref false
-
 let keep_w32_intf = ref false
 
 let () =
@@ -40,11 +38,8 @@ let () =
     ~doc:" Deprecated, use -deriving-disable-w32-method"
 
 let keep_w32_impl () = !keep_w32_impl || Driver.pretty ()
-
 let keep_w32_intf () = !keep_w32_intf || Driver.pretty ()
-
 let keep_w60_impl = ref false
-
 let keep_w60_intf = ref false
 
 let () =
@@ -63,7 +58,6 @@ let () =
     ~doc:" Do not try to disable warning 60 for the generated code"
 
 let keep_w60_impl () = !keep_w60_impl || Driver.pretty ()
-
 let keep_w60_intf () = !keep_w60_intf || Driver.pretty ()
 
 module Args = struct
@@ -96,7 +90,6 @@ module Args = struct
     | Cons : ('m1, 'a -> 'm2) t * 'a param -> ('m1, 'm2) t
 
   let empty = Nil
-
   let ( +> ) a b = Cons (a, b)
 
   let rec names : type a b. (a, b) t -> string list = function
@@ -321,7 +314,6 @@ module Deriver = struct
   end
 
   type t = Actual_deriver of Actual_deriver.t | Alias of Alias.t
-
   type Ppx_derivers.deriver += T of t
 
   let derivers () =
@@ -467,7 +459,6 @@ module Deriver = struct
 end
 
 let add = Deriver.add
-
 let add_alias = Deriver.add_alias
 
 (* +-----------------------------------------------------------------+

--- a/src/deriving.mli
+++ b/src/deriving.mli
@@ -5,7 +5,6 @@ open Import
 (** Specification of generator arguments *)
 module Args : sig
   type ('a, 'b) t
-
   type 'a param
 
   val empty : ('m, 'm) t
@@ -44,7 +43,6 @@ type t
 
 module Generator : sig
   type deriver = t
-
   type ('output_ast, 'input_ast) t
 
   val make :

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -4,41 +4,23 @@ open Utils
 module Arg = Caml.Arg
 
 let exe_name = Caml.Filename.basename Caml.Sys.executable_name
-
 let args = ref []
-
 let add_arg key spec ~doc = args := (key, spec, doc) :: !args
-
 let loc_fname = ref None
-
 let perform_checks = ref Options.perform_checks
-
 let perform_checks_on_extensions = ref Options.perform_checks_on_extensions
-
 let perform_locations_check = ref Options.perform_locations_check
-
 let debug_attribute_drop = ref false
-
 let apply_list = ref None
-
 let preprocessor = ref None
-
 let no_merge = ref false
-
 let request_print_passes = ref false
-
 let request_print_transformations = ref false
-
 let use_color = ref true
-
 let diff_command = ref Options.diff_command
-
 let pretty = ref false
-
 let styler = ref None
-
 let output_metadata_filename = ref None
-
 let corrected_suffix = ref ".ppx-corrected"
 
 module Lint_error = struct
@@ -61,18 +43,14 @@ module Cookies = struct
     Astlib.Ast_metadata.set_cookie name (Selected_ast.to_ocaml Expression expr)
 
   let handlers = ref []
-
   let add_handler f = handlers := !handlers @ [ f ]
 
   let add_simple_handler name pattern ~f =
     add_handler (fun T -> f (get T name pattern))
 
   let acknowledge_cookies T = List.iter !handlers ~f:(fun f -> f T)
-
   let post_handlers = ref []
-
   let add_post_handler f = post_handlers := !post_handlers @ [ f ]
-
   let call_post_handlers T = List.iter !post_handlers ~f:(fun f -> f T)
 end
 
@@ -854,7 +832,6 @@ let add_cookies (ast : Intf_or_impl.t) : Intf_or_impl.t =
   | Impl x -> Impl (add_cookies_str x)
 
 let corrections = ref []
-
 let add_to_list r x = r := x :: !r
 
 let register_correction ~loc ~repl =
@@ -863,7 +840,6 @@ let register_correction ~loc ~repl =
        ~repl)
 
 let process_file_hooks = ref []
-
 let register_process_file_hook f = add_to_list process_file_hooks f
 
 module File_property = struct
@@ -876,9 +852,7 @@ module File_property = struct
   type packed = T : _ t -> packed
 
   let all = ref []
-
   let register t = add_to_list all (T t)
-
   let reset_all () = List.iter !all ~f:(fun (T t) -> t.data <- None)
 
   let dump_and_reset_all () =
@@ -899,7 +873,6 @@ struct
     { name = Name.name; data = None; sexp_of_t = T.sexp_of_t }
 
   let () = File_property.register t
-
   let set x = t.data <- Some x
 end
 
@@ -1043,13 +1016,9 @@ let process_file (kind : Kind.t) fn ~input_name ~relocate ~output_mode
     Caml.exit 1)
 
 let output_mode = ref Pretty_print
-
 let output = ref None
-
 let kind = ref None
-
 let input = ref None
-
 let embed_errors = ref false
 
 let set_input fn =
@@ -1415,7 +1384,5 @@ let enable_checks () =
   perform_checks_on_extensions := true
 
 let enable_location_check () = perform_locations_check := true
-
 let disable_location_check () = perform_locations_check := false
-
 let map_structure st = map_structure st

--- a/src/driver.mli
+++ b/src/driver.mli
@@ -41,7 +41,6 @@ end
 
 module Instrument : sig
   type t
-
   type pos = Before | After
 
   val make : (Parsetree.structure -> Parsetree.structure) -> position:pos -> t
@@ -252,11 +251,7 @@ val pretty : unit -> bool
 (**/**)
 
 val map_structure : structure -> structure
-
 val map_signature : signature -> signature
-
 val enable_checks : unit -> unit
-
 val enable_location_check : unit -> unit
-
 val disable_location_check : unit -> unit

--- a/src/expansion_context.ml
+++ b/src/expansion_context.ml
@@ -6,11 +6,8 @@ module Base = struct
     { tool_name; code_path; input_name }
 
   let code_path t = t.code_path
-
   let input_name t = t.input_name
-
   let tool_name t = t.tool_name
-
   let enter_expr t = { t with code_path = Code_path.enter_expr t.code_path }
 
   let enter_module ~loc name t =
@@ -24,13 +21,9 @@ module Extension = struct
   type t = { extension_point_loc : Location.t; base : Base.t }
 
   let make ~extension_point_loc ~base () = { extension_point_loc; base }
-
   let extension_point_loc t = t.extension_point_loc
-
   let code_path t = t.base.code_path
-
   let input_name t = t.base.input_name
-
   let tool_name t = t.base.tool_name
 
   let with_loc_and_path f ~ctxt =
@@ -45,13 +38,9 @@ module Deriver = struct
     { derived_item_loc; base; inline }
 
   let derived_item_loc t = t.derived_item_loc
-
   let code_path t = t.base.code_path
-
   let input_name t = t.base.input_name
-
   let tool_name t = t.base.tool_name
-
   let inline t = t.inline
 
   let with_loc_and_path f ~ctxt =

--- a/src/expansion_context.mli
+++ b/src/expansion_context.mli
@@ -39,7 +39,6 @@ module Base : sig
       details. *)
 
   val enter_module : loc:Location.t -> string -> t -> t
-
   val enter_value : loc:Location.t -> string -> t -> t
 end
 

--- a/src/extension.ml
+++ b/src/extension.ml
@@ -21,25 +21,15 @@ module Context = struct
   type packed = T : _ t -> packed
 
   let class_expr = Class_expr
-
   let class_field = Class_field
-
   let class_type = Class_type
-
   let class_type_field = Class_type_field
-
   let core_type = Core_type
-
   let expression = Expression
-
   let module_expr = Module_expr
-
   let module_type = Module_type
-
   let pattern = Pattern
-
   let signature_item = Signature_item
-
   let structure_item = Structure_item
 
   let desc : type a. a t -> string = function
@@ -396,6 +386,5 @@ module V2 = struct
   type nonrec t = t
 
   let declare = declare
-
   let declare_inline = declare_inline
 end

--- a/src/extension.mli
+++ b/src/extension.mli
@@ -19,31 +19,18 @@ module Context : sig
         (** For ppx_import compat only, please do not use *)
 
   val class_expr : class_expr t
-
   val class_field : class_field t
-
   val class_type : class_type t
-
   val class_type_field : class_type_field t
-
   val core_type : core_type t
-
   val expression : expression t
-
   val module_expr : module_expr t
-
   val module_type : module_type t
-
   val pattern : pattern t
-
   val signature_item : signature_item t
-
   val structure_item : structure_item t
-
   val eq : 'a t -> 'b t -> ('a, 'b) equality
-
   val get_extension : 'a t -> 'a -> (extension * attributes) option
-
   val merge_attributes : 'a t -> 'a -> attributes -> 'a
 end
 

--- a/src/file_path.mli
+++ b/src/file_path.mli
@@ -3,7 +3,5 @@ open! Import
 (** Return the path used as root in a file *)
 
 val get_default_path : Location.t -> string
-
 val get_default_path_str : structure -> string
-
 val get_default_path_sig : signature -> string

--- a/src/gen/gen_ast_builder.ml
+++ b/src/gen/gen_ast_builder.ml
@@ -214,7 +214,6 @@ let generate filename =
   dump "ast_builder_generated" Pprintast.structure st ~ext:".ml"
 
 let args = []
-
 let usage = Printf.sprintf "%s [options] <.ml files>\n" Sys.argv.(0)
 
 let () =

--- a/src/gen/gen_ast_pattern.ml
+++ b/src/gen/gen_ast_pattern.ml
@@ -237,7 +237,6 @@ let generate filename =
   dump "ast_pattern_generated" Pprintast.structure st ~ext:".ml"
 
 let args = []
-
 let usage = Printf.sprintf "%s [options] <.ml files>\n" Sys.argv.(0)
 
 let () =

--- a/src/gen/import.ml
+++ b/src/gen/import.ml
@@ -12,7 +12,6 @@ let lident x = Longident.Lident x
 
 module Loc = struct
   let mk x = { Location.loc; txt = x }
-
   let lident x = mk (Longident.parse x) [@@warning "-3"]
 end
 
@@ -21,7 +20,6 @@ module String = Stdppx.String
 module Array = Stdppx.Array
 
 let evar v = Exp.ident (Loc.lident v)
-
 let pvar v = Pat.var (Loc.mk v)
 
 let common_prefix l =
@@ -73,7 +71,6 @@ let fqn_longident' path s : Longident.t =
   | Lapply _ -> assert false
 
 let fqn_longident path id : Longident.t = fqn_longident' path id
-
 let is_loc = function Lident "loc" -> true | _ -> false
 
 let get_types ~filename =
@@ -81,7 +78,6 @@ let get_types ~filename =
   let map =
     object
       inherit Ast.map as super
-
       inherit Ppxlib_traverse_builtins.map
 
       method! core_type_desc =
@@ -120,13 +116,9 @@ let is_wrapper ~prefix lds =
 (* Small metaquotation system *)
 module M = struct
   let parse f fmt = Format.kasprintf (fun s -> f (Lexing.from_string s)) fmt
-
   let expr fmt = parse Parse.expression fmt
-
   let patt fmt = parse Parse.pattern fmt
-
   let ctyp fmt = parse Parse.core_type fmt
-
   let str fmt = parse Parse.implementation fmt
 
   let stri fmt =
@@ -141,11 +133,8 @@ end
 (* Antiquotations *)
 module A = struct
   let expr = Pprintast.expression
-
   let patt = Pprintast.pattern
-
   let ctyp = Pprintast.core_type
-
   let str = Pprintast.structure
 
   let id ppf x =

--- a/src/ignore_unused_warning.mli
+++ b/src/ignore_unused_warning.mli
@@ -1,3 +1,2 @@
 val add_dummy_user_for_values : Ast_traverse.map
-
 val binds_module_names : bool Ast_traverse.fold

--- a/src/loc.ml
+++ b/src/loc.ml
@@ -3,9 +3,6 @@ open! Import
 type 'a t = 'a loc = { txt : 'a; loc : Location.t }
 
 let txt t = t.txt
-
 let loc t = t.loc
-
 let make ~loc txt = { loc; txt }
-
 let map t ~f = { t with txt = f t.txt }

--- a/src/loc.mli
+++ b/src/loc.mli
@@ -5,9 +5,6 @@ open! Import
 type 'a t = 'a loc = { txt : 'a; loc : Location.t }
 
 val txt : 'a t -> 'a
-
 val loc : _ t -> Location.t
-
 val make : loc:Location.t -> 'a -> 'a t
-
 val map : 'a t -> f:('a -> 'b) -> 'b t

--- a/src/location.ml
+++ b/src/location.ml
@@ -24,7 +24,6 @@ let init lexbuf fname =
     { pos_fname = fname; pos_lnum = 1; pos_bol = 0; pos_cnum = 0 }
 
 let raise_errorf ?loc fmt = L.raise_errorf ?loc fmt
-
 let report_exception = L.report_exception
 
 let of_lexbuf (lexbuf : Lexing.lexbuf) =
@@ -56,7 +55,6 @@ let compare_pos p1 p2 =
   | n -> n
 
 let min_pos p1 p2 = if compare_pos p1 p2 <= 0 then p1 else p2
-
 let max_pos p1 p2 = if compare_pos p1 p2 >= 0 then p1 else p2
 
 let compare loc1 loc2 =

--- a/src/location.mli
+++ b/src/location.mli
@@ -40,16 +40,12 @@ val print : Caml.Format.formatter -> t -> unit
 type nonrec 'a loc = 'a loc = { txt : 'a; loc : t }
 
 val compare_pos : Lexing.position -> Lexing.position -> int
-
 val min_pos : Lexing.position -> Lexing.position -> Lexing.position
-
 val max_pos : Lexing.position -> Lexing.position -> Lexing.position
-
 val compare : t -> t -> int
 
 module Error : sig
   type location = t
-
   type t
 
   val make : loc:location -> string -> sub:(location * string) list -> t
@@ -58,7 +54,6 @@ module Error : sig
     loc:location -> ('a, Caml.Format.formatter, unit, t) format4 -> 'a
 
   val message : t -> string
-
   val set_message : t -> string -> t
 
   val register_error_of_exn : (exn -> t option) -> unit

--- a/src/location_check.ml
+++ b/src/location_check.ml
@@ -4,9 +4,7 @@ module Non_intersecting_ranges : sig
   type t
 
   val empty : t
-
   val insert : node_name:string -> Location.t -> t -> t
-
   val union : t -> t -> t
 
   val covered_by : t -> loc:Location.t -> bool
@@ -134,7 +132,6 @@ let all_payloads_inside_parent ~loc =
       Location.compare_pos loc.loc_end attr.attr_loc.loc_end >= 0)
 
 let file : string option ref = ref None
-
 let same_file_so_far = ref true
 
 let stayed_in_the_same_file fname =

--- a/src/longident.mli
+++ b/src/longident.mli
@@ -5,11 +5,8 @@ open! Import
 type t = longident = Lident of string | Ldot of t * string | Lapply of t * t
 
 val compare : t -> t -> int
-
 val sexp_of_t : t -> Sexp.t
-
 val flatten_exn : t -> string list
-
 val last_exn : t -> string
 
 val parse : string -> t
@@ -20,5 +17,4 @@ val parse : string -> t
 val name : t -> string
 
 module Map : Map.S with type key = t
-
 module Set : Set.S with type elt = t

--- a/src/merlin_helpers.ml
+++ b/src/merlin_helpers.ml
@@ -1,9 +1,7 @@
 open! Import
 
 let mk_attr_noloc txt = Ast_helper.Attr.mk Location.{ txt; loc = none }
-
 let hide_attribute : attribute = mk_attr_noloc "merlin.hide" (PStr [])
-
 let focus_attribute : attribute = mk_attr_noloc "merlin.focus" (PStr [])
 
 let hide_pattern ({ ppat_attributes; _ } as p) =

--- a/src/merlin_helpers.mli
+++ b/src/merlin_helpers.mli
@@ -20,9 +20,6 @@ val focus_attribute : attribute
     specific pieces of AST. *)
 
 val hide_pattern : pattern -> pattern
-
 val focus_pattern : pattern -> pattern
-
 val hide_expression : expression -> expression
-
 val focus_expression : expression -> expression

--- a/src/name.ml
+++ b/src/name.ml
@@ -41,7 +41,6 @@ module Pattern = struct
     { name; dot_suffixes = String.Set.of_list (dot_suffixes name) }
 
   let name t = t.name
-
   let matches t matched = String.Set.mem matched t.dot_suffixes
 end
 
@@ -109,23 +108,16 @@ module Whitelisted = struct
     | `Extension -> String.Set.mem name extensions
 
   let get_attribute_list () = String.Set.elements attributes
-
   let get_extension_list () = String.Set.elements extensions
 end
 
 module Reserved_namespaces = struct
   let tbl : (string, unit) Hashtbl.t = Hashtbl.create 16
-
   let reserve ns = Hashtbl.add_exn tbl ~key:ns ~data:()
-
   let () = reserve "merlin"
-
   let () = reserve "reason"
-
   let () = reserve "refmt"
-
   let () = reserve "metaocaml"
-
   let () = reserve "ocamlformat"
 
   let is_in_reserved_namespaces name =
@@ -157,7 +149,6 @@ let ignore_checks name =
 
 module Registrar = struct
   type element = { fully_qualified_name : string; declared_at : Caller_id.t }
-
   type all_for_context = { mutable all : element String.Map.t }
 
   type 'a t = {

--- a/src/name.mli
+++ b/src/name.mli
@@ -65,9 +65,7 @@ end
 
 module Whitelisted : sig
   val get_attribute_list : unit -> string list
-
   val get_extension_list : unit -> string list
-
   val is_whitelisted : kind:[ `Attribute | `Extension ] -> string -> bool
 end
 

--- a/src/options.ml
+++ b/src/options.ml
@@ -5,9 +5,6 @@ let perform_checks = false
    them externally to make it easier to use non ppxlib based
    rewriters with ppxlib *)
 let perform_checks_on_extensions = false
-
 let perform_locations_check = false
-
 let fail_on_duplicate_derivers = false
-
 let diff_command = None

--- a/src/reconcile.ml
+++ b/src/reconcile.ml
@@ -145,7 +145,6 @@ let generated_code_end =
   "(* -----{ GENERATED CODE END   }------------------------------------- *)"
 
 type mode = Using_line_directives | Delimiting_generated_blocks
-
 type target = Output of mode | Corrected
 
 let skip_blank_eol contents (pos : Lexing.position) =

--- a/src/reconcile.mli
+++ b/src/reconcile.mli
@@ -23,7 +23,6 @@ module Replacement : sig
 end
 
 type mode = Using_line_directives | Delimiting_generated_blocks
-
 type target = Output of mode | Corrected
 
 val reconcile :

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -14,7 +14,6 @@ module Kind = struct
     else None
 
   let describe = function Impl -> "implementation" | Intf -> "interface"
-
   let equal : t -> t -> bool = Poly.equal
 end
 
@@ -54,7 +53,6 @@ module Ast_io = struct
     | System_error of Location.Error.t * input_version
 
   type input_source = Stdin | File of string
-
   type input_kind = Possibly_source of Kind.t * string | Necessarily_binary
 
   let read_error_to_string (error : read_error) =
@@ -191,7 +189,6 @@ module Ast_io = struct
 
   module Read_bin = struct
     type ast = Intf of signature | Impl of structure
-
     type t = { ast : ast; input_name : string }
 
     let read_binary fn =
@@ -208,7 +205,6 @@ module Ast_io = struct
       | Error e -> Error (read_error_to_string e)
 
     let get_ast t = t.ast
-
     let get_input_name t = t.input_name
   end
 end

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -6,9 +6,7 @@ module Kind : sig
   type t = Intf | Impl
 
   val of_filename : string -> t option
-
   val describe : t -> string
-
   val equal : t -> t -> bool
 end
 
@@ -16,9 +14,7 @@ module Intf_or_impl : sig
   type t = Intf of signature | Impl of structure
 
   val map : t -> Ast_traverse.map -> t
-
   val map_with_context : t -> 'a Ast_traverse.map_with_context -> 'a -> t
-
   val kind : t -> Kind.t
 end
 
@@ -40,22 +36,17 @@ module Ast_io : sig
     | System_error of Location.Error.t * input_version
 
   type input_source = Stdin | File of string
-
   type input_kind = Possibly_source of Kind.t * string | Necessarily_binary
 
   val read : input_source -> input_kind:input_kind -> (t, read_error) result
-
   val write : out_channel -> t -> add_ppx_context:bool -> unit
 
   module Read_bin : sig
     type ast = Intf of signature | Impl of structure
-
     type t
 
     val read_binary : string -> (t, string) result
-
     val get_ast : t -> ast
-
     val get_input_name : t -> string
   end
 end

--- a/stdppx/stdppx.ml
+++ b/stdppx/stdppx.ml
@@ -9,50 +9,31 @@ module type Comparisons = sig
   type t
 
   val compare : t -> t -> int
-
   val equal : t -> t -> bool
-
   val ( = ) : t -> t -> bool
-
   val ( < ) : t -> t -> bool
-
   val ( > ) : t -> t -> bool
-
   val ( <> ) : t -> t -> bool
-
   val ( <= ) : t -> t -> bool
-
   val ( >= ) : t -> t -> bool
-
   val min : t -> t -> t
-
   val max : t -> t -> t
 end
 
 module Poly = struct
   let compare = compare
-
   let equal = ( = )
-
   let ( = ) = ( = )
-
   let ( < ) = ( < )
-
   let ( > ) = ( > )
-
   let ( <> ) = ( <> )
-
   let ( <= ) = ( <= )
-
   let ( >= ) = ( >= )
-
   let min = min
-
   let max = max
 end
 
 include (Poly : Comparisons with type t := int)
-
 module Array = Array
 
 module Bool = struct
@@ -72,7 +53,6 @@ end
 
 module Char = struct
   include Char
-
   include (Poly : Comparisons with type t := char)
 end
 
@@ -174,7 +154,6 @@ end
 
 module Int = struct
   let max_int = max_int
-
   let to_string = string_of_int
 
   include (Poly : Comparisons with type t := int)
@@ -186,9 +165,7 @@ module List = struct
   include struct
     (* shadow non-tail-recursive functions *)
     let merge = `not_tail_recursive
-
     let remove_assoc = `not_tail_recursive
-
     let remove_assq = `not_tail_recursive
 
     let rev_mapi list ~f =
@@ -203,14 +180,12 @@ module List = struct
       fold_left2 (rev list1) (rev list2) ~init ~f:(fun acc x y -> f x y acc)
 
     let map list ~f = rev (rev_map list ~f)
-
     let mapi list ~f = rev (rev_mapi list ~f)
 
     let fold_right list ~init ~f =
       fold_left (List.rev list) ~init ~f:(fun acc x -> f x acc)
 
     let append x y = rev_append (rev x) y
-
     let concat list = fold_right list ~init:[] ~f:append
 
     let rev_combine list1 list2 =
@@ -240,9 +215,7 @@ module List = struct
         match option with None -> tail | Some head -> head :: tail)
 
   let filter_opt list = rev (rev_filter_opt list)
-
   let filter_map list ~f = rev_filter_opt (rev_map list ~f)
-
   let concat_map list ~f = concat (map list ~f)
 
   let rec find_map list ~f =
@@ -292,11 +265,8 @@ end
 
 module Option = struct
   let is_some = function None -> false | Some _ -> true
-
   let iter t ~f = match t with None -> () | Some x -> f x
-
   let map t ~f = match t with None -> None | Some x -> Some (f x)
-
   let value t ~default = match t with None -> default | Some x -> x
 end
 
@@ -321,13 +291,9 @@ module String = struct
   include String
 
   let is_empty (t : t) = length t = 0
-
   let prefix t len = sub t ~pos:0 ~len
-
   let suffix t len = sub t ~pos:(length t - len) ~len
-
   let drop_prefix t len = sub t ~pos:len ~len:(length t - len)
-
   let drop_suffix t len = sub t ~pos:0 ~len:(length t - len)
 
   let is_prefix t ~prefix =
@@ -383,11 +349,8 @@ module String = struct
         Some (sub t ~pos:0 ~len:i, sub t ~pos:(i + 1) ~len:(length t - i - 1))
 
   let capitalize_ascii = Stdlib.String.capitalize_ascii
-
   let lowercase_ascii = Stdlib.String.lowercase_ascii
-
   let uncapitalize_ascii = Stdlib.String.uncapitalize_ascii
-
   let split_on_char t ~sep = Stdlib.String.split_on_char sep t
 
   include (Poly : Comparisons with type t := string)
@@ -403,7 +366,5 @@ module String = struct
 end
 
 let ( @ ) = List.append
-
 let output oc bytes ~pos ~len = output oc bytes pos len
-
 let output_substring oc string ~pos ~len = output_substring oc string pos len

--- a/test/driver/error_embedding/raiser.ml
+++ b/test/driver/error_embedding/raiser.ml
@@ -10,5 +10,4 @@ let rule =
   |> Context_free.Rule.extension
 
 let () = Driver.register_transformation ~rules:[ rule ] "test"
-
 let () = Driver.standalone ()

--- a/test/driver/exception_handling/extender.ml
+++ b/test/driver/exception_handling/extender.ml
@@ -29,9 +29,7 @@ let raise_located_error_extension =
     expand_raise_located_error
 
 let rule1 = Ppxlib.Context_free.Rule.extension extension_point_extension
-
 let rule2 = Ppxlib.Context_free.Rule.extension raise_exception_extension
-
 let rule3 = Ppxlib.Context_free.Rule.extension raise_located_error_extension
 
 let () =

--- a/test/driver/run_as_ppx_rewriter/print_greetings.ml
+++ b/test/driver/run_as_ppx_rewriter/print_greetings.ml
@@ -16,7 +16,5 @@ let bye_rule =
 
 (* the two rules need to be registered separately in order to test the `-apply` flag in run.t *)
 let () = Driver.register_transformation ~rules:[ hi_rule ] "print_hi"
-
 let () = Driver.register_transformation ~rules:[ bye_rule ] "print_bye"
-
 let () = Ppxlib.Driver.run_as_ppx_rewriter ()

--- a/test/driver/run_as_ppx_rewriter/print_magic_number.ml
+++ b/test/driver/run_as_ppx_rewriter/print_magic_number.ml
@@ -1,9 +1,5 @@
 let magic_length = String.length Astlib.Config.ast_impl_magic_number
-
 let buf = Bytes.create magic_length
-
 let len = input stdin buf 0 magic_length
-
 let s = Bytes.sub_string buf 0 len
-
 let () = Printf.printf "Magic number: %s" s

--- a/traverse/ppxlib_traverse.ml
+++ b/traverse/ppxlib_traverse.ml
@@ -11,15 +11,10 @@ let vars_of_list ~get_loc l =
   List.mapi l ~f:(fun i x -> { txt = alphabet.(i); loc = get_loc x })
 
 let evar_of_var { txt; loc } = evar ~loc txt
-
 let pvar_of_var { txt; loc } = pvar ~loc txt
-
 let tvar_of_var { txt; loc } = ptyp_var ~loc txt
-
 let evars_of_vars = List.map ~f:evar_of_var
-
 let pvars_of_vars = List.map ~f:pvar_of_var
-
 let tvars_of_vars = List.map ~f:tvar_of_var
 
 module Backends = struct
@@ -37,7 +32,6 @@ module Backends = struct
   class type what =
     object
       method name : string
-
       inherit reconstructors
 
       method class_params :
@@ -50,7 +44,6 @@ module Backends = struct
 
       (* Basic combinator type *)
       method typ : loc:Location.t -> core_type -> core_type
-
       method any : loc:Location.t -> expression
 
       method combine :
@@ -63,17 +56,11 @@ module Backends = struct
   let mapper : what =
     object
       method name = "map"
-
       inherit reconstructors
-
       method class_params ~loc:_ = []
-
       method apply ~loc expr args = eapply ~loc expr args
-
       method abstract ~loc patt expr = pexp_fun ~loc Nolabel None patt expr
-
       method typ ~loc ty = ptyp_arrow ~loc Nolabel ty ty
-
       method any ~loc = [%expr fun x -> x]
 
       method combine ~loc combinators ~reconstruct =
@@ -86,17 +73,11 @@ module Backends = struct
   let iterator : what =
     object
       method name = "iter"
-
       inherit reconstructors
-
       method class_params ~loc:_ = []
-
       method apply ~loc expr args = eapply ~loc expr args
-
       method abstract ~loc patt expr = pexp_fun ~loc Nolabel None patt expr
-
       method typ ~loc ty = [%type: [%t ty] -> unit]
-
       method any ~loc = [%expr fun _ -> ()]
 
       method combine ~loc combinators ~reconstruct:_ =
@@ -110,7 +91,6 @@ module Backends = struct
   let folder : what =
     object
       method name = "fold"
-
       inherit reconstructors
 
       method class_params ~loc =
@@ -122,7 +102,6 @@ module Backends = struct
         eabstract ~loc [ patt; pvar ~loc "acc" ] expr
 
       method typ ~loc ty = [%type: [%t ty] -> 'acc -> 'acc]
-
       method any ~loc = [%expr fun _ acc -> acc]
 
       method combine ~loc combinators ~reconstruct:_ =
@@ -139,7 +118,6 @@ module Backends = struct
   let fold_mapper : what =
     object
       method name = "fold_map"
-
       inherit reconstructors
 
       method class_params ~loc =
@@ -151,7 +129,6 @@ module Backends = struct
         eabstract ~loc [ patt; pvar ~loc "acc" ] expr
 
       method typ ~loc ty = [%type: [%t ty] -> 'acc -> [%t ty] * 'acc]
-
       method any ~loc = [%expr fun x acc -> (x, acc)]
 
       method combine ~loc combinators ~reconstruct =
@@ -187,7 +164,6 @@ module Backends = struct
     let uses_ctx = uses_var "ctx" in
     object
       method name = "map_with_context"
-
       inherit reconstructors
 
       method class_params ~loc =
@@ -200,7 +176,6 @@ module Backends = struct
         else eabstract ~loc [ pvar ~loc "_ctx"; patt ] expr
 
       method typ ~loc ty = [%type: 'ctx -> [%t ty] -> [%t ty]]
-
       method any ~loc = [%expr fun _ctx x -> x]
 
       method combine ~loc combinators ~reconstruct =
@@ -220,11 +195,8 @@ module Backends = struct
         [ (ptyp_var ~loc "res", (NoVariance, NoInjectivity)) ]
 
       method apply ~loc expr args = eapply ~loc expr args
-
       method abstract ~loc patt expr = pexp_fun ~loc Nolabel None patt expr
-
       method typ ~loc ty = [%type: [%t ty] -> 'res]
-
       method any ~loc = [%expr self#other]
 
       method combine ~loc combinators ~reconstruct =
@@ -479,11 +451,8 @@ let lift_virtual_methods ~loc methods =
         class virtual blah =
           object
             method virtual record : (string * 'res) list -> 'res
-
             method virtual constr : string -> 'res list -> 'res
-
             method virtual tuple : 'res list -> 'res
-
             method virtual other : 'a. 'a -> 'res
           end]
     with

--- a/traverse_builtins/ppxlib_traverse_builtins.ml
+++ b/traverse_builtins/ppxlib_traverse_builtins.ml
@@ -1,14 +1,9 @@
 module T = struct
   type 'a map = 'a -> 'a
-
   type 'a iter = 'a -> unit
-
   type ('a, 'acc) fold = 'a -> 'acc -> 'acc
-
   type ('a, 'acc) fold_map = 'a -> 'acc -> 'a * 'acc
-
   type ('ctx, 'a) map_with_context = 'ctx -> 'a -> 'a
-
   type ('a, 'res) lift = 'a -> 'res
 end
 
@@ -16,18 +11,14 @@ class map =
   let any x = x in
   object
     method int : int T.map = any
-
     method string : string T.map = any
-
     method bool : bool T.map = any
-
     method char : char T.map = any
 
     method option : 'a. 'a T.map -> 'a option T.map =
       fun f x -> match x with None -> None | Some x -> Some (f x)
 
     method list : 'a. 'a T.map -> 'a list T.map = List.map
-
     method array : 'a. 'a T.map -> 'a array T.map = Array.map
   end
 
@@ -35,18 +26,14 @@ class iter =
   let any = ignore in
   object
     method int : int T.iter = any
-
     method string : string T.iter = any
-
     method bool : bool T.iter = any
-
     method char : char T.iter = any
 
     method option : 'a. 'a T.iter -> 'a option T.iter =
       fun f x -> match x with None -> () | Some x -> f x
 
     method list : 'a. 'a T.iter -> 'a list T.iter = List.iter
-
     method array : 'a. 'a T.iter -> 'a array T.iter = Array.iter
   end
 
@@ -54,11 +41,8 @@ class ['acc] fold =
   let any _ acc = acc in
   object
     method int : (int, 'acc) T.fold = any
-
     method string : (string, 'acc) T.fold = any
-
     method bool : (bool, 'acc) T.fold = any
-
     method char : (char, 'acc) T.fold = any
 
     method option : 'a. ('a, 'acc) T.fold -> ('a option, 'acc) T.fold =
@@ -83,11 +67,8 @@ class ['acc] fold_map =
   let any x acc = (x, acc) in
   object
     method int : (int, 'acc) T.fold_map = any
-
     method string : (string, 'acc) T.fold_map = any
-
     method bool : (bool, 'acc) T.fold_map = any
-
     method char : (char, 'acc) T.fold_map = any
 
     method option : 'a. ('a, 'acc) T.fold_map -> ('a option, 'acc) T.fold_map =
@@ -129,11 +110,8 @@ class ['ctx] map_with_context =
   let any _ x = x in
   object
     method int : ('ctx, int) T.map_with_context = any
-
     method string : ('ctx, string) T.map_with_context = any
-
     method bool : ('ctx, bool) T.map_with_context = any
-
     method char : ('ctx, char) T.map_with_context = any
 
     method option
@@ -156,31 +134,18 @@ class ['ctx] map_with_context =
 class virtual ['res] lift =
   object (self)
     method virtual other : 'a. ('a, 'res) T.lift
-
     method virtual int : (int, 'res) T.lift
-
     method virtual string : (string, 'res) T.lift
-
     method virtual bool : (bool, 'res) T.lift
-
     method virtual char : (char, 'res) T.lift
-
     method virtual array : 'a. ('a, 'res) T.lift -> ('a array, 'res) T.lift
-
     method virtual float : (float, 'res) T.lift
-
     method virtual int32 : (int32, 'res) T.lift
-
     method virtual int64 : (int64, 'res) T.lift
-
     method virtual nativeint : (nativeint, 'res) T.lift
-
     method virtual unit : (unit, 'res) T.lift
-
     method virtual record : (string * 'res) list -> 'res
-
     method virtual constr : string -> 'res list -> 'res
-
     method virtual tuple : 'res list -> 'res
 
     method option : 'a. ('a, 'res) T.lift -> ('a option, 'res) T.lift =
@@ -199,34 +164,19 @@ class virtual ['res] lift =
 class type ['res] std_lifters =
   object
     method other : 'a. ('a, 'res) T.lift
-
     method int : (int, 'res) T.lift
-
     method string : (string, 'res) T.lift
-
     method bool : (bool, 'res) T.lift
-
     method char : (char, 'res) T.lift
-
     method array : 'a. ('a, 'res) T.lift -> ('a array, 'res) T.lift
-
     method record : (string * 'res) list -> 'res
-
     method constr : string -> 'res list -> 'res
-
     method tuple : 'res list -> 'res
-
     method float : (float, 'res) T.lift
-
     method int32 : (int32, 'res) T.lift
-
     method int64 : (int64, 'res) T.lift
-
     method nativeint : (nativeint, 'res) T.lift
-
     method unit : (unit, 'res) T.lift
-
     method option : 'a. ('a, 'res) T.lift -> ('a option, 'res) T.lift
-
     method list : 'a. ('a, 'res) T.lift -> ('a list, 'res) T.lift
   end


### PR DESCRIPTION
This is a preview of the not-yet-released `ocamlformat.0.20.0`, please wait until the package is published in opam to merge this PR. The output is still likely to slightly change before the package is released.
The changes are due to:
- `module-item-spacing` is now set to `compact` for the default profile
- `module-item-spacing` is now correctly applied to mutually recursive type definitions