### PR TITLE
Add tests for application of context-free rules inside payloads

### DIFF
--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -30,6 +30,7 @@ test/driver/attributes/test.ml
 test/driver/instrument/test.ml
 test/driver/non-compressible-suffix/test.ml
 test/driver/transformations/test.ml
+test/expansion_inside_payloads/test.ml
 test/extensions_and_deriving/test.ml
 test/location/exception/test.ml
 test/ppx_import_support/test.ml

--- a/test/expansion_inside_payloads/dune
+++ b/test/expansion_inside_payloads/dune
@@ -1,0 +1,13 @@
+(rule
+ (alias runtest)
+ (enabled_if
+  (>= %{ocaml_version} "4.10.0"))
+ (deps
+  (:test test.ml)
+  (package ppxlib))
+ (action
+  (chdir
+   %{project_root}
+   (progn
+    (run expect-test %{test})
+    (diff? %{test} %{test}.corrected)))))

--- a/test/expansion_inside_payloads/test.ml
+++ b/test/expansion_inside_payloads/test.ml
@@ -1,0 +1,211 @@
+open Ppxlib
+
+(* --------------------------- Test Setup ----------------------------------- *)
+
+(* These tests check that the inside of payloads is properly expanded or not
+   expanded by the driver. *)
+
+let int_of_payload ~loc ~transformation_name payload =
+  (match payload with
+   | PStr
+      [ {pstr_desc =
+          Pstr_eval
+            ( {pexp_desc = Pexp_constant (Pconst_integer (i, None)); _ }
+            , _)
+        ; _} ] ->
+     int_of_string i
+   | _ -> Location.raise_errorf ~loc "Invalid %s payload!" transformation_name)
+
+[%%expect{|
+val int_of_payload :
+  loc:location -> transformation_name:string -> payload -> int = <fun>
+|}]
+
+(* A legacy transformation, rewriting [%legacy_add_one <int>] as
+   [<int + 1>], written as a whole AST transformation *)
+let legacy_add_one =
+  object
+    inherit Ast_traverse.map as super
+
+    method! expression expr = 
+      match expr.pexp_desc with
+      | Pexp_extension ({txt = "legacy_add_one"; _}, payload) ->
+        let loc = expr.pexp_loc in
+        let i = int_of_payload ~loc ~transformation_name:"add_one" payload in
+        Ast_builder.Default.eint ~loc (i + 1)
+      | _ -> super#expression expr
+    end
+
+let () =
+  Driver.register_transformation
+    ~impl:legacy_add_one#structure
+    "legacy_add_one"
+
+[%%expect{|
+val legacy_add_one : Ast_traverse.map = <obj>
+|}]
+
+(* A legacy attribute-based generator implemented as a whole AST transformation.
+   [type _ = _ [@@gen_x <int>]] generates an extra [let x = <int>]. *)
+let legacy_deriver =
+  let get_gen_x attrs =
+      List.find_map
+        (function
+          | {attr_name = {txt = "gen_x"; _}; attr_payload; attr_loc} ->
+            Some (attr_payload, attr_loc)
+          | _ -> None)
+        attrs
+  in
+  object(self)
+    inherit Ast_traverse.map
+
+    method! structure str =
+      List.concat_map
+        (fun stri ->
+           match stri.pstr_desc with
+           | Pstr_type (_, [{ptype_attributes = (_::_ as attrs); _}]) ->
+             (match get_gen_x attrs with
+              | Some (payload, loc) ->
+                let i = int_of_payload ~loc ~transformation_name:"gen_x" payload in
+                let stri = self#structure_item stri in
+                let value = Ast_builder.Default.eint ~loc i in
+                let x_binding = [%stri let x = [%e value]] in
+                [stri; x_binding]
+              | None -> [self#structure_item stri])
+           | _ -> [self#structure_item stri])
+        str
+  end
+
+let () =
+  Driver.register_transformation
+    ~impl:legacy_deriver#structure
+    "legacy_deriver"
+
+[%%expect{|
+val legacy_deriver : Ast_traverse.map = <obj>
+|}]
+
+(* An expression extension that simply expands to its payload.
+   I.e. [[%id 1]] expands to [1]. *)
+let id =
+  Extension.V3.declare
+    "id"
+    Extension.Context.expression
+    Ast_pattern.(single_expr_payload __)
+    (fun ~ctxt:_ expr -> expr)
+  |> Context_free.Rule.extension
+
+let () = Driver.register_transformation ~rules:[id] "id"
+
+[%%expect{|
+val id : Context_free.Rule.t = <abstr>
+|}]
+
+(* ------------------------- Actual Test ----------------------------------- *)
+
+(* Context free transformations are applied inside payload of extensions or
+   attributes that aren't themselves expanded by context-free rules
+
+   The examples below are expected to succeed as the extension inside the payload
+   should be expanded during the context-free rule pass, that happens before
+   whole AST transformations. *)
+let x = [%legacy_add_one [%id 1]]
+
+[%%expect{|
+val x : int = 2
+|}]
+
+type t = unit
+[@@gen_x [%id 1]]
+
+[%%expect{|
+type t = unit
+val x : int = 1
+|}]
+
+(* --------------------------- Test Setup ----------------------------------- *)
+
+(* The same transformation as [legacy_add_one] but written as a context-free
+   rule *)
+let add_one =
+  Extension.V3.declare
+    "add_one"
+    Extension.Context.expression
+    Ast_pattern.(single_expr_payload (eint __))
+    (fun ~ctxt i ->
+       let loc = Expansion_context.Extension.extension_point_loc ctxt in
+       Ast_builder.Default.eint ~loc (i + 1))
+  |> Context_free.Rule.extension
+
+let () = Driver.register_transformation ~rules:[add_one] "add_one"
+
+[%%expect{|
+val add_one : Context_free.Rule.t = <abstr>
+|}]
+
+(* A deriver that accepts an integer [value] argument, specifying the value
+   of the derived integer [x].
+
+   E.g. [type t = _ [@@deriving x ~value:1]] will derive
+   [let x = 1]. *)
+let deriver =
+  let expand ~ctxt _type_decl value =
+    let loc = Expansion_context.Deriver.derived_item_loc ctxt in
+    let value =
+      match value with
+      | None -> [%expr 0]
+      | Some i -> Ast_builder.Default.eint ~loc i
+    in
+    [%str let x = [%e value]]
+  in
+  let args =
+    let open Deriving.Args in
+    let value = arg "value" Ast_pattern.(eint __) in
+    empty +> value
+  in
+  let str_type_decl =
+    Deriving.Generator.V2.make args expand
+  in
+  Deriving.add ~str_type_decl "x"
+
+[%%expect{|
+val deriver : Deriving.t = <abstr>
+|}]
+
+(* ------------------------- Actual Test ----------------------------------- *)
+
+(* Context-free transformations cannot be applied inside the payload of
+   extensions that are themselves expanded by a context-free rule,
+   simply because the outermost extension is expanded first.
+
+   The example below should trigger an error as the payload is expected to be an
+   integer expression and the extension in its payload should NOT be expanded.
+
+   This is an expected and relatively sane behaviour. As Carl Eastlund pointed
+   out, it might make sense at some point to allow expander to ask ppxlib to
+   expand a node explicitly via a callback but it shouldn't be done by default.
+   *)
+let y = [%add_one [%id 1]]
+
+[%%expect{|
+Line _, characters 18-25:
+Error: constant expected
+|}]
+
+(* Context-free transformations should not be applied inside the payload of
+   attributes interpreted by other context-free rules. This is a bug introduced
+   in https://github.com/ocaml-ppx/ppxlib/pull/279.
+
+   The example below should trigger an error as the [value] argument in the
+   paylaod is expected to be an integer expression and the extension in its
+   payload should NOT be expanded.
+
+   Here, just as in extensions, we might eventually provide a callback to expand
+   nodes explicitly. *)
+type u = unit
+[@@deriving x ~value:[%id 1]]
+
+[%%expect{|
+type u = t
+val x : int = 1
+|}]

--- a/test/expansion_inside_payloads/test.ml
+++ b/test/expansion_inside_payloads/test.ml
@@ -216,9 +216,8 @@ val y : string = "Payload is an extension point"
    attributes interpreted by other context-free rules. This is a bug introduced
    in https://github.com/ocaml-ppx/ppxlib/pull/279.
 
-   The example below should trigger an error as the [value] argument in the
-   paylaod is expected to be an integer expression and the extension in its
-   payload should NOT be expanded.
+   The example below should report the payload as being an extension point as
+   the [value] argument in the paylaod should NOT be expanded.
 
    Here, just as in extensions, we might eventually provide a callback to expand
    nodes explicitly. *)

--- a/test/expansion_inside_payloads/test.ml
+++ b/test/expansion_inside_payloads/test.ml
@@ -5,48 +5,63 @@ open Ppxlib
 (* These tests check that the inside of payloads is properly expanded or not
    expanded by the driver. *)
 
-let int_of_payload ~loc ~transformation_name payload =
-  (match payload with
-   | PStr
-      [ {pstr_desc =
-          Pstr_eval
-            ( {pexp_desc = Pexp_constant (Pconst_integer (i, None)); _ }
-            , _)
-        ; _} ] ->
-     int_of_string i
-   | _ -> Location.raise_errorf ~loc "Invalid %s payload!" transformation_name)
+let expr_description ~loc ~error expr =
+  match expr.pexp_desc with
+  | Pexp_constant (Pconst_integer _) ->
+    Ast_builder.Default.estring ~loc "Payload is an integer"
+  | Pexp_extension _ ->
+    Ast_builder.Default.estring ~loc "Payload is an extension point"
+  | _ -> error ()
 
 [%%expect{|
-val int_of_payload :
-  loc:location -> transformation_name:string -> payload -> int = <fun>
+val expr_description :
+  loc:location -> error:(unit -> expression) -> expression -> expression =
+  <fun>
 |}]
 
-(* A legacy transformation, rewriting [%legacy_add_one <int>] as
-   [<int + 1>], written as a whole AST transformation *)
-let legacy_add_one =
+let payload_description ~loc ~transformation_name payload =
+  let error () =
+    Location.raise_errorf ~loc "Invalid %s payload!" transformation_name
+  in
+  (match payload with
+   | PStr [{ pstr_desc = Pstr_eval (expr, _attr); _ }] ->
+     expr_description ~loc ~error expr
+   | _ -> error ())
+
+[%%expect{|
+val payload_description :
+  loc:location -> transformation_name:string -> payload -> expression = <fun>
+|}]
+
+(* A legacy transformation, rewriting [%legacy_add_one ...] as
+   a string, describing the kind of the payload. Only accepts integer and
+   extensions as payloads. *)
+let legacy_describe_payload =
   object
     inherit Ast_traverse.map as super
 
     method! expression expr = 
       match expr.pexp_desc with
-      | Pexp_extension ({txt = "legacy_add_one"; _}, payload) ->
+      | Pexp_extension ({txt = "legacy_describe_payload"; _}, payload) ->
         let loc = expr.pexp_loc in
-        let i = int_of_payload ~loc ~transformation_name:"add_one" payload in
-        Ast_builder.Default.eint ~loc (i + 1)
+        payload_description ~loc ~transformation_name:"legacy_describe_payload"
+          payload
       | _ -> super#expression expr
     end
 
 let () =
   Driver.register_transformation
-    ~impl:legacy_add_one#structure
-    "legacy_add_one"
+    ~impl:legacy_describe_payload#structure
+    "legacy_describe_payload"
 
 [%%expect{|
-val legacy_add_one : Ast_traverse.map = <obj>
+val legacy_describe_payload : Ast_traverse.map = <obj>
 |}]
 
 (* A legacy attribute-based generator implemented as a whole AST transformation.
-   [type _ = _ [@@gen_x <int>]] generates an extra [let x = <int>]. *)
+   [type _ = _ [@@gen_x payload]] generates an extra [let x = <string>] where
+   [<string>] is a descriptiong of the kind of [payload]. Only accepts integer
+   and extensions as payloads. *)
 let legacy_deriver =
   let get_gen_x attrs =
       List.find_map
@@ -66,9 +81,10 @@ let legacy_deriver =
            | Pstr_type (_, [{ptype_attributes = (_::_ as attrs); _}]) ->
              (match get_gen_x attrs with
               | Some (payload, loc) ->
-                let i = int_of_payload ~loc ~transformation_name:"gen_x" payload in
+                let value =
+                  payload_description ~loc ~transformation_name:"gen_x" payload
+                in
                 let stri = self#structure_item stri in
-                let value = Ast_builder.Default.eint ~loc i in
                 let x_binding = [%stri let x = [%e value]] in
                 [stri; x_binding]
               | None -> [self#structure_item stri])
@@ -106,13 +122,13 @@ val id : Context_free.Rule.t = <abstr>
 (* Context free transformations are applied inside payload of extensions or
    attributes that aren't themselves expanded by context-free rules
 
-   The examples below are expected to succeed as the extension inside the payload
-   should be expanded during the context-free rule pass, that happens before
-   whole AST transformations. *)
-let x = [%legacy_add_one [%id 1]]
+   The examples below are expected to display that their paylaod is an integer
+   as the extension inside the payload should be expanded during the
+   context-free rule pass, that happens before whole AST transformations. *)
+let x = [%legacy_describe_payload [%id 1]]
 
 [%%expect{|
-val x : int = 2
+val x : string = "Payload is an integer"
 |}]
 
 type t = unit
@@ -120,48 +136,52 @@ type t = unit
 
 [%%expect{|
 type t = unit
-val x : int = 1
+val x : string = "Payload is an integer"
 |}]
 
 (* --------------------------- Test Setup ----------------------------------- *)
 
-(* The same transformation as [legacy_add_one] but written as a context-free
-   rule *)
-let add_one =
+(* The same transformation as [legacy_describe_payload] but written as a
+   context-free rule *)
+let describe_payload =
   Extension.V3.declare
-    "add_one"
+    "describe_payload"
     Extension.Context.expression
-    Ast_pattern.(single_expr_payload (eint __))
-    (fun ~ctxt i ->
+    Ast_pattern.__
+    (fun ~ctxt payload ->
        let loc = Expansion_context.Extension.extension_point_loc ctxt in
-       Ast_builder.Default.eint ~loc (i + 1))
+       payload_description ~loc ~transformation_name:"describe_payload" payload)
   |> Context_free.Rule.extension
 
-let () = Driver.register_transformation ~rules:[add_one] "add_one"
+let () = Driver.register_transformation ~rules:[describe_payload] "describe_payload"
 
 [%%expect{|
-val add_one : Context_free.Rule.t = <abstr>
+val describe_payload : Context_free.Rule.t = <abstr>
 |}]
 
-(* A deriver that accepts an integer [value] argument, specifying the value
-   of the derived integer [x].
-
-   E.g. [type t = _ [@@deriving x ~value:1]] will derive
-   [let x = 1]. *)
+(* A deriver that accepts a [payload] argument. It generates a value binding
+   to a string describing the nature of its payload.
+   E.g. [type t = _ [@@deriving x ~payload:1]] will derive
+   [let x = "Payload is an integer"].
+   The value argument only accepts integer and extensions. *)
 let deriver =
-  let expand ~ctxt _type_decl value =
+  let expand ~ctxt _type_decl payload =
     let loc = Expansion_context.Deriver.derived_item_loc ctxt in
     let value =
-      match value with
-      | None -> [%expr 0]
-      | Some i -> Ast_builder.Default.eint ~loc i
+      match payload with
+      | None -> Location.raise_errorf ~loc "payload argument is mandatory"
+      | Some expr ->
+        let error () =
+          Location.raise_errorf ~loc "Invalid 'deriving x' payload!"
+        in
+        expr_description ~loc ~error expr
     in
     [%str let x = [%e value]]
   in
   let args =
     let open Deriving.Args in
-    let value = arg "value" Ast_pattern.(eint __) in
-    empty +> value
+    let payload = arg "payload" Ast_pattern.__ in
+    empty +> payload
   in
   let str_type_decl =
     Deriving.Generator.V2.make args expand
@@ -178,18 +198,18 @@ val deriver : Deriving.t = <abstr>
    extensions that are themselves expanded by a context-free rule,
    simply because the outermost extension is expanded first.
 
-   The example below should trigger an error as the payload is expected to be an
-   integer expression and the extension in its payload should NOT be expanded.
+   The example below should describe their payload to be an extension
+   because the extension inside their payload should NOT be expanded when they
+   run.
 
    This is an expected and relatively sane behaviour. As Carl Eastlund pointed
    out, it might make sense at some point to allow expander to ask ppxlib to
    expand a node explicitly via a callback but it shouldn't be done by default.
    *)
-let y = [%add_one [%id 1]]
+let y = [%describe_payload [%id 1]]
 
 [%%expect{|
-Line _, characters 18-25:
-Error: constant expected
+val y : string = "Payload is an extension point"
 |}]
 
 (* Context-free transformations should not be applied inside the payload of
@@ -203,9 +223,9 @@ Error: constant expected
    Here, just as in extensions, we might eventually provide a callback to expand
    nodes explicitly. *)
 type u = unit
-[@@deriving x ~value:[%id 1]]
+[@@deriving x ~payload:[%id 1]]
 
 [%%expect{|
 type u = t
-val x : int = 1
+val x : string = "Payload is an integer"
 |}]


### PR DESCRIPTION
This PR adds tests to characterize the application of context-free rules inside payloads.

The tests are split between to categories:
1. Payloads of extensions/attributes interpreted by other context-free rules
2. Payloads of extensions/attributes that are interpreted by whole AST transformation, or not interpreted at all

The comments describe the pre-#279 behaviour which is:
No expansion happens inside `1` as the expansion order prevents this from happening anyway. Nodes inside `2` are expanded just as any other node.

#279 broke that behaviour partly, as now the payload of attributes interpreted by ppxlib are expanded before the corresponding rule is applied, breaking some existing ppx-es.

I'd like to fix this in a subsequent PR, reverting back to the old behaviour.

It is worth noting that the payload of attributes in `1` actually were expanded, this was simply done after the context-free rule was applied. I'll see if I can preserve this behaviour but I doubt it can be done in a reasonable way. I also don't think it's worth a lot of effort as I don't expect a lot of ppx-es to rely on this but I might be wrong.