### PR TITLE
Generating transformation list on order and with no loss

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ Unreleased
 
 - Ast patterns: add `drop` and `as` patterns (#313 by @Kakadu, review by @pitag-ha)
 
+- Fixed a bug resulting in disscarded rewriters in the presence of
+  instrumentations, as well as a wrong order of rewriting (#296, @panglesd)
+
 0.24.0 (08/12/2021)
 -------------------
 

--- a/test/driver/run_as_ppx_rewriter/test.t/run.t
+++ b/test/driver/run_as_ppx_rewriter/test.t/run.t
@@ -60,7 +60,7 @@ The only possible usage is [extra_args] <infile> <outfile>...
     -locations-check            Enable locations check only
     -apply <names>              Apply these transformations in order (comma-separated list)
     -dont-apply <names>         Exclude these transformations
-    -no-merge                   Do not merge context free transformations (better for debugging rewriters)
+    -no-merge                   Do not merge context free transformations (better for debugging rewriters). As a result, the context-free transformations are not all applied before all impl and intf.
     -cookie NAME=EXPR           Set the cookie NAME to EXPR
     --cookie                    Same as -cookie
     -help                       Display this list of options
@@ -81,7 +81,7 @@ The only exception is consulting help
     -locations-check            Enable locations check only
     -apply <names>              Apply these transformations in order (comma-separated list)
     -dont-apply <names>         Exclude these transformations
-    -no-merge                   Do not merge context free transformations (better for debugging rewriters)
+    -no-merge                   Do not merge context free transformations (better for debugging rewriters). As a result, the context-free transformations are not all applied before all impl and intf.
     -cookie NAME=EXPR           Set the cookie NAME to EXPR
     --cookie                    Same as -cookie
     -help                       Display this list of options


### PR DESCRIPTION
This PR solves the following problems:
- When an `instrumentation` argument was given, together with an `impl` or `intf` argument, during a `Driver.register` call, both the `impl` and `intf` transformations were discarded.
- The order of application was not the one specified in the doc: rules registered together with a `before instrumentation` were applied before the instrumentation, those registered together with an `after instrumentation` were applied just before the after instrumentation (that is, after the non instrumentation whole file transforms).
- When using the `no-merge` command line option, the order was different from the one specified.

The last point is solved by adding a comment in the option decription that enabling it changes the order of execution.

The first two points are solved in a "hotfix" manner. In the future, I think this part of the code would need to be rewritten to make types ensure sanity and prevent other bugs to appear!

(this PR is based on PR #294. Only the last commit is new. Should I rebase for a clearer PR?)