### PR TITLE
Compact yet informative error reporting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ unreleased
 
 - Improve error messages in ppx raised exceptions (#292, @panglesd)
 
+- Embed error messages in the AST for extenders and derivers (#294, @panglesd)
+
 0.23.0 (31/08/2021)
 -------------------
 

--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -12,7 +12,7 @@ module Rule = struct
       attribute : ('b, 'c) Attribute.t;
       expect : bool;
       expand :
-        ?embed_errors:bool ->
+        embed_errors:bool ->
         ctxt:Expansion_context.Deriver.t ->
         Asttypes.rec_flag ->
         'b list ->
@@ -33,7 +33,7 @@ module Rule = struct
       attribute : ('b, 'c) Attribute.t;
       expect : bool;
       expand :
-        ?embed_errors:bool ->
+        embed_errors:bool ->
         ctxt:Expansion_context.Deriver.t ->
         'b ->
         'c ->
@@ -109,7 +109,7 @@ module Rule = struct
 
   type ('a, 'b, 'c) attr_group_inline =
     ('b, 'c) Attribute.t ->
-    (?embed_errors:bool ->
+    (embed_errors:bool ->
     ctxt:Expansion_context.Deriver.t ->
     Asttypes.rec_flag ->
     'b list ->
@@ -119,7 +119,7 @@ module Rule = struct
 
   type ('a, 'b, 'c) attr_inline =
     ('b, 'c) Attribute.t ->
-    (?embed_errors:bool ->
+    (embed_errors:bool ->
     ctxt:Expansion_context.Deriver.t ->
     'b ->
     'c ->
@@ -208,8 +208,7 @@ module Generated_code_hook = struct
     | _ -> t.f context { loc with loc_start = loc.loc_end } x
 end
 
-let rec map_node_rec ?(embed_errors = false) context ts super_call loc base_ctxt
-    x =
+let rec map_node_rec ~embed_errors context ts super_call loc base_ctxt x =
   let ctxt =
     Expansion_context.Extension.make ~extension_point_loc:loc ~base:base_ctxt ()
   in
@@ -222,8 +221,8 @@ let rec map_node_rec ?(embed_errors = false) context ts super_call loc base_ctxt
           map_node_rec ~embed_errors context ts super_call loc base_ctxt
             (EC.merge_attributes context x attrs))
 
-let map_node ?(embed_errors = false) (context : 'a EC.t) ts super_call loc
-    base_ctxt (x : 'a) ~hook =
+let map_node ~embed_errors (context : 'a EC.t) ts super_call loc base_ctxt
+    (x : 'a) ~hook =
   let ctxt =
     Expansion_context.Extension.make ~extension_point_loc:loc ~base:base_ctxt ()
   in
@@ -240,8 +239,8 @@ let map_node ?(embed_errors = false) (context : 'a EC.t) ts super_call loc
           Generated_code_hook.replace hook context loc (Single generated_code);
           generated_code)
 
-let rec map_nodes context ts super_call get_loc ?(embed_errors = false)
-    base_ctxt l ~hook ~in_generated_code =
+let rec map_nodes context ts super_call get_loc ~embed_errors base_ctxt l ~hook
+    ~in_generated_code =
   match l with
   | [] -> []
   | x :: l -> (
@@ -338,8 +337,7 @@ let sort_attr_inline l =
    This complexity is horrible, but in practice we don't care as [attrs] is always a list
    of one element; it only has [@@deriving].
 *)
-let handle_attr_group_inline ?(embed_errors = false) attrs rf items ~loc
-    ~base_ctxt =
+let handle_attr_group_inline ~embed_errors attrs rf items ~loc ~base_ctxt =
   List.filter_map attrs ~f:(fun (Rule.Attr_group_inline.T group) ->
       Option.map (get_group group.attribute items) ~f:(fun values ->
           let ctxt =
@@ -349,7 +347,7 @@ let handle_attr_group_inline ?(embed_errors = false) attrs rf items ~loc
           let expect_items = group.expand ~embed_errors ~ctxt rf items values in
           expect_items))
 
-let handle_attr_inline ?(embed_errors = false) attrs item ~loc ~base_ctxt =
+let handle_attr_inline ~embed_errors attrs item ~loc ~base_ctxt =
   List.filter_map attrs ~f:(fun (Rule.Attr_inline.T a) ->
       Option.map (Attribute.get a.attribute item) ~f:(fun value ->
           let ctxt =
@@ -368,8 +366,7 @@ module Expect_mismatch_handler = struct
 end
 
 class map_top_down ?(expect_mismatch_handler = Expect_mismatch_handler.nop)
-  ?(generated_code_hook = Generated_code_hook.nop) ?(embed_errors = false) rules
-  =
+  ?(generated_code_hook = Generated_code_hook.nop) ~embed_errors rules =
   let hook = generated_code_hook in
 
   let special_functions =

--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -208,30 +208,29 @@ module Generated_code_hook = struct
     | _ -> t.f context { loc with loc_start = loc.loc_end } x
 end
 
-let rec map_node_rec context ts super_call loc base_ctxt x
-    ?(embed_errors = false) =
+let rec map_node_rec ?(embed_errors = false) context ts super_call loc base_ctxt
+    x =
   let ctxt =
     Expansion_context.Extension.make ~extension_point_loc:loc ~base:base_ctxt ()
   in
   match EC.get_extension context x with
   | None -> super_call base_ctxt x
   | Some (ext, attrs) -> (
-      match E.For_context.convert ts ~ctxt ext embed_errors context x with
+      match E.For_context.convert ~embed_errors ts ~ctxt ext context x with
       | None -> super_call base_ctxt x
       | Some x ->
-          map_node_rec context ts super_call loc base_ctxt
-            (EC.merge_attributes context x attrs)
-            ~embed_errors)
+          map_node_rec ~embed_errors context ts super_call loc base_ctxt
+            (EC.merge_attributes context x attrs))
 
-let map_node (context : 'a EC.t) ts super_call loc base_ctxt (x : 'a) ~hook
-    ?(embed_errors = false) =
+let map_node ?(embed_errors = false) (context : 'a EC.t) ts super_call loc
+    base_ctxt (x : 'a) ~hook =
   let ctxt =
     Expansion_context.Extension.make ~extension_point_loc:loc ~base:base_ctxt ()
   in
   match EC.get_extension context x with
   | None -> super_call base_ctxt x
   | Some (ext, attrs) -> (
-      match E.For_context.convert ts ~ctxt ext embed_errors context x with
+      match E.For_context.convert ~embed_errors ts ~ctxt ext context x with
       | None -> super_call base_ctxt x
       | Some x ->
           map_node_rec context ts super_call loc base_ctxt
@@ -263,7 +262,7 @@ let rec map_nodes context ts super_call get_loc ?(embed_errors = false)
               ~base:base_ctxt ()
           in
           match
-            E.For_context.convert_inline ts ~ctxt ext embed_errors context x
+            E.For_context.convert_inline ~embed_errors ts ~ctxt ext context x
           with
           | None ->
               let x = super_call base_ctxt x in
@@ -373,7 +372,7 @@ module Expect_mismatch_handler = struct
 end
 
 class map_top_down ?(expect_mismatch_handler = Expect_mismatch_handler.nop)
-  ?(generated_code_hook = Generated_code_hook.nop) ?(embed_errors = true) rules
+  ?(generated_code_hook = Generated_code_hook.nop) ?(embed_errors = false) rules
   =
   let hook = generated_code_hook in
 
@@ -607,8 +606,8 @@ class map_top_down ?(expect_mismatch_handler = Expect_mismatch_handler.nop)
                     ~base:base_ctxt ()
                 in
                 match
-                  E.For_context.convert_inline structure_item ~ctxt ext
-                    embed_errors EC.Structure_item item
+                  E.For_context.convert_inline ~embed_errors structure_item
+                    ~ctxt ext EC.Structure_item item
                 with
                 | None ->
                     let item = super#structure_item base_ctxt item in
@@ -708,8 +707,8 @@ class map_top_down ?(expect_mismatch_handler = Expect_mismatch_handler.nop)
                     ~base:base_ctxt ()
                 in
                 match
-                  E.For_context.convert_inline signature_item ~ctxt ext
-                    embed_errors EC.Signature_item item
+                  E.For_context.convert_inline ~embed_errors signature_item
+                    ~ctxt ext EC.Signature_item item
                 with
                 | None ->
                     let item = super#signature_item base_ctxt item in

--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -595,7 +595,7 @@ class map_top_down ?(expect_mismatch_handler = Expect_mismatch_handler.nop)
         | item :: rest -> (
             let loc = item.pstr_loc in
             match item.pstr_desc with
-            | Pstr_extension (((_str_loc, _) as ext), attrs) -> (
+            | Pstr_extension (ext, attrs) -> (
                 let extension_point_loc = item.pstr_loc in
                 let ctxt =
                   Expansion_context.Extension.make ~extension_point_loc

--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -340,28 +340,24 @@ let sort_attr_inline l =
 *)
 let handle_attr_group_inline ?(embed_errors = false) attrs rf items ~loc
     ~base_ctxt =
-  List.fold_left attrs ~init:[] ~f:(fun acc (Rule.Attr_group_inline.T group) ->
-      match get_group group.attribute items with
-      | None -> acc
-      | Some values ->
-          let ctxt =
-            Expansion_context.Deriver.make ~derived_item_loc:loc
-              ~inline:group.expect ~base:base_ctxt ()
-          in
-          let expect_items = group.expand ~embed_errors ~ctxt rf items values in
-          expect_items :: acc)
+  List.filter_map attrs ~f:(fun (Rule.Attr_group_inline.T group) ->
+      Option.map (get_group group.attribute items) ~f:(fun values ->
+      let ctxt =
+        Expansion_context.Deriver.make ~derived_item_loc:loc
+          ~inline:group.expect ~base:base_ctxt ()
+      in
+      let expect_items = group.expand ~embed_errors ~ctxt rf items values in
+      expect_items))
 
 let handle_attr_inline ?(embed_errors = false) attrs item ~loc ~base_ctxt =
-  List.fold_left attrs ~init:[] ~f:(fun acc (Rule.Attr_inline.T a) ->
-      match Attribute.get a.attribute item with
-      | None -> acc
-      | Some value ->
-          let ctxt =
-            Expansion_context.Deriver.make ~derived_item_loc:loc
-              ~inline:a.expect ~base:base_ctxt ()
-          in
-          let expect_items = a.expand ~embed_errors ~ctxt item value in
-          expect_items :: acc)
+  List.filter_map attrs ~f:(fun (Rule.Attr_inline.T a) ->
+    Option.map (Attribute.get a.attribute item) ~f:(fun value ->
+      let ctxt =
+        Expansion_context.Deriver.make ~derived_item_loc:loc
+          ~inline:a.expect ~base:base_ctxt ()
+      in
+      let expect_items = a.expand ~embed_errors ~ctxt item value in
+      expect_items))
 
 module Expect_mismatch_handler = struct
   type t = {

--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -342,22 +342,22 @@ let handle_attr_group_inline ?(embed_errors = false) attrs rf items ~loc
     ~base_ctxt =
   List.filter_map attrs ~f:(fun (Rule.Attr_group_inline.T group) ->
       Option.map (get_group group.attribute items) ~f:(fun values ->
-      let ctxt =
-        Expansion_context.Deriver.make ~derived_item_loc:loc
-          ~inline:group.expect ~base:base_ctxt ()
-      in
-      let expect_items = group.expand ~embed_errors ~ctxt rf items values in
-      expect_items))
+          let ctxt =
+            Expansion_context.Deriver.make ~derived_item_loc:loc
+              ~inline:group.expect ~base:base_ctxt ()
+          in
+          let expect_items = group.expand ~embed_errors ~ctxt rf items values in
+          expect_items))
 
 let handle_attr_inline ?(embed_errors = false) attrs item ~loc ~base_ctxt =
   List.filter_map attrs ~f:(fun (Rule.Attr_inline.T a) ->
-    Option.map (Attribute.get a.attribute item) ~f:(fun value ->
-      let ctxt =
-        Expansion_context.Deriver.make ~derived_item_loc:loc
-          ~inline:a.expect ~base:base_ctxt ()
-      in
-      let expect_items = a.expand ~embed_errors ~ctxt item value in
-      expect_items))
+      Option.map (Attribute.get a.attribute item) ~f:(fun value ->
+          let ctxt =
+            Expansion_context.Deriver.make ~derived_item_loc:loc
+              ~inline:a.expect ~base:base_ctxt ()
+          in
+          let expect_items = a.expand ~embed_errors ~ctxt item value in
+          expect_items))
 
 module Expect_mismatch_handler = struct
   type t = {

--- a/src/context_free.mli
+++ b/src/context_free.mli
@@ -50,7 +50,8 @@ module Rule : sig
 
   type ('a, 'b, 'c) attr_group_inline =
     ('b, 'c) Attribute.t ->
-    (ctxt:Expansion_context.Deriver.t ->
+    (?embed_errors:bool ->
+    ctxt:Expansion_context.Deriver.t ->
     Asttypes.rec_flag ->
     'b list ->
     'c option list ->
@@ -83,7 +84,11 @@ module Rule : sig
 
   type ('a, 'b, 'c) attr_inline =
     ('b, 'c) Attribute.t ->
-    (ctxt:Expansion_context.Deriver.t -> 'b -> 'c -> 'a list) ->
+    (?embed_errors:bool ->
+    ctxt:Expansion_context.Deriver.t ->
+    'b ->
+    'c ->
+    'a list) ->
     t
   (** Same as [attr_group_inline] but for elements that are not part of a group,
       such as exceptions and type extensions *)

--- a/src/context_free.mli
+++ b/src/context_free.mli
@@ -153,5 +153,6 @@ class map_top_down :
     Expect_mismatch_handler.t (* default: Expect_mismatch_handler.nop *)
   -> ?generated_code_hook:
        Generated_code_hook.t (* default: Generated_code_hook.nop *)
+  -> ?embed_errors:bool (* default: false *)
   -> Rule.t list
   -> Ast_traverse.map_with_expansion_context

--- a/src/context_free.mli
+++ b/src/context_free.mli
@@ -50,7 +50,7 @@ module Rule : sig
 
   type ('a, 'b, 'c) attr_group_inline =
     ('b, 'c) Attribute.t ->
-    (?embed_errors:bool ->
+    (embed_errors:bool ->
     ctxt:Expansion_context.Deriver.t ->
     Asttypes.rec_flag ->
     'b list ->
@@ -84,7 +84,7 @@ module Rule : sig
 
   type ('a, 'b, 'c) attr_inline =
     ('b, 'c) Attribute.t ->
-    (?embed_errors:bool ->
+    (embed_errors:bool ->
     ctxt:Expansion_context.Deriver.t ->
     'b ->
     'c ->
@@ -158,6 +158,6 @@ class map_top_down :
     Expect_mismatch_handler.t (* default: Expect_mismatch_handler.nop *)
   -> ?generated_code_hook:
        Generated_code_hook.t (* default: Generated_code_hook.nop *)
-  -> ?embed_errors:bool (* default: false *)
+  -> embed_errors:bool
   -> Rule.t list
   -> Ast_traverse.map_with_expansion_context

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -227,8 +227,10 @@ module Generator = struct
             (match Location.Error.of_exn exn with
             | None ->
                 Location.Error.make ~loc:name.loc
-                  ("(ppx deriver " ^ name.txt ^ ") " ^ Printexc.to_string exn ^ {|
-Raising unlocated exceptions are discouraged in derivers. You might want to file an issue to the maintainers of |}^name.txt)
+                  ("(ppx deriver " ^ name.txt ^ ") " ^ Printexc.to_string exn
+                 ^ {|
+Raising unlocated exceptions are discouraged in derivers. You might want to file an issue to the maintainers of |}
+                 ^ name.txt)
                   ~sub:[]
             | Some error ->
                 Location.Error.set_message error

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -745,8 +745,7 @@ let types_used_by_deriving :
 let merge_generators field l =
   List.filter_map l ~f:(fun x -> x) |> List.concat |> Deriver.resolve_all field
 
-let expand_type_decls context ?(embed_errors = false) ~ctxt rec_flag tds values
-    =
+let expand_type_decls context ~embed_errors ~ctxt rec_flag tds values =
   let generators = merge_generators (Deriver.Field.type_decl context) values in
   (* TODO: instead of disabling the unused warning for types themselves, we
      should add a tag [@@unused]. *)
@@ -759,8 +758,7 @@ let expand_type_decls context ?(embed_errors = false) ~ctxt rec_flag tds values
     ~hide:(not @@ Expansion_context.Deriver.inline ctxt)
     generated
 
-let expand_module_type_decl context ?(embed_errors = false) ~ctxt mtd generators
-    =
+let expand_module_type_decl context ~embed_errors ~ctxt mtd generators =
   let generators =
     Deriver.resolve_all (Deriver.Field.module_type_decl context) generators
   in
@@ -772,7 +770,7 @@ let expand_module_type_decl context ?(embed_errors = false) ~ctxt mtd generators
     ~hide:(not @@ Expansion_context.Deriver.inline ctxt)
     generated
 
-let expand_exception context ?(embed_errors = false) ~ctxt ec generators =
+let expand_exception context ~embed_errors ~ctxt ec generators =
   let generators =
     Deriver.resolve_all (Deriver.Field.type_exception context) generators
   in
@@ -784,7 +782,7 @@ let expand_exception context ?(embed_errors = false) ~ctxt ec generators =
     ~hide:(not @@ Expansion_context.Deriver.inline ctxt)
     generated
 
-let expand_type_ext context ?(embed_errors = false) ~ctxt te generators =
+let expand_type_ext context ~embed_errors ~ctxt te generators =
   let generators =
     Deriver.resolve_all (Deriver.Field.type_ext context) generators
   in

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -141,15 +141,9 @@ type parsed_args =
   | Unknown_syntax of Location.t * string
 
 module Context = struct
+
   type 'a t = Str : structure_item t | Sig : signature_item t
 
-  (* let extension_builder : type a. a t -> loc:location -> extension -> a = *)
-  (*  fun t -> *)
-  (*  match t with *)
-  (*   | Type_declaration -> Ast_builder.Default.ptyp_extension *)
-  (*   | Extension -> failwith "yo" *)
-  (*   | Exception -> failwith "yo" *)
-  (*   | Module_type_declaration -> Ast_builder.Default.pmod_constraint *)
 end
 
 module Generator = struct

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -141,9 +141,7 @@ type parsed_args =
   | Unknown_syntax of Location.t * string
 
 module Context = struct
-
   type 'a t = Str : structure_item t | Sig : signature_item t
-
 end
 
 module Generator = struct

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -227,7 +227,8 @@ module Generator = struct
             (match Location.Error.of_exn exn with
             | None ->
                 Location.Error.make ~loc:name.loc
-                  ("(ppx deriver " ^ name.txt ^ ") " ^ Printexc.to_string exn)
+                  ("(ppx deriver " ^ name.txt ^ ") " ^ Printexc.to_string exn ^ {|
+Raising unlocated exceptions are discouraged in derivers. You might want to file an issue to the maintainers of |}^name.txt)
                   ~sub:[]
             | Some error ->
                 Location.Error.set_message error

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -228,16 +228,16 @@ module Generator = struct
           let extension_node =
             (match Location.Error.of_exn exn with
             | None ->
-                Location.Error.make ~loc:name.loc
-                  ("(ppx deriver " ^ name.txt ^ ") " ^ Printexc.to_string exn
-                 ^ {|
-Raising unlocated exceptions are discouraged in derivers. You might want to file an issue to the maintainers of |}
-                 ^ name.txt)
-                  ~sub:[]
+                Location.Error.make ~loc:name.loc ~sub:[]
+                @@ Printf.sprintf
+                     "(PPX %s) %s\n\
+                      (Ppxlib:) %s has violated the PPX norm on how to report \
+                      errors. Precise location of error cannot be given."
+                     name.txt (Printexc.to_string exn) name.txt
             | Some error ->
                 Location.Error.set_message error
-                @@ "(ppx deriver " ^ name.txt ^ ") "
-                ^ Location.Error.message error)
+                @@ Printf.sprintf "(PPX %s) %s" name.txt
+                     (Location.Error.message error))
             |> Location.Error.to_extension
           in
           match context with

--- a/src/deriving.mli
+++ b/src/deriving.mli
@@ -42,6 +42,10 @@ end
 type t
 (** Type of registered derivers *)
 
+module Context : sig
+  type 'a t
+end
+
 module Generator : sig
   type deriver = t
 

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -1463,6 +1463,7 @@ let parse_input passed_in_args ~valid_args ~incorrect_input_msg =
       Caml.exit 0
 
 let run_as_ppx_rewriter_main ~standalone_args ~usage input =
+  embed_errors := true;
   let valid_args = get_args ~standalone_args () in
   match List.rev @@ Array.to_list @@ input with
   | output_fn :: input_fn :: flags_and_prog_name

--- a/src/driver.mli
+++ b/src/driver.mli
@@ -251,9 +251,9 @@ val pretty : unit -> bool
 
 (**/**)
 
-val map_structure : structure -> structure
+val map_structure : structure -> embed_errors:bool -> structure
 
-val map_signature : signature -> signature
+val map_signature : signature -> embed_errors:bool -> signature
 
 val enable_checks : unit -> unit
 

--- a/src/extension.ml
+++ b/src/extension.ml
@@ -262,21 +262,22 @@ type 'a expander_result = Simple of 'a | Inline of 'a list
 module For_context = struct
   type 'a t = ('a, 'a expander_result) M.t
 
+  exception ContextFreeException of string * exn
+
   let exn_to_extension exn str =
-    match Location.Error.of_exn exn with
+    (match Location.Error.of_exn exn with
     | None ->
         Location.Error.make ~loc:str.loc
-          ("(ppx extender " ^ str.txt ^ ") " ^ Printexc.to_string exn
-         ^ {|
-Raising unlocated exception in extenders are discouraged. You might want to file an issue to the maintainers of |}
-         ^ str.txt)
+          ("(PPX " ^ str.txt ^ ":) " ^ Printexc.to_string exn ^ "\n"
+         ^ "(Ppxlib:) " ^ str.txt
+         ^ " has violated the PPX norm on how to report errors. Precise \
+            location of error cannot be given.")
           ~sub:[]
-        |> Location.Error.to_extension
     | Some error ->
         Location.Error.set_message error
-        @@ "(ppx extender " ^ str.txt ^ ") "
-        ^ Location.Error.message error
-        |> Location.Error.to_extension
+        @@ "(PPX " ^ str.txt ^ ") "
+        ^ Location.Error.message error)
+    |> Location.Error.to_extension
 
   let convert ?(embed_errors = false) ts ~ctxt ((str, _) as ext) context x =
     let loc = Expansion_context.Extension.extension_point_loc ctxt in
@@ -287,10 +288,12 @@ Raising unlocated exception in extenders are discouraged. You might want to file
           match Ast_pattern.parse pattern loc (snd ext) (f ~ctxt ~arg) with
           | Simple x -> Some x
           | Inline _ -> failwith "Extension.convert"
-        with exn when embed_errors ->
-          let extension_node = exn_to_extension exn str in
-          Some (Context.extension_builder context x ~loc:str.loc extension_node)
-        )
+        with
+        | exn when embed_errors ->
+            let extension_node = exn_to_extension exn str in
+            Some
+              (Context.extension_builder context x ~loc:str.loc extension_node)
+        | exn -> raise @@ ContextFreeException (str.txt, exn))
 
   let convert_inline ?(embed_errors = false) ts ~ctxt ((str, _) as ext) context
       x =

--- a/src/extension.ml
+++ b/src/extension.ml
@@ -114,6 +114,25 @@ module Context = struct
     | Ppx_import, type_decl -> get_ppx_import_extension type_decl
     | _ -> None
 
+  let extension_builder : type a. a t -> a -> loc:location -> extension -> a =
+   fun t x ->
+    match t with
+    | Class_expr -> Ast_builder.Default.pcl_extension
+    | Class_field -> Ast_builder.Default.pcf_extension
+    | Class_type -> Ast_builder.Default.pcty_extension
+    | Class_type_field -> Ast_builder.Default.pctf_extension
+    | Core_type -> Ast_builder.Default.ptyp_extension
+    | Expression -> Ast_builder.Default.pexp_extension
+    | Module_expr -> Ast_builder.Default.pmod_extension
+    | Module_type -> Ast_builder.Default.pmty_extension
+    | Pattern -> Ast_builder.Default.ppat_extension
+    | Signature_item ->
+        fun ~loc ext -> Ast_builder.Default.psig_extension ~loc ext []
+    | Structure_item ->
+        fun ~loc ext -> Ast_builder.Default.pstr_extension ~loc ext []
+    | Ppx_import ->
+       fun ~loc ext -> { x with ptype_manifest = Some (Ast_builder.Default.ptyp_extension ~loc ext) }
+
   let merge_attributes : type a. a t -> a -> attributes -> a =
    fun t x attrs ->
     match t with

--- a/src/extension.ml
+++ b/src/extension.ml
@@ -265,33 +265,35 @@ module For_context = struct
   let exn_to_extension exn str =
     match Location.Error.of_exn exn with
     | None ->
-       Location.Error.make ~loc:str.loc
-         ("(ppx extender " ^ str.txt ^ ") " ^ Printexc.to_string exn ^ {|
-Raising unlocated exception in extenders are discouraged. You might want to file an issue to the maintainers of |}^str.txt)
-         ~sub:[]
-       |> Location.Error.to_extension
-    |  Some error ->
+        Location.Error.make ~loc:str.loc
+          ("(ppx extender " ^ str.txt ^ ") " ^ Printexc.to_string exn
+         ^ {|
+Raising unlocated exception in extenders are discouraged. You might want to file an issue to the maintainers of |}
+         ^ str.txt)
+          ~sub:[]
+        |> Location.Error.to_extension
+    | Some error ->
         Location.Error.set_message error
         @@ "(ppx extender " ^ str.txt ^ ") "
-           ^ Location.Error.message error
+        ^ Location.Error.message error
         |> Location.Error.to_extension
 
   let convert ?(embed_errors = false) ts ~ctxt ((str, _) as ext) context x =
     let loc = Expansion_context.Extension.extension_point_loc ctxt in
     match M.find ts ext with
     | None -> None
-    | Some ({ payload = M.Payload_parser (pattern, f); _ }, arg) ->
+    | Some ({ payload = M.Payload_parser (pattern, f); _ }, arg) -> (
         try
           match Ast_pattern.parse pattern loc (snd ext) (f ~ctxt ~arg) with
           | Simple x -> Some x
           | Inline _ -> failwith "Extension.convert"
         with exn when embed_errors ->
           let extension_node = exn_to_extension exn str in
-          Some
-            (Context.extension_builder context x ~loc:str.loc extension_node)
+          Some (Context.extension_builder context x ~loc:str.loc extension_node)
+        )
 
-  let convert_inline ?(embed_errors = false) ts ~ctxt ((str, _) as ext)
-      context x =
+  let convert_inline ?(embed_errors = false) ts ~ctxt ((str, _) as ext) context
+      x =
     let loc = Expansion_context.Extension.extension_point_loc ctxt in
     match M.find ts ext with
     | None -> None
@@ -303,10 +305,7 @@ Raising unlocated exception in extenders are discouraged. You might want to file
         with exn when embed_errors ->
           let extension_node = exn_to_extension exn str in
           Some
-            [
-              Context.extension_builder context x ~loc:str.loc
-                extension_node;
-            ])
+            [ Context.extension_builder context x ~loc:str.loc extension_node ])
 end
 
 type t = T : _ For_context.t -> t

--- a/src/extension.ml
+++ b/src/extension.ml
@@ -262,27 +262,35 @@ type 'a expander_result = Simple of 'a | Inline of 'a list
 module For_context = struct
   type 'a t = ('a, 'a expander_result) M.t
 
-  let convert ?(embed_errors = false) ts ~ctxt ((str_loc, _) as ext) context x =
+  let exn_to_extension exn str =
+    match Location.Error.of_exn exn with
+    | None ->
+       Location.Error.make ~loc:str.loc
+         ("(ppx extender " ^ str.txt ^ ") " ^ Printexc.to_string exn ^ {|
+Raising unlocated exception in extenders are discouraged. You might want to file an issue to the maintainers of |}^str.txt)
+         ~sub:[]
+       |> Location.Error.to_extension
+    |  Some error ->
+        Location.Error.set_message error
+        @@ "(ppx extender " ^ str.txt ^ ") "
+           ^ Location.Error.message error
+        |> Location.Error.to_extension
+
+  let convert ?(embed_errors = false) ts ~ctxt ((str, _) as ext) context x =
     let loc = Expansion_context.Extension.extension_point_loc ctxt in
     match M.find ts ext with
     | None -> None
-    | Some ({ payload = M.Payload_parser (pattern, f); _ }, arg) -> (
+    | Some ({ payload = M.Payload_parser (pattern, f); _ }, arg) ->
         try
           match Ast_pattern.parse pattern loc (snd ext) (f ~ctxt ~arg) with
           | Simple x -> Some x
           | Inline _ -> failwith "Extension.convert"
         with exn when embed_errors ->
-          let extension_node =
-            Location.Error.make ~loc
-              ("(ppx " ^ str_loc.txt ^ ") " ^ Printexc.to_string exn)
-              ~sub:[]
-            |> Location.Error.to_extension
-          in
+          let extension_node = exn_to_extension exn str in
           Some
-            (Context.extension_builder context x ~loc:str_loc.loc extension_node)
-        )
+            (Context.extension_builder context x ~loc:str.loc extension_node)
 
-  let convert_inline ?(embed_errors = false) ts ~ctxt ((str_loc, _) as ext)
+  let convert_inline ?(embed_errors = false) ts ~ctxt ((str, _) as ext)
       context x =
     let loc = Expansion_context.Extension.extension_point_loc ctxt in
     match M.find ts ext with
@@ -293,15 +301,10 @@ module For_context = struct
           | Simple x -> Some [ x ]
           | Inline l -> Some l
         with exn when embed_errors ->
-          let extension_node =
-            Location.Error.make ~loc
-              ("(ppx " ^ str_loc.txt ^ ") " ^ Printexc.to_string exn)
-              ~sub:[]
-            |> Location.Error.to_extension
-          in
+          let extension_node = exn_to_extension exn str in
           Some
             [
-              Context.extension_builder context x ~loc:str_loc.loc
+              Context.extension_builder context x ~loc:str.loc
                 extension_node;
             ])
 end

--- a/src/extension.ml
+++ b/src/extension.ml
@@ -262,7 +262,7 @@ type 'a expander_result = Simple of 'a | Inline of 'a list
 module For_context = struct
   type 'a t = ('a, 'a expander_result) M.t
 
-  let convert ts ~ctxt ((str_loc, _) as ext) embed_errors context x =
+  let convert ?(embed_errors = false) ts ~ctxt ((str_loc, _) as ext) context x =
     let loc = Expansion_context.Extension.extension_point_loc ctxt in
     match M.find ts ext with
     | None -> None
@@ -282,7 +282,8 @@ module For_context = struct
             (Context.extension_builder context x ~loc:str_loc.loc extension_node)
         )
 
-  let convert_inline ts ~ctxt ((str_loc, _) as ext) embed_errors context x =
+  let convert_inline ?(embed_errors = false) ts ~ctxt ((str_loc, _) as ext)
+      context x =
     let loc = Expansion_context.Extension.extension_point_loc ctxt in
     match M.find ts ext with
     | None -> None

--- a/src/extension.mli
+++ b/src/extension.mli
@@ -111,19 +111,19 @@ module For_context : sig
   type 'a t
 
   val convert :
+    ?embed_errors:bool ->
     'a t list ->
     ctxt:Expansion_context.Extension.t ->
     extension ->
-    bool ->
     'a Context.t ->
     'a ->
     'a option
 
   val convert_inline :
+    ?embed_errors:bool ->
     'a t list ->
     ctxt:Expansion_context.Extension.t ->
     extension ->
-    bool ->
     'a Context.t ->
     'a ->
     'a list option

--- a/src/extension.mli
+++ b/src/extension.mli
@@ -111,12 +111,21 @@ module For_context : sig
   type 'a t
 
   val convert :
-    'a t list -> ctxt:Expansion_context.Extension.t -> extension -> 'a option
+    'a t list ->
+    ctxt:Expansion_context.Extension.t ->
+    extension ->
+    bool ->
+    'a Context.t ->
+    'a ->
+    'a option
 
   val convert_inline :
     'a t list ->
     ctxt:Expansion_context.Extension.t ->
     extension ->
+    bool ->
+    'a Context.t ->
+    'a ->
     'a list option
 end
 

--- a/src/extension.mli
+++ b/src/extension.mli
@@ -44,6 +44,8 @@ module Context : sig
 
   val get_extension : 'a t -> 'a -> (extension * attributes) option
 
+  val extension_builder : 'a t -> 'a -> loc:location -> extension -> 'a
+
   val merge_attributes : 'a t -> 'a -> attributes -> 'a
 end
 

--- a/src/extension.mli
+++ b/src/extension.mli
@@ -110,6 +110,8 @@ module For_context : sig
 
   type 'a t
 
+  exception ContextFreeException of string * exn
+
   val convert :
     ?embed_errors:bool ->
     'a t list ->

--- a/test/deriving/test.ml
+++ b/test/deriving/test.ml
@@ -37,15 +37,13 @@ val mtd : Deriving.t = <abstr>
 type t = int [@@deriving bar]
 [%%expect{|
 Line _, characters 25-28:
-Error: The following located exception was raised during the context-free transformation phase:
-Deriver foo is needed for bar, you need to add it before in the list
+Error: (Ppxlib context-free phase:) Deriver foo is needed for bar, you need to add it before in the list
 |}]
 
 type t = int [@@deriving bar, foo]
 [%%expect{|
 Line _, characters 25-33:
-Error: The following located exception was raised during the context-free transformation phase:
-Deriver foo is needed for bar, you need to add it before in the list
+Error: (Ppxlib context-free phase:) Deriver foo is needed for bar, you need to add it before in the list
 |}]
 
 type nonrec int = int [@@deriving foo, bar]

--- a/test/driver/error_embedding/test.t/run.t
+++ b/test/driver/error_embedding/test.t/run.t
@@ -8,8 +8,7 @@ is caught and packed into an output AST
 
   $ echo "let _ = [%raise]" > impl.ml
   $ ../raiser.exe -embed-errors impl.ml
-  [%%ocaml.error
-    "The following located exception was raised during the context-free transformation phase:\nRaising inside the rewriter"]
+  let _ = [%ocaml.error "(ppx raise) Raising inside the rewriter"]
 
 The same is true when using the `-as-ppx` mode (note that the error is reported
 by ocaml itself. Due to a change of formatting since 4.08.0, we are forced to

--- a/test/driver/error_embedding/test.t/run.t
+++ b/test/driver/error_embedding/test.t/run.t
@@ -8,7 +8,7 @@ is caught and packed into an output AST
 
   $ echo "let _ = [%raise]" > impl.ml
   $ ../raiser.exe -embed-errors impl.ml
-  let _ = [%ocaml.error "(ppx raise) Raising inside the rewriter"]
+  let _ = [%ocaml.error "(ppx extender raise) Raising inside the rewriter"]
 
 The same is true when using the `-as-ppx` mode (note that the error is reported
 by ocaml itself. Due to a change of formatting since 4.08.0, we are forced to

--- a/test/driver/error_embedding/test.t/run.t
+++ b/test/driver/error_embedding/test.t/run.t
@@ -8,7 +8,7 @@ is caught and packed into an output AST
 
   $ echo "let _ = [%raise]" > impl.ml
   $ ../raiser.exe -embed-errors impl.ml
-  let _ = [%ocaml.error "(ppx extender raise) Raising inside the rewriter"]
+  let _ = [%ocaml.error "(PPX raise) Raising inside the rewriter"]
 
 The same is true when using the `-as-ppx` mode (note that the error is reported
 by ocaml itself. Due to a change of formatting since 4.08.0, we are forced to
@@ -17,7 +17,7 @@ unify both styles by stripping whitespaces)
   $ ocaml -ppx '../raiser.exe -as-ppx' impl.ml 2> error
   [2]
   $ cat error | awk '{$1=$1};1' |tr '\n' ' '
-  File "./impl.ml", line 1, characters 8-16: Error: The following located exception was raised during the context-free transformation phase: Raising inside the rewriter 
+  File "./impl.ml", line 1, characters 8-16: Error: (PPX raise) Raising inside the rewriter 
 
 Also exceptions raised in a preprocessor get embedded into an AST(while the
 error from the preprocessor's stderr also gets reported on the driver's stderr)

--- a/test/driver/exception_handling/run.t
+++ b/test/driver/exception_handling/run.t
@@ -86,7 +86,9 @@ location:
   $ echo "let _ = [%gen_raise_located_error]" >> impl.ml
   $ ./extender.exe -embed-errors impl.ml
   let x = 1 + 1.
-  let _ = [%ocaml.error "(ppx gen_raise_located_error) A raised located error"]
+  let _ =
+    [%ocaml.error
+      "(ppx extender gen_raise_located_error) A raised located error"]
 
  In the case of derivers, it is put at the location of the attribute:
 
@@ -116,15 +118,18 @@ location: the extension point or attribute location.
 
  In the case of extensions:
 
-  $ echo "let _ = [%gen_raise_exc] + [%gen_raise_exc]" > impl.ml
+  $ echo "let _ = [%gen_raise_exc \"payload\"] + [%gen_raise_exc \"payload\"]" > impl.ml
   $ ./extender.exe impl.ml
   Fatal error: exception The following exception was raised during the context-free transformation phase:
   (Failure "A raised exception")
   [2]
   $ ./extender.exe -embed-errors impl.ml
   let _ =
-    ([%ocaml.error "(ppx gen_raise_exc) (Failure \"A raised exception\")"]) +
-      ([%ocaml.error "(ppx gen_raise_exc) (Failure \"A raised exception\")"])
+    ([%ocaml.error
+       "(ppx extender gen_raise_exc) (Failure \"A raised exception\")\nRaising unlocated exception in extenders are discouraged. You might want to file an issue to the maintainers of gen_raise_exc"])
+      +
+      ([%ocaml.error
+         "(ppx extender gen_raise_exc) (Failure \"A raised exception\")\nRaising unlocated exception in extenders are discouraged. You might want to file an issue to the maintainers of gen_raise_exc"])
 
  In the case of derivers
 
@@ -137,7 +142,7 @@ location: the extension point or attribute location.
     struct
       let _ = fun (_ : b) -> ()
       [%%ocaml.error
-        "(ppx deriver deriver_raised_exception) (Failure \"A raised exception\")"]
+        "(ppx deriver deriver_raised_exception) (Failure \"A raised exception\")\nRaising unlocated exceptions are discouraged in derivers. You might want to file an issue to the maintainers of deriver_raised_exception"]
     end[@@ocaml.doc "@inline"][@@merlin.hide ]
 
  In the case of whole file transformations:

--- a/test/expansion_context/map_structure_print_ctxt.ml
+++ b/test/expansion_context/map_structure_print_ctxt.ml
@@ -6,4 +6,5 @@ let set_filename (lexbuf : Lexing.lexbuf) ~filename =
 let _ =
   Lexing.from_channel stdin
   |> set_filename ~filename:"lexbuf_pos_fname"
-  |> Parse.implementation |> Driver.map_structure
+  |> Parse.implementation
+  |> Driver.map_structure ~embed_errors:false

--- a/test/expect/expect_test.ml
+++ b/test/expect/expect_test.ml
@@ -47,7 +47,7 @@ let apply_rewriters : Parsetree.toplevel_phrase -> Parsetree.toplevel_phrase =
   | Ptop_dir _ as x -> x
   | Ptop_def s ->
       let s = Ppxlib.Selected_ast.of_ocaml Structure s in
-      let s' = Ppxlib.Driver.map_structure s in
+      let s' = Ppxlib.Driver.map_structure s ~embed_errors:false in
       Ptop_def (Ppxlib.Selected_ast.to_ocaml Structure s')
 
 let main () =

--- a/test/extensions_and_deriving/test.ml
+++ b/test/extensions_and_deriving/test.ml
@@ -51,8 +51,7 @@ val gen_type_decl : Context_free.Rule.t = <abstr>
 
 [%%expect{|
 Line _, characters 3-19:
-Error: The following located exception was raised during the context-free transformation phase:
-Attributes not allowed here
+Error: (Ppxlib context-free phase:) Attributes not allowed here
 |}]
 
 (* Generates a [type t = int[@@deriving derived]] *)


### PR DESCRIPTION
This PR aims at providing a better reporting of errors, following the discussion from #292  and the new way of embedding errors from #294.

# Aim

After discussion, an error message should:
- Give the information needed for the user, and nothing more, that is:
  - The name of the ppx throwing the error
  - the actual error,
  - the explanation of why some features are missing (such as no other errors reported in merlin, or no location given), only when that makes sense.
  - separated in a clear way
- Give a hint to the ppx author on how to improve the error reporting.
  - Give a warning about the fact that the error is not reported the right way (but only when it is not reported the right way)
  - Use a formulation that is easy to google, hoping that it gets to the ppxlib manual on error reporting (wip)
  
# Implementation

With the aim in mind, here is how the errors are generated:
- If the error is linked with a ppx, the error starts with `(PPX name_of_ppx:) `. If it happens during the rewriting phase but is not linked with a ppx, it starts with: `(Ppxlib context-free phase:) `,
- then there is the error
- if either:
  - Case 1: A located error was raised in a whole file rewriter, or
  - Case 2: A regular exception was raised in a context-free rewriter
  - Case 3: A regular exception was raised in a whole file rewriter
then `(Ppxlib:)  ppx_name has violated the PPX norm on how to report errors.` is added in a next line
- Furthermore:
  - In case 3, a suffix `No location of error can be given.`
  - In case 2, a suffix `Precise location of error cannot be given.`
  - In case 1 or 3, when the tool is merlin, a suffix `Other errors can't be reported anymore.`

# Discussion 

To continue the discussion, I have some questions:
- In case 1, when the tool is not Merlin, the reported error is not justified by a suffix: only  `(Ppxlib:)  ppx_name has violated the PPX norm on how to report errors.`. Would it be better to add `Merlin won't be able to report other errors.`?
- Is case 2 `Precise location of error cannot be given.` Can this be missleading, as the location of the extension node is already given?