### PR TITLE
New behavior wrt exception

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,9 @@ Unreleased
   consider a type declaration recursive if the type appeared inside an attribute
   payload (#299, @NathanReb)
 
+- Append the last valid AST to the error in case of located exception when
+  `embed_errors` is true (#315, @panglesd)
+
 0.23.0 (31/08/2021)
 -------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@ Unreleased
 - Fixed a bug resulting in disscarded rewriters in the presence of
   instrumentations, as well as a wrong order of rewriting (#296, @panglesd)
 
+- Driver: Append the last valid AST to the error in case of located exception
+  when embedding errors (#315, @panglesd)
+
 0.24.0 (08/12/2021)
 -------------------
 
@@ -29,8 +32,6 @@ Unreleased
   consider a type declaration recursive if the type appeared inside an attribute
   payload (#299, @NathanReb)
 
-- Append the last valid AST to the error in case of located exception when
-  `embed_errors` is true (#315, @panglesd)
 
 0.23.0 (31/08/2021)
 -------------------

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -942,6 +942,8 @@ struct
   let set x = t.data <- Some x
 end
 
+(*$*)
+
 let error_to_str_extension error =
   let loc = Location.none in
   let ext = Location.Error.to_extension error in
@@ -953,6 +955,8 @@ let exn_to_str_extension exn =
   | None -> raise exn
   | Some error -> error_to_str_extension error
 
+(*$ str_to_sig _last_text_block *)
+
 let error_to_sig_extension error =
   let loc = Location.none in
   let ext = Location.Error.to_extension error in
@@ -963,6 +967,8 @@ let exn_to_sig_extension exn =
   match Location.Error.of_exn exn with
   | None -> raise exn
   | Some error -> error_to_sig_extension error
+
+(*$*)
 
 let error_to_extension error ~(kind : Kind.t) =
   let loc = Location.none in

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -502,9 +502,9 @@ let get_whole_ast_passes ~hook ~expect_mismatch_handler ~tool_name ~input_name =
 let apply_transforms (type t) ~tool_name ~file_path ~field ~lint_field
     ~dropped_so_far ~hook ~expect_mismatch_handler ~input_name ~f_exception
     ~embed_errors x =
-  let module M = struct
-    exception Wrapper of t list * label loc list * (location * label) list * exn
-  end in
+  let exception
+    Wrapper of t list * label loc list * (location * label) list * exn
+  in
   let cts =
     get_whole_ast_passes ~tool_name ~hook ~expect_mismatch_handler ~input_name
   in
@@ -531,7 +531,7 @@ let apply_transforms (type t) ~tool_name ~file_path ~field ~lint_field
             | Some f -> (
                 try lint_errors @ f ctxt x
                 with exn when embed_errors ->
-                  raise @@ M.Wrapper (x, dropped, lint_errors, exn))
+                  raise @@ Wrapper (x, dropped, lint_errors, exn))
           in
           match field ct with
           | None -> (x, dropped, lint_errors)
@@ -539,7 +539,7 @@ let apply_transforms (type t) ~tool_name ~file_path ~field ~lint_field
               let x =
                 try f ctxt x
                 with exn when embed_errors ->
-                  raise @@ M.Wrapper (x, dropped, lint_errors, exn)
+                  raise @@ Wrapper (x, dropped, lint_errors, exn)
               in
               let dropped =
                 if !debug_attribute_drop then (
@@ -552,7 +552,7 @@ let apply_transforms (type t) ~tool_name ~file_path ~field ~lint_field
               (x, dropped, lint_errors))
     in
     Ok (return acc)
-  with M.Wrapper (x, dropped, lint_errors, exn) ->
+  with Wrapper (x, dropped, lint_errors, exn) ->
     Error (return (f_exception exn :: x, dropped, lint_errors))
 
 (*$*)

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -576,7 +576,7 @@ let map_structure_gen st ~tool_name ~hook ~expect_mismatch_handler ~input_name =
   if !perform_checks then (
     Attribute.reset_checks ();
     Attribute.collect#structure st);
-  let lint_and_check lint_errors st =
+  let lint lint_errors st =
     let st =
       match lint_errors with
       | [] -> st
@@ -586,6 +586,9 @@ let map_structure_gen st ~tool_name ~hook ~expect_mismatch_handler ~input_name =
               Ast_builder.Default.pstr_attribute ~loc attr)
           @ st
     in
+    st
+  in
+  let cookies_and_check st =
     Cookies.call_post_handlers T;
     if !perform_checks then (
       (* TODO: these two passes could be merged, we now have more passes for
@@ -611,10 +614,10 @@ let map_structure_gen st ~tool_name ~hook ~expect_mismatch_handler ~input_name =
         ~expect_mismatch_handler ~input_name
         ~f_exception:(fun (a, b) -> WrapStructureAndLintErrors (a, b))
     with WrapStructureAndLintErrors ((st, lint_errors), exn) ->
-      let st = lint_and_check lint_errors st in
+      let st = lint lint_errors st in
       raise @@ WrapStructure (st, exn)
   in
-  lint_and_check lint_errors st
+  st |> lint lint_errors |> cookies_and_check
 
 let map_structure st =
   try

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -661,11 +661,14 @@ let map_structure_gen st ~tool_name ~hook ~expect_mismatch_handler ~input_name
   | Ok (st, lint_errors) -> Ok (st |> lint lint_errors |> cookies_and_check)
 
 let map_structure st =
-  map_structure_gen st
-    ~tool_name:(Astlib.Ast_metadata.tool_name ())
-    ~hook:Context_free.Generated_code_hook.nop
-    ~expect_mismatch_handler:Context_free.Expect_mismatch_handler.nop
-    ~input_name:None ~embed_errors:false
+  match
+    map_structure_gen st
+      ~tool_name:(Astlib.Ast_metadata.tool_name ())
+      ~hook:Context_free.Generated_code_hook.nop
+      ~expect_mismatch_handler:Context_free.Expect_mismatch_handler.nop
+      ~input_name:None ~embed_errors:false
+  with
+  | Ok ast | Error ast -> ast
 
 (*$ str_to_sig _last_text_block *)
 
@@ -717,11 +720,14 @@ let map_signature_gen sg ~tool_name ~hook ~expect_mismatch_handler ~input_name
   | Ok (sg, lint_errors) -> Ok (sg |> lint lint_errors |> cookies_and_check)
 
 let map_signature sg =
-  map_signature_gen sg
-    ~tool_name:(Astlib.Ast_metadata.tool_name ())
-    ~hook:Context_free.Generated_code_hook.nop
-    ~expect_mismatch_handler:Context_free.Expect_mismatch_handler.nop
-    ~input_name:None ~embed_errors:false
+  match
+    map_signature_gen sg
+      ~tool_name:(Astlib.Ast_metadata.tool_name ())
+      ~hook:Context_free.Generated_code_hook.nop
+      ~expect_mismatch_handler:Context_free.Expect_mismatch_handler.nop
+      ~input_name:None ~embed_errors:false
+  with
+  | Ok ast | Error ast -> ast
 
 (*$*)
 

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -639,7 +639,7 @@ let map_signature_gen sg ~tool_name ~hook ~expect_mismatch_handler ~input_name =
   if !perform_checks then (
     Attribute.reset_checks ();
     Attribute.collect#signature sg);
-  let lint_and_check lint_errors sg =
+  let lint lint_errors sg =
     let sg =
       match lint_errors with
       | [] -> sg
@@ -649,6 +649,9 @@ let map_signature_gen sg ~tool_name ~hook ~expect_mismatch_handler ~input_name =
               Ast_builder.Default.psig_attribute ~loc attr)
           @ sg
     in
+    sg
+  in
+  let cookies_and_check sg =
     Cookies.call_post_handlers T;
     if !perform_checks then (
       (* TODO: these two passes could be merged, we now have more passes for
@@ -674,10 +677,10 @@ let map_signature_gen sg ~tool_name ~hook ~expect_mismatch_handler ~input_name =
         ~expect_mismatch_handler ~input_name
         ~f_exception:(fun (a, b) -> WrapSignatureAndLintErrors (a, b))
     with WrapSignatureAndLintErrors ((sg, lint_errors), exn) ->
-      let sg = lint_and_check lint_errors sg in
+      let sg = lint lint_errors sg in
       raise @@ WrapSignature (sg, exn)
   in
-  lint_and_check lint_errors sg
+  sg |> lint lint_errors |> cookies_and_check
 
 let map_signature sg =
   try

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -947,8 +947,7 @@ end
 let error_to_str_extension error =
   let loc = Location.none in
   let ext = Location.Error.to_extension error in
-  let open Ast_builder.Default in
-  pstr_extension ~loc ext []
+  Ast_builder.Default.pstr_extension ~loc ext []
 
 let exn_to_str_extension exn =
   match Location.Error.of_exn exn with
@@ -960,8 +959,7 @@ let exn_to_str_extension exn =
 let error_to_sig_extension error =
   let loc = Location.none in
   let ext = Location.Error.to_extension error in
-  let open Ast_builder.Default in
-  psig_extension ~loc ext []
+  Ast_builder.Default.psig_extension ~loc ext []
 
 let exn_to_sig_extension exn =
   match Location.Error.of_exn exn with
@@ -971,15 +969,9 @@ let exn_to_sig_extension exn =
 (*$*)
 
 let error_to_extension error ~(kind : Kind.t) =
-  let loc = Location.none in
-  let ext = Location.Error.to_extension error in
-  let open Ast_builder.Default in
-  let ast =
-    match kind with
-    | Intf -> Intf_or_impl.Intf [ psig_extension ~loc ext [] ]
-    | Impl -> Intf_or_impl.Impl [ pstr_extension ~loc ext [] ]
-  in
-  ast
+  match kind with
+  | Intf -> Intf_or_impl.Intf [ error_to_sig_extension error ]
+  | Impl -> Intf_or_impl.Impl [ error_to_str_extension error ]
 
 let exn_to_extension exn ~(kind : Kind.t) =
   match Location.Error.of_exn exn with

--- a/test/driver/error_embedding/test.t/run.t
+++ b/test/driver/error_embedding/test.t/run.t
@@ -4,11 +4,12 @@ different compiler versions in the subsequent tests
   $ export OCAML_ERROR_STYLE=short
 
 With the `-embed-errors` options, if a PPX raises, the first such exception
-is caught and packed into an output AST
+is caught and prepended to the last valid AST
 
   $ echo "let _ = [%raise]" > impl.ml
   $ ../raiser.exe -embed-errors impl.ml
   [%%ocaml.error "Raising inside the rewriter"]
+  let _ = [%raise ]
 
 The same is true when using the `-as-ppx` mode (note that the error is reported
 by ocaml itself)

--- a/test/driver/exception_handling/run.t
+++ b/test/driver/exception_handling/run.t
@@ -68,9 +68,7 @@ caught, so no AST is produced.
   [1]
 
 When the argument `-embed-errors` is added, the exception is caught
-and the whole AST is replaced with a single error extension node. The
-first line `let x = 1+1.` is thus not present in the AST, and no error
-can be reported about it.
+and the whole AST is prepended with an error extension node.
 
  In the case of extenders:
 
@@ -78,6 +76,8 @@ can be reported about it.
   $ echo "let _ = [%gen_raise_located_error]" >> impl.ml
   $ ./extender.exe -embed-errors impl.ml
   [%%ocaml.error "A raised located error"]
+  let x = 1 + 1.
+  let _ = [%gen_raise_located_error ]
 
  In the case of derivers
 
@@ -86,12 +86,15 @@ can be reported about it.
   $ echo "type b = int [@@deriving deriver_located_error]" >> impl.ml
   $ ./deriver.exe -embed-errors impl.ml
   [%%ocaml.error "A raised located error"]
+  type a = int
+  type b = int[@@deriving deriver_located_error]
 
  In the case of whole file transformations:
 
   $ echo "let x = 1+1. " > impl.ml
   $ ./whole_file_located_error.exe -embed-errors impl.ml
   [%%ocaml.error "A located error in a whole file transform"]
+  let x = 1 + 1.
 
 3. Raising an exception. The exception is not caught by the driver.
 


### PR DESCRIPTION
This PR implements the change in behavior proposed in #314.

When a located exception is raised during a rewriting pass, and either the `as-ppx` or the `embed_errors` flag is set, then instead of replacing the ast by an error extension node, the last valid AST (the one before the error) is used and prepended with the error extension node.