### PR TITLE
Add `error_extensionf` in the API to ease the process of embedding errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 
+- Added `error_extensionf` function to the `Location` module (#316, @panglesd)
+
 - Ast patterns: add `drop` and `as` patterns (#313 by @Kakadu, review by @pitag-ha)
 
 0.24.0 (08/12/2021)
@@ -23,8 +25,6 @@ Unreleased
 - Fix a bug in `type_is_recursive` and `really_recursive` where they would
   consider a type declaration recursive if the type appeared inside an attribute
   payload (#299, @NathanReb)
-
-- Added `error_extensionf` function to the `Locate` module (#316, @panglesd)
 
 0.23.0 (31/08/2021)
 -------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@ Unreleased
   consider a type declaration recursive if the type appeared inside an attribute
   payload (#299, @NathanReb)
 
+- Added `error_extensionf` function to the `Locate` module (#316, @panglesd)
+
 0.23.0 (31/08/2021)
 -------------------
 

--- a/examples/simple-deriver/ppx_deriving_accessors.ml
+++ b/examples/simple-deriver/ppx_deriving_accessors.ml
@@ -38,8 +38,11 @@ let generate_impl ~ctxt (_rec_flag, type_declarations) =
   List.map type_declarations ~f:(fun (td : type_declaration) ->
       match td with
       | { ptype_kind = Ptype_abstract | Ptype_variant _ | Ptype_open; _ } ->
-          Location.raise_errorf ~loc
-            "Cannot derive accessors for non record types"
+          let ext =
+            Location.error_extensionf ~loc
+              "Cannot derive accessors for non record types"
+          in
+          [ Ast_builder.Default.pstr_extension ~loc ext [] ]
       | { ptype_kind = Ptype_record fields; _ } ->
           List.map fields ~f:accessor_impl)
   |> List.concat
@@ -49,8 +52,11 @@ let generate_intf ~ctxt (_rec_flag, type_declarations) =
   List.map type_declarations ~f:(fun (td : type_declaration) ->
       match td with
       | { ptype_kind = Ptype_abstract | Ptype_variant _ | Ptype_open; _ } ->
-          Location.raise_errorf ~loc
-            "Cannot derive accessors for non record types"
+          let ext =
+            Location.error_extensionf ~loc
+              "Cannot derive accessors for non record types"
+          in
+          [ Ast_builder.Default.psig_extension ~loc ext [] ]
       | { ptype_kind = Ptype_record fields; ptype_name; _ } ->
           List.map fields ~f:(accessor_intf ~ptype_name))
   |> List.concat

--- a/examples/simple-deriver/ppx_deriving_accessors.ml
+++ b/examples/simple-deriver/ppx_deriving_accessors.ml
@@ -37,9 +37,13 @@ let generate_impl ~ctxt (_rec_flag, type_declarations) =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
   List.map type_declarations ~f:(fun (td : type_declaration) ->
       match td with
-      | { ptype_kind = Ptype_abstract | Ptype_variant _ | Ptype_open; _ } ->
+      | {
+       ptype_kind = Ptype_abstract | Ptype_variant _ | Ptype_open;
+       ptype_loc;
+       _;
+      } ->
           let ext =
-            Location.error_extensionf ~loc
+            Location.error_extensionf ~loc:ptype_loc
               "Cannot derive accessors for non record types"
           in
           [ Ast_builder.Default.pstr_extension ~loc ext [] ]
@@ -51,9 +55,13 @@ let generate_intf ~ctxt (_rec_flag, type_declarations) =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
   List.map type_declarations ~f:(fun (td : type_declaration) ->
       match td with
-      | { ptype_kind = Ptype_abstract | Ptype_variant _ | Ptype_open; _ } ->
+      | {
+       ptype_kind = Ptype_abstract | Ptype_variant _ | Ptype_open;
+       ptype_loc;
+       _;
+      } ->
           let ext =
-            Location.error_extensionf ~loc
+            Location.error_extensionf ~loc:ptype_loc
               "Cannot derive accessors for non record types"
           in
           [ Ast_builder.Default.psig_extension ~loc ext [] ]

--- a/examples/simple-extension-rewriter/ppx_get_env.ml
+++ b/examples/simple-extension-rewriter/ppx_get_env.ml
@@ -5,8 +5,11 @@ let expand ~ctxt env_var =
   match Sys.getenv env_var with
   | value -> Ast_builder.Default.estring ~loc value
   | exception Not_found ->
-      Location.raise_errorf ~loc "The environement variable %s is unbound"
-        env_var
+      let ext =
+        Location.error_extensionf ~loc "The environement variable %s is unbound"
+          env_var
+      in
+      Ast_builder.Default.pexp_extension ~loc ext
 
 let my_extension =
   Extension.V3.declare "get_env" Extension.Context.expression

--- a/src/location.ml
+++ b/src/location.ml
@@ -70,6 +70,11 @@ module Error = struct
   let createf ~loc fmt = Format.kasprintf (fun str -> make ~loc ~sub:[] str) fmt
 end
 
+let extensionf ~loc fmt =
+  Format.kasprintf
+    (fun str -> Error.to_extension @@ Error.make ~loc ~sub:[] str)
+    fmt
+
 exception Error = L.Error
 
 let () =

--- a/src/location.ml
+++ b/src/location.ml
@@ -70,7 +70,7 @@ module Error = struct
   let createf ~loc fmt = Format.kasprintf (fun str -> make ~loc ~sub:[] str) fmt
 end
 
-let extensionf ~loc fmt =
+let error_extensionf ~loc fmt =
   Format.kasprintf
     (fun str -> Error.to_extension @@ Error.make ~loc ~sub:[] str)
     fmt

--- a/src/location.mli
+++ b/src/location.mli
@@ -84,4 +84,8 @@ module Error : sig
 end
 with type location := t
 
+val extensionf : loc:t -> ('a, Format.formatter, unit, extension) format4 -> 'a
+(** Returns an error extension node. When encountered in the AST, the compiler
+    recognizes it and displays the error properly. *)
+
 exception Error of Error.t

--- a/src/location.mli
+++ b/src/location.mli
@@ -25,8 +25,8 @@ val init : Lexing.lexbuf -> string -> unit
     named file. *)
 
 val raise_errorf : ?loc:t -> ('a, Caml.Format.formatter, unit, 'b) format4 -> 'a
-(** Raise a located error. The exception is caught by driver and handled
-    appropriately *)
+(** Raise a located error. Should be avoided as much as possible, in the
+    benefits of {!error_extensionf}. *)
 
 val of_lexbuf : Lexing.lexbuf -> t
 (** Return the location corresponding to the last matched regular expression *)

--- a/src/location.mli
+++ b/src/location.mli
@@ -25,8 +25,8 @@ val init : Lexing.lexbuf -> string -> unit
     named file. *)
 
 val raise_errorf : ?loc:t -> ('a, Caml.Format.formatter, unit, 'b) format4 -> 'a
-(** Raise a located error. Should be avoided as much as possible, in the
-    benefits of {!error_extensionf}. *)
+(** Raise a located error. Should be avoided as much as possible, in favor of
+    {!error_extensionf}. *)
 
 val of_lexbuf : Lexing.lexbuf -> t
 (** Return the location corresponding to the last matched regular expression *)

--- a/src/location.mli
+++ b/src/location.mli
@@ -84,7 +84,8 @@ module Error : sig
 end
 with type location := t
 
-val extensionf : loc:t -> ('a, Format.formatter, unit, extension) format4 -> 'a
+val error_extensionf :
+  loc:t -> ('a, Format.formatter, unit, extension) format4 -> 'a
 (** Returns an error extension node. When encountered in the AST, the compiler
     recognizes it and displays the error properly. *)
 

--- a/test/driver/exception_handling/deriver.ml
+++ b/test/driver/exception_handling/deriver.ml
@@ -3,7 +3,7 @@ open Ppxlib
 let generate_impl_extension_node ~ctxt (_rec_flag, _type_declarations) =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
   let extension_node =
-    Location.extensionf ~loc "An error message in an extension node"
+    Location.error_extensionf ~loc "An error message in an extension node"
   in
   [ Ast_builder.Default.pstr_extension ~loc extension_node [] ]
 

--- a/test/driver/exception_handling/deriver.ml
+++ b/test/driver/exception_handling/deriver.ml
@@ -3,8 +3,7 @@ open Ppxlib
 let generate_impl_extension_node ~ctxt (_rec_flag, _type_declarations) =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
   let extension_node =
-    Location.Error.(
-      make ~loc "An error message in an extension node" ~sub:[] |> to_extension)
+    Location.extensionf ~loc "An error message in an extension node"
   in
   [ Ast_builder.Default.pstr_extension ~loc extension_node [] ]
 

--- a/test/driver/exception_handling/extender.ml
+++ b/test/driver/exception_handling/extender.ml
@@ -3,8 +3,7 @@ open Ppxlib
 let expand_into_extension_node ~ctxt =
   let loc = Expansion_context.Extension.extension_point_loc ctxt in
   let extension_node =
-    Location.Error.(
-      make ~loc "An error message in an extension node" ~sub:[] |> to_extension)
+    Location.extensionf ~loc "An error message in an extension node"
   in
   Ast_builder.Default.pexp_extension ~loc extension_node
 

--- a/test/driver/exception_handling/extender.ml
+++ b/test/driver/exception_handling/extender.ml
@@ -3,7 +3,7 @@ open Ppxlib
 let expand_into_extension_node ~ctxt =
   let loc = Expansion_context.Extension.extension_point_loc ctxt in
   let extension_node =
-    Location.extensionf ~loc "An error message in an extension node"
+    Location.error_extensionf ~loc "An error message in an extension node"
   in
   Ast_builder.Default.pexp_extension ~loc extension_node
 

--- a/test/driver/exception_handling/whole_file_extension_point.ml
+++ b/test/driver/exception_handling/whole_file_extension_point.ml
@@ -10,9 +10,7 @@ let () =
           | hd :: _ -> hd.pstr_loc
         in
         let extension_node =
-          Location.Error.(
-            make ~loc "An error message in an extension node" ~sub:[]
-            |> to_extension)
+          Location.extensionf ~loc "An error message in an extension node"
         in
         [ Ast_builder.Default.pstr_extension ~loc extension_node [] ])
       "raise_exc")

--- a/test/driver/exception_handling/whole_file_extension_point.ml
+++ b/test/driver/exception_handling/whole_file_extension_point.ml
@@ -10,7 +10,7 @@ let () =
           | hd :: _ -> hd.pstr_loc
         in
         let extension_node =
-          Location.extensionf ~loc "An error message in an extension node"
+          Location.error_extensionf ~loc "An error message in an extension node"
         in
         [ Ast_builder.Default.pstr_extension ~loc extension_node [] ])
       "raise_exc")


### PR DESCRIPTION
This is part of the #314 tasks.

The examples are updated to embed errors using the new function, instead of raising located errors.