### PR TITLE
Update of the manual to document error reporting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ unreleased
 
 - Driver, when run with `--check`: Allow `toplevel_printer` attributes (#340, @pitag-ha)
 
+- Documentation: Add a section on reporting errors by embedding extension nodes
+  in the AST (#318, @panglesd)
+
 0.26.0 (21/03/2022)
 -------------------
 

--- a/doc/manual.mld
+++ b/doc/manual.mld
@@ -586,3 +586,101 @@ the type of the whole [metaquot] extension point. E.g. you can write:
           let structure_item =
             [%stri let [%p some_pat] : [%t some_type] = [%e some_expr]]
 ]}
+
+{2 Handling errors}
+
+In order to give a nice user experience when reporting errors or failures in a ppx, it is necessary to include as much of the generated content as possible. Most IDE tools, such as Merlin, rely on the AST for their features, such as displaying type, jumping to definition or showing the list of errors.
+
+A common way to report an error is to throw an exception. However, this method interrupts the execution flow of the ppxlib driver and leaves later PPX's unexpanded when handing the AST over to merlin.
+
+Instead, it is better to always return a valid AST, as complete as possible, but with "error extension nodes" at every place where successful code generation was impossible. Error extension nodes are special extension nodes [[%ocaml.error error_message]], which can be embedded into a valid AST and are interpreted later as errors, for instance by the compiler or Merlin. As all extension nodes, they can be put {{:https://ocaml.org/manual/extensionnodes.html}at many places in the AST}, to replace for instance structure items, expressions or patterns.
+
+So whenever you're in doubt if to throw an exception or if to embed the error as an error extension node when writing a ppx rewriter, the answer is most likely: embed the error is the way to go! And whenever you're in doubt about where exactly inside the AST to embed the error, a good rule of thumb is: as deep in the AST as possible.
+
+For instance, suppose a rewriter is supposed to define a new record type, but there is an error in the generation of the type of one field. In order to have the most complete AST as output, the rewriter can still define the type and all of its fields, putting an extension node in place of the type of the faulty field:
+
+{[
+   type long_record = {
+     field_1: int;
+     field_2: [%ocaml.error "field_2 could not be implemented due to foo"];
+   }
+]}
+
+Ppxlib provides a function in its API to create error extension nodes: {!Ppxlib.Location.error_extensionf}. This function creates an extension node, which has then to be transformed in the right kind of node using functions such as for instance {!Ppxlib.Ast_builder.Default.pexp_extension}.
+
+{3 A documented example}
+
+Let us give an example. We will define a deriver on types records, which constructs a default value from a given type. For instance, the derivation on the type [type t = { x:int; y: float; z: string}] would yield [let default_t = {x= 0; y= 0.; z= ""}]. This deriver has two limitations:
+
+1. It does not work on other types than records,
+2. It only works for records containing fields of type [string], [int] or [float].
+
+The rewriter should warn the user about these limitations with a good error reporting. Let us first look at the second point. Here is the function mapping the fields from the type definition to a default expression.
+
+{[
+          let create_record ~loc fields =
+            let declaration_to_instantiation (ld : label_declaration) =
+              let loc = ld.pld_loc in
+              let { pld_type; pld_name; _ } = ld in
+              let e =
+                match pld_type with
+                | { ptyp_desc = Ptyp_constr ({ txt = Lident "string"; _ }, []); _ } ->
+                    pexp_constant ~loc (Pconst_string ("", loc, None))
+                | { ptyp_desc = Ptyp_constr ({ txt = Lident "int"; _ }, []); _ } ->
+                    pexp_constant ~loc (Pconst_integer ("0", None))
+                | { ptyp_desc = Ptyp_constr ({ txt = Lident "float"; _ }, []); _ } ->
+                    pexp_constant ~loc (Pconst_float ("0.", None))
+                | _ ->
+                    pexp_extension ~loc
+                    @@ Location.error_extensionf ~loc
+                         "Default value can only be derived for int, float, and string."
+              in
+              ({ txt = Lident pld_name.txt; loc }, e)
+            in
+            let l = List.map fields ~f:declaration_to_instantiation in
+            pexp_record ~loc l None
+]}
+
+
+When the record definition contains several fields with types other than [int], [float] or [string], several error nodes are added in the AST. Moreover, the location of the error nodes corresponds to the definition of the record fields. This allows tools such as Merlin to report all errors at once, at the right location, resulting in a better workflow than having to recompile everytime one error is corrected to see the next one.
+
+The first limitation is that the deriver cannot work on non record types. However, we decided here to derive a default value even in the case of non-record types, so that it does not appear as undefined in the remaining of the file. This impossible value consists of an error extension node.
+
+{[
+          let generate_impl ~ctxt (_rec_flag, type_declarations) =
+            let loc = Expansion_context.Deriver.derived_item_loc ctxt in
+            List.map type_declarations ~f:(fun (td : type_declaration) ->
+                let e, name =
+                  match td with
+                  | { ptype_kind = Ptype_record fields; ptype_name; ptype_loc; _ } ->
+                      (create_record ~loc:ptype_loc fields, ptype_name)
+                  | { ptype_name; ptype_loc; _ } ->
+                      ( pexp_extension ~loc
+                        @@ Location.error_extensionf ~loc:ptype_loc
+                             "Cannot derive accessors for non record type %s"
+                             ptype_name.txt,
+                        ptype_name )
+                in
+                [
+                  pstr_value ~loc Nonrecursive
+                    [
+                      {
+                        pvb_pat = ppat_var ~loc { txt = "default_" ^ name.txt; loc };
+                        pvb_expr = e;
+                        pvb_attributes = [];
+                        pvb_loc = loc;
+                      };
+                    ];
+                ])
+            |> List.concat
+]}
+
+{3 In case of panic}
+
+In some rare cases, it might happen that a whole file rewriter is not able to output a meaningful AST. In this case, they might be tempted to raise a located error: an exception that includes the location of the error. Moreover, this has historically been what was suggested to do by ppxlib examples, but is now discouraged in most of the cases, as it prevent Merlin features to work well.
+
+If such an exception is uncaught, the binary will return with an error code and the exeption be pretty-printed, including the location. When the driver is spawned with the [-embed-errors] or [-as-ppx] flags, the driver will look for located error. If it catches one, it will stop its chain of rewriting at this point, and output an AST consisting of the located error followed by the last valid AST: the one passed to the raising rewriter.
+
+Even more in context-free rewriters, raising should be avoided, in favour of outputting a single error node when a finer grained reporting is not needed or possible. As the whole context-free rewriting is done in one traverse of the AST, a single raise will cancel both the context-free pass and upcoming rewriters, and the AST prior to the context-free pass will be outputted together with the error.
+
+The function provided by the API to raise located errors is {!Ppxlib.Location.raise_errorf}.

--- a/doc/manual.mld
+++ b/doc/manual.mld
@@ -677,9 +677,9 @@ The first limitation is that the deriver cannot work on non record types. Howeve
 
 {3 In case of panic}
 
-In some rare cases, it might happen that a whole file rewriter is not able to output a meaningful AST. In this case, they might be tempted to raise a located error: an exception that includes the location of the error. Moreover, this has historically been what was suggested to do by ppxlib examples, but is now discouraged in most of the cases, as it prevent Merlin features to work well.
+In some rare cases, it might happen that a whole file rewriter is not able to output a meaningful AST. In this case, they might be tempted to raise a located error: an exception that includes the location of the error. Moreover, this has historically been what was suggested to do by ppxlib examples, but is now discouraged in most of the cases, as it prevents Merlin features to work well.
 
-If such an exception is uncaught, the binary will return with an error code and the exeption be pretty-printed, including the location. When the driver is spawned with the [-embed-errors] or [-as-ppx] flags, the driver will look for located error. If it catches one, it will stop its chain of rewriting at this point, and output an AST consisting of the located error followed by the last valid AST: the one passed to the raising rewriter.
+If such an exception is uncaught, the ppx driver will return with an error code and the exception will be pretty-printed, including the location (that's the case when the driver is called by dune). When the driver is spawned with the [-embed-errors] or [-as-ppx] flags (that's the case when the driver is called by merlin), the driver will look for located error. If it catches one, it will stop its chain of rewriting at this point, and output an AST consisting of the located error followed by the last valid AST: the one passed to the raising rewriter.
 
 Even more in context-free rewriters, raising should be avoided, in favour of outputting a single error node when a finer grained reporting is not needed or possible. As the whole context-free rewriting is done in one traverse of the AST, a single raise will cancel both the context-free pass and upcoming rewriters, and the AST prior to the context-free pass will be outputted together with the error.
 

--- a/doc/manual.mld
+++ b/doc/manual.mld
@@ -589,7 +589,10 @@ the type of the whole [metaquot] extension point. E.g. you can write:
 
 {2 Handling errors}
 
+
 In order to give a nice user experience when reporting errors or failures in a ppx, it is necessary to include as much of the generated content as possible. Most IDE tools, such as Merlin, rely on the AST for their features, such as displaying type, jumping to definition or showing the list of errors.
+
+{3 Embedding the errors in the AST}
 
 A common way to report an error is to throw an exception. However, this method interrupts the execution flow of the ppxlib driver and leaves later PPX's unexpanded when handing the AST over to merlin.
 
@@ -606,14 +609,16 @@ For instance, suppose a rewriter is supposed to define a new record type, but th
    }
 ]}
 
-Ppxlib provides a function in its API to create error extension nodes: {!Ppxlib.Location.error_extensionf}. This function creates an extension node, which has then to be transformed in the right kind of node using functions such as for instance {!Ppxlib.Ast_builder.Default.pexp_extension}.
+Ppxlib provides a function in its API to create error extension nodes: {{!Ppxlib.Location.error_extensionf}[error_extensionf]}. This function creates an extension node, which has then to be transformed in the right kind of node using functions such as for instance {{!Ppxlib.Ast_builder.Default.pexp_extension}[pexp_extension]}.
 
 {3 A documented example}
 
 Let us give an example. We will define a deriver on types records, which constructs a default value from a given type. For instance, the derivation on the type [type t = { x:int; y: float; z: string}] would yield [let default_t = {x= 0; y= 0.; z= ""}]. This deriver has two limitations:
 
-1. It does not work on other types than records,
-2. It only works for records containing fields of type [string], [int] or [float].
+{ol
+{- It does not work on other types than records,}
+{- It only works for records containing fields of type [string], [int] or [float].}
+}
 
 The rewriter should warn the user about these limitations with a good error reporting. Let us first look at the second point. Here is the function mapping the fields from the type definition to a default expression.
 
@@ -677,10 +682,40 @@ The first limitation is that the deriver cannot work on non record types. Howeve
 
 {3 In case of panic}
 
-In some rare cases, it might happen that a whole file rewriter is not able to output a meaningful AST. In this case, they might be tempted to raise a located error: an exception that includes the location of the error. Moreover, this has historically been what was suggested to do by ppxlib examples, but is now discouraged in most of the cases, as it prevents Merlin features to work well.
+In some rare cases, it might happen that a whole file rewriter is not able to output a meaningful AST. In this case, they might be tempted to raise a located error: an exception that includes the location of the error. Moreover, this h as historically been what was suggested to do by ppxlib examples, but is now discouraged in most of the cases, as it prevents Merlin features to work well.
 
 If such an exception is uncaught, the ppx driver will return with an error code and the exception will be pretty-printed, including the location (that's the case when the driver is called by dune). When the driver is spawned with the [-embed-errors] or [-as-ppx] flags (that's the case when the driver is called by merlin), the driver will look for located error. If it catches one, it will stop its chain of rewriting at this point, and output an AST consisting of the located error followed by the last valid AST: the one passed to the raising rewriter.
 
 Even more in context-free rewriters, raising should be avoided, in favour of outputting a single error node when a finer grained reporting is not needed or possible. As the whole context-free rewriting is done in one traverse of the AST, a single raise will cancel both the context-free pass and upcoming rewriters, and the AST prior to the context-free pass will be outputted together with the error.
 
-The function provided by the API to raise located errors is {!Ppxlib.Location.raise_errorf}.
+The function provided by the API to raise located errors is {{!Ppxlib.Location.raise_errorf}[raise_errorf]}.
+
+{3 Migrating from raising to embedding errors}
+
+Lots of ppx-es exclusively use {{!Ppxlib.Location.raise_errorf}[raise_errorf]} to report errors, instead of the more merlin friendly way consisting of embedding errors in the AST, as described in this section.
+
+If you want to migrate such a codebase to the embedding approach, here are a few recipes to do that. Indeed, it might not be completely trivial, as raising can be done anywhere in the code, including in places where "embedding" would not make sense. What you can do is to turn your internal raising functions to function returning a [result] type.
+
+The workflow for this change would look like this:
+
+{ol
+{- Search through your code all uses of {{!Ppxlib.Location.raise_errorf}[raise_errorf]}, using for instance [grep].}
+{- For each of them, turn them into function returning a [(_, extension) result] type, using {{!Ppxlib.Location.error_extensionf}[error_extensionf]} to generate the [Error].}
+{- Let the compiler or merlin tell you where you need to propagate the [result] type (most certainly using [map]s and [bind]s).}
+{- When you have propagated until a point where you can, embed the extension in case of [Error extension].}
+}
+
+This is quite convenient, as it allows you to do a "type-driven" modification, using at full the static analysis of OCaml to never omit a special case, and to confidently find the place the most deeply in the AST to embed the error. However, it might induces quite a lot of code modification, and exceptions are sometimes convenient to use, depending on the taste. In case you want to do only a very simple to keep using exception, catch them and turn them into extension points embedded in the AST, here is an example:
+
+{[
+let rewrite_extension_point loc payload =
+  try generate_ast payload
+  with exn ->
+    let get_error exn =
+      match Location.Error.of_exn exn with
+      | None -> raise exn
+      | Some error -> error
+    in
+    let extension = exn |> get_error |> Location.Error.to_extension in
+    Ast_builder.Default.pstr_extension ~loc ext []
+]}


### PR DESCRIPTION
This PR is part of the #314 tasks.

It adds a section about error reporting in the `ppx for plugin authors` section.

Note that it assumes that #316 has been merged, as it mentions the new API.