### PR TITLE
Preview: upgrade to ocamlformat.0.21.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version=0.20.0
+version=0.21.0
 profile=conventional
 parse-docstrings=true

--- a/ast/ast.ml
+++ b/ast/ast.ml
@@ -210,24 +210,25 @@ and core_type_desc = Parsetree.core_type_desc =
      [< `A|`B ]        (flag = Closed; labels = Some [])
      [< `A|`B > `X `Y ](flag = Closed; labels = Some ["X";"Y"])
   *)
-  | Ptyp_poly of string loc list * core_type (* 'a1 ... 'an. T
+  | Ptyp_poly of string loc list * core_type
+    (* 'a1 ... 'an. T
 
-                                                Can only appear in the following context:
+       Can only appear in the following context:
 
-                                                - As the core_type of a Ppat_constraint node corresponding
-                                                to a constraint on a let-binding: let x : 'a1 ... 'an. T
-                                                = e ...
+       - As the core_type of a Ppat_constraint node corresponding
+       to a constraint on a let-binding: let x : 'a1 ... 'an. T
+       = e ...
 
-                                                - Under Cfk_virtual for methods (not values).
+       - Under Cfk_virtual for methods (not values).
 
-                                                - As the core_type of a Pctf_method node.
+       - As the core_type of a Pctf_method node.
 
-                                                - As the core_type of a Pexp_poly node.
+       - As the core_type of a Pexp_poly node.
 
-                                                - As the pld_type field of a label_declaration.
+       - As the pld_type field of a label_declaration.
 
-                                                - As a core_type of a Ptyp_object node.
-                                             *)
+       - As a core_type of a Ptyp_object node.
+    *)
   | Ptyp_package of package_type
   (* (module S) *)
   | Ptyp_extension of extension

--- a/src/ast_pattern.mli
+++ b/src/ast_pattern.mli
@@ -13,11 +13,15 @@ open! Import
     To understand how to use it, let's consider the example of ppx_inline_test.
     We want to recognize patterns of the form:
 
-    {[ let%test "name" = expr ]}
+    {[
+      let%test "name" = expr
+    ]}
 
     Which is a syntactic sugar for:
 
-    {[ [%%test let "name" = expr] ]}
+    {[
+      [%%test let "name" = expr]
+    ]}
 
     If we wanted to write a function that recognizes the payload of [%%test]
     using normal pattern matching we would write:
@@ -62,7 +66,9 @@ open! Import
     Notice that the place-holders for [name] and [expr] have been replaced by
     [__]. The following pattern with have type:
 
-    {[ (payload, string -> expression -> 'a, 'a) Ast_pattern.t ]}
+    {[
+      (payload, string -> expression -> 'a, 'a) Ast_pattern.t
+    ]}
 
     which means that it matches values of type [payload] and captures a string
     and expression from it. The two captured elements comes from the use of
@@ -98,11 +104,15 @@ val __' : ('a, 'a Loc.t -> 'b, 'b) t
     Note: this should only be used for types that do not embed a location. For
     instance you can use it to capture a string constant:
 
-    {[ estring __' ]}
+    {[
+      estring __'
+    ]}
 
     but using it to capture an expression would not yield the expected result:
 
-    {[ pair (eint (int 42)) __' ]}
+    {[
+      pair (eint (int 42)) __'
+    ]}
 
     In the latter case you should use the [pexp_loc] field of the captured
     expression instead. *)

--- a/src/attribute.mli
+++ b/src/attribute.mli
@@ -108,7 +108,9 @@ val declare :
     "foo.default" declared in the previous example, on this code it will match
     the [@foo.default 0] attribute:
 
-    {[ type t = { x : int [@default 42] [@foo.default 0] } ]}
+    {[
+      type t = { x : int [@default 42] [@foo.default 0] }
+    ]}
 
     This is to allow the user to specify a [@default] attribute for all
     re-writers that use it but still put a specific one for one specific

--- a/src/driver.mli
+++ b/src/driver.mli
@@ -165,7 +165,9 @@ val register_code_transformation :
   [@@deprecated "[since 2015-11] use register_transformation instead"]
 (** Same as:
 
-    {[ register_transformation ~name ~impl ~intf () ]} *)
+    {[
+      register_transformation ~name ~impl ~intf ()
+    ]} *)
 
 val register_correction : loc:Location.t -> repl:string -> unit
 (** Rewriters might call this function to suggest a correction to the code

--- a/src/name.mli
+++ b/src/name.mli
@@ -27,7 +27,9 @@ val split_path : string -> string * string option
 val dot_suffixes : string -> string list
 (** [fold_dot_suffixes "foo.@bar.blah" ~init ~f] is
 
-    {[ [ "bar.blah"; "foo.bar.blah" ] ]} *)
+    {[
+      [ "bar.blah"; "foo.bar.blah" ]
+    ]} *)
 
 module Registrar : sig
   type 'context t


### PR DESCRIPTION
This is a preview of the formatting of your project codebase with the upcoming `ocamlformat.0.21.0`. Note that this package is not yet released in opam (so the linting/formatting task of your CI won't pass), the formatting might also change slightly in the released version as we try to integrate feedback from our users.

The changes on this project are due to:
- the separators of codeblocks `{[]}` in doc-comments are now placed on their own line, this is the new syntax agreed upon with other tools handling odoc comments.

As always, we are happy to hear your feedback!  Thank you for using ocamlformat!