### PR TITLE
Fix and optimize quoter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ unreleased
 
 - Fix Ast_pattern.many (#333, @nojb)
 
+- Fix quoter and optimize identifier quoting (#327, @sim642)
+
 0.26.0 (21/03/2022)
 -------------------
 

--- a/src/quoter.ml
+++ b/src/quoter.ml
@@ -30,4 +30,4 @@ let quote t (e : expression) =
   in
   t.bindings <- binding :: t.bindings;
   t.next_id <- t.next_id + 1;
-  Ast.evar name
+  Ast.eapply (Ast.evar name) [ Ast.eunit ]

--- a/src/quoter.ml
+++ b/src/quoter.ml
@@ -18,16 +18,25 @@ let quote t (e : expression) =
   let loc = e.pexp_loc in
   let (module Ast) = Ast_builder.make loc in
   let name = "__" ^ Int.to_string t.next_id in
+  let binding_expr, quoted_expr =
+    match e with
+    (* Optimize identifier quoting by avoiding closure.
+       See https://github.com/ocaml-ppx/ppx_deriving/pull/252. *)
+    | { pexp_desc = Pexp_ident _; _ } -> (e, Ast.evar name)
+    | _ ->
+        let binding_expr =
+          Ast.pexp_fun Nolabel None
+            (let unit = Ast_builder.Default.Located.lident ~loc "()" in
+             Ast.ppat_construct unit None)
+            e
+        in
+        let quoted_expr = Ast.eapply (Ast.evar name) [ Ast.eunit ] in
+        (binding_expr, quoted_expr)
+  in
   let binding =
     let pat = Ast.pvar name in
-    let expr =
-      Ast.pexp_fun Nolabel None
-        (let unit = Ast_builder.Default.Located.lident ~loc "()" in
-         Ast.ppat_construct unit None)
-        e
-    in
-    Ast.value_binding ~pat ~expr
+    Ast.value_binding ~pat ~expr:binding_expr
   in
   t.bindings <- binding :: t.bindings;
   t.next_id <- t.next_id + 1;
-  Ast.eapply (Ast.evar name) [ Ast.eunit ]
+  quoted_expr

--- a/test/quoter/test.ml
+++ b/test/quoter/test.ml
@@ -18,16 +18,49 @@ let expr1 =
 [%%expect{|
 val expr1 : expression =
   {Ppxlib__.Import.pexp_desc =
-    Ppxlib__.Import.Pexp_ident
-     {Ppxlib__.Import.txt = Ppxlib__.Import.Lident "__0";
-      loc =
-       {Ppxlib__.Import.loc_start =
-         {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
-          pos_cnum = -1};
-        loc_end =
-         {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
-          pos_cnum = -1};
-        loc_ghost = true}};
+    Ppxlib__.Import.Pexp_apply
+     ({Ppxlib__.Import.pexp_desc =
+        Ppxlib__.Import.Pexp_ident
+         {Ppxlib__.Import.txt = Ppxlib__.Import.Lident "__0";
+          loc =
+           {Ppxlib__.Import.loc_start =
+             {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+              pos_bol = 0; pos_cnum = -1};
+            loc_end =
+             {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+              pos_bol = 0; pos_cnum = -1};
+            loc_ghost = true}};
+       pexp_loc =
+        {Ppxlib__.Import.loc_start =
+          {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+           pos_cnum = -1};
+         loc_end =
+          {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+           pos_cnum = -1};
+         loc_ghost = true};
+       pexp_loc_stack = []; pexp_attributes = []},
+     [(Ppxlib__.Import.Nolabel,
+       {Ppxlib__.Import.pexp_desc =
+         Ppxlib__.Import.Pexp_construct
+          ({Ppxlib__.Import.txt = Ppxlib__.Import.Lident "()";
+            loc =
+             {Ppxlib__.Import.loc_start =
+               {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+                pos_bol = 0; pos_cnum = -1};
+              loc_end =
+               {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+                pos_bol = 0; pos_cnum = -1};
+              loc_ghost = true}},
+          None);
+        pexp_loc =
+         {Ppxlib__.Import.loc_start =
+           {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+            pos_cnum = -1};
+          loc_end =
+           {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+            pos_cnum = -1};
+          loc_ghost = true};
+        pexp_loc_stack = []; pexp_attributes = []})]);
    pexp_loc =
     {Ppxlib__.Import.loc_start =
       {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
@@ -41,7 +74,7 @@ val expr1 : expression =
 
 Pprintast.string_of_expression expr1;;
 [%%expect{|
-- : string = "__0"
+- : string = "__0 ()"
 |}]
 
 let expr2 =
@@ -50,16 +83,49 @@ let expr2 =
 [%%expect{|
 val expr2 : expression =
   {Ppxlib__.Import.pexp_desc =
-    Ppxlib__.Import.Pexp_ident
-     {Ppxlib__.Import.txt = Ppxlib__.Import.Lident "__1";
-      loc =
-       {Ppxlib__.Import.loc_start =
-         {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
-          pos_cnum = -1};
-        loc_end =
-         {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
-          pos_cnum = -1};
-        loc_ghost = true}};
+    Ppxlib__.Import.Pexp_apply
+     ({Ppxlib__.Import.pexp_desc =
+        Ppxlib__.Import.Pexp_ident
+         {Ppxlib__.Import.txt = Ppxlib__.Import.Lident "__1";
+          loc =
+           {Ppxlib__.Import.loc_start =
+             {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+              pos_bol = 0; pos_cnum = -1};
+            loc_end =
+             {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+              pos_bol = 0; pos_cnum = -1};
+            loc_ghost = true}};
+       pexp_loc =
+        {Ppxlib__.Import.loc_start =
+          {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+           pos_cnum = -1};
+         loc_end =
+          {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+           pos_cnum = -1};
+         loc_ghost = true};
+       pexp_loc_stack = []; pexp_attributes = []},
+     [(Ppxlib__.Import.Nolabel,
+       {Ppxlib__.Import.pexp_desc =
+         Ppxlib__.Import.Pexp_construct
+          ({Ppxlib__.Import.txt = Ppxlib__.Import.Lident "()";
+            loc =
+             {Ppxlib__.Import.loc_start =
+               {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+                pos_bol = 0; pos_cnum = -1};
+              loc_end =
+               {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+                pos_bol = 0; pos_cnum = -1};
+              loc_ghost = true}},
+          None);
+        pexp_loc =
+         {Ppxlib__.Import.loc_start =
+           {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+            pos_cnum = -1};
+          loc_end =
+           {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+            pos_cnum = -1};
+          loc_ghost = true};
+        pexp_loc_stack = []; pexp_attributes = []})]);
    pexp_loc =
     {Ppxlib__.Import.loc_start =
       {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
@@ -258,15 +324,15 @@ val quoted : expression =
         Some
          {Ppxlib__.Import.pexp_desc =
            Ppxlib__.Import.Pexp_tuple
-            [{Ppxlib__.Import.pexp_desc = Ppxlib__.Import.Pexp_ident ...;
-               pexp_loc = ...; pexp_loc_stack = ...; pexp_attributes = ...};
-              ...];
-           pexp_loc = ...; pexp_loc_stack = ...; pexp_attributes = ...});
-       pexp_loc = ...; pexp_loc_stack = ...; pexp_attributes = ...});
-    pexp_loc = ...; pexp_loc_stack = ...; pexp_attributes = ...}
+            [{Ppxlib__.Import.pexp_desc = Ppxlib__.Import.Pexp_apply (...);
+              pexp_loc = ...; pexp_loc_stack = ...; pexp_attributes = ...};
+             ...];
+          pexp_loc = ...; pexp_loc_stack = ...; pexp_attributes = ...});
+      pexp_loc = ...; pexp_loc_stack = ...; pexp_attributes = ...});
+   pexp_loc = ...; pexp_loc_stack = ...; pexp_attributes = ...}
 |}]
 
 Pprintast.string_of_expression quoted;;
 [%%expect{|
-- : string = "let rec __1 () = bar\nand __0 () = foo in [__0; __1]"
+- : string = "let rec __1 () = bar\nand __0 () = foo in [__0 (); __1 ()]"
 |}]

--- a/test/quoter/test.ml
+++ b/test/quoter/test.ml
@@ -18,49 +18,16 @@ let expr1 =
 [%%expect{|
 val expr1 : expression =
   {Ppxlib__.Import.pexp_desc =
-    Ppxlib__.Import.Pexp_apply
-     ({Ppxlib__.Import.pexp_desc =
-        Ppxlib__.Import.Pexp_ident
-         {Ppxlib__.Import.txt = Ppxlib__.Import.Lident "__0";
-          loc =
-           {Ppxlib__.Import.loc_start =
-             {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
-              pos_bol = 0; pos_cnum = -1};
-            loc_end =
-             {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
-              pos_bol = 0; pos_cnum = -1};
-            loc_ghost = true}};
-       pexp_loc =
-        {Ppxlib__.Import.loc_start =
-          {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
-           pos_cnum = -1};
-         loc_end =
-          {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
-           pos_cnum = -1};
-         loc_ghost = true};
-       pexp_loc_stack = []; pexp_attributes = []},
-     [(Ppxlib__.Import.Nolabel,
-       {Ppxlib__.Import.pexp_desc =
-         Ppxlib__.Import.Pexp_construct
-          ({Ppxlib__.Import.txt = Ppxlib__.Import.Lident "()";
-            loc =
-             {Ppxlib__.Import.loc_start =
-               {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
-                pos_bol = 0; pos_cnum = -1};
-              loc_end =
-               {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
-                pos_bol = 0; pos_cnum = -1};
-              loc_ghost = true}},
-          None);
-        pexp_loc =
-         {Ppxlib__.Import.loc_start =
-           {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
-            pos_cnum = -1};
-          loc_end =
-           {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
-            pos_cnum = -1};
-          loc_ghost = true};
-        pexp_loc_stack = []; pexp_attributes = []})]);
+    Ppxlib__.Import.Pexp_ident
+     {Ppxlib__.Import.txt = Ppxlib__.Import.Lident "__0";
+      loc =
+       {Ppxlib__.Import.loc_start =
+         {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+          pos_cnum = -1};
+        loc_end =
+         {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+          pos_cnum = -1};
+        loc_ghost = true}};
    pexp_loc =
     {Ppxlib__.Import.loc_start =
       {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
@@ -74,7 +41,7 @@ val expr1 : expression =
 
 Pprintast.string_of_expression expr1;;
 [%%expect{|
-- : string = "__0 ()"
+- : string = "__0"
 |}]
 
 let expr2 =
@@ -83,10 +50,37 @@ let expr2 =
 [%%expect{|
 val expr2 : expression =
   {Ppxlib__.Import.pexp_desc =
+    Ppxlib__.Import.Pexp_ident
+     {Ppxlib__.Import.txt = Ppxlib__.Import.Lident "__1";
+      loc =
+       {Ppxlib__.Import.loc_start =
+         {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+          pos_cnum = -1};
+        loc_end =
+         {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+          pos_cnum = -1};
+        loc_ghost = true}};
+   pexp_loc =
+    {Ppxlib__.Import.loc_start =
+      {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       pos_cnum = -1};
+     loc_end =
+      {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       pos_cnum = -1};
+     loc_ghost = true};
+   pexp_loc_stack = []; pexp_attributes = []}
+|}]
+
+let expr3 =
+  Ast.eapply ~loc:Location.none (Ast.evar "foo" ~loc:Location.none) [Ast.eunit ~loc:Location.none]
+  |> Quoter.quote quoter
+[%%expect{|
+val expr3 : expression =
+  {Ppxlib__.Import.pexp_desc =
     Ppxlib__.Import.Pexp_apply
      ({Ppxlib__.Import.pexp_desc =
         Ppxlib__.Import.Pexp_ident
-         {Ppxlib__.Import.txt = Ppxlib__.Import.Lident "__1";
+         {Ppxlib__.Import.txt = Ppxlib__.Import.Lident "__2";
           loc =
            {Ppxlib__.Import.loc_start =
              {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
@@ -137,8 +131,13 @@ val expr2 : expression =
    pexp_loc_stack = []; pexp_attributes = []}
 |}]
 
+Pprintast.string_of_expression expr3;;
+[%%expect{|
+- : string = "__2 ()"
+|}]
+
 let quoted =
-  let expr = Ast.elist ~loc:Location.none [expr1; expr2] in
+  let expr = Ast.elist ~loc:Location.none [expr1; expr2; expr3] in
   Quoter.sanitize quoter expr
 [%%expect{|
 val quoted : expression =
@@ -147,7 +146,7 @@ val quoted : expression =
      [{Ppxlib__.Import.pvb_pat =
         {Ppxlib__.Import.ppat_desc =
           Ppxlib__.Import.Ppat_var
-           {Ppxlib__.Import.txt = "__1";
+           {Ppxlib__.Import.txt = "__2";
             loc =
              {Ppxlib__.Import.loc_start =
                {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
@@ -190,16 +189,49 @@ val quoted : expression =
               loc_ghost = true};
             ppat_loc_stack = []; ppat_attributes = []},
            {Ppxlib__.Import.pexp_desc =
-             Ppxlib__.Import.Pexp_ident
-              {Ppxlib__.Import.txt = Ppxlib__.Import.Lident "bar";
-               loc =
-                {Ppxlib__.Import.loc_start =
-                  {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
-                   pos_bol = 0; pos_cnum = -1};
-                 loc_end =
-                  {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
-                   pos_bol = 0; pos_cnum = -1};
-                 loc_ghost = true}};
+             Ppxlib__.Import.Pexp_apply
+              ({Ppxlib__.Import.pexp_desc =
+                 Ppxlib__.Import.Pexp_ident
+                  {Ppxlib__.Import.txt = Ppxlib__.Import.Lident "foo";
+                   loc =
+                    {Ppxlib__.Import.loc_start =
+                      {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+                       pos_bol = 0; pos_cnum = -1};
+                     loc_end =
+                      {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+                       pos_bol = 0; pos_cnum = -1};
+                     loc_ghost = true}};
+                pexp_loc =
+                 {Ppxlib__.Import.loc_start =
+                   {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+                    pos_bol = 0; pos_cnum = -1};
+                  loc_end =
+                   {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+                    pos_bol = 0; pos_cnum = -1};
+                  loc_ghost = true};
+                pexp_loc_stack = []; pexp_attributes = []},
+              [(Ppxlib__.Import.Nolabel,
+                {Ppxlib__.Import.pexp_desc =
+                  Ppxlib__.Import.Pexp_construct
+                   ({Ppxlib__.Import.txt = Ppxlib__.Import.Lident "()";
+                     loc =
+                      {Ppxlib__.Import.loc_start =
+                        {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+                         pos_bol = 0; pos_cnum = -1};
+                       loc_end =
+                        {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+                         pos_bol = 0; pos_cnum = -1};
+                       loc_ghost = true}},
+                   None);
+                 pexp_loc =
+                  {Ppxlib__.Import.loc_start =
+                    {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+                     pos_bol = 0; pos_cnum = -1};
+                   loc_end =
+                    {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+                     pos_bol = 0; pos_cnum = -1};
+                   loc_ghost = true};
+                 pexp_loc_stack = []; pexp_attributes = []})]);
             pexp_loc =
              {Ppxlib__.Import.loc_start =
                {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
@@ -209,6 +241,57 @@ val quoted : expression =
                 pos_bol = 0; pos_cnum = -1};
               loc_ghost = true};
             pexp_loc_stack = []; pexp_attributes = []});
+         pexp_loc =
+          {Ppxlib__.Import.loc_start =
+            {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+             pos_cnum = -1};
+           loc_end =
+            {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+             pos_cnum = -1};
+           loc_ghost = true};
+         pexp_loc_stack = []; pexp_attributes = []};
+       pvb_attributes = [];
+       pvb_loc =
+        {Ppxlib__.Import.loc_start =
+          {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+           pos_cnum = -1};
+         loc_end =
+          {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+           pos_cnum = -1};
+         loc_ghost = true}};
+      {Ppxlib__.Import.pvb_pat =
+        {Ppxlib__.Import.ppat_desc =
+          Ppxlib__.Import.Ppat_var
+           {Ppxlib__.Import.txt = "__1";
+            loc =
+             {Ppxlib__.Import.loc_start =
+               {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+                pos_bol = 0; pos_cnum = -1};
+              loc_end =
+               {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+                pos_bol = 0; pos_cnum = -1};
+              loc_ghost = true}};
+         ppat_loc =
+          {Ppxlib__.Import.loc_start =
+            {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+             pos_cnum = -1};
+           loc_end =
+            {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+             pos_cnum = -1};
+           loc_ghost = true};
+         ppat_loc_stack = []; ppat_attributes = []};
+       pvb_expr =
+        {Ppxlib__.Import.pexp_desc =
+          Ppxlib__.Import.Pexp_ident
+           {Ppxlib__.Import.txt = Ppxlib__.Import.Lident "bar";
+            loc =
+             {Ppxlib__.Import.loc_start =
+               {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+                pos_bol = 0; pos_cnum = -1};
+              loc_end =
+               {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
+                pos_bol = 0; pos_cnum = -1};
+              loc_ghost = true}};
          pexp_loc =
           {Ppxlib__.Import.loc_start =
             {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
@@ -243,96 +326,16 @@ val quoted : expression =
           {Ppxlib__.Import.loc_start =
             {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
              pos_cnum = -1};
-           loc_end =
-            {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
-             pos_cnum = -1};
-           loc_ghost = true};
-         ppat_loc_stack = []; ppat_attributes = []};
-       pvb_expr =
-        {Ppxlib__.Import.pexp_desc =
-          Ppxlib__.Import.Pexp_fun (Ppxlib__.Import.Nolabel, None,
-           {Ppxlib__.Import.ppat_desc =
-             Ppxlib__.Import.Ppat_construct
-              ({Ppxlib__.Import.txt = Ppxlib__.Import.Lident "()";
-                loc =
-                 {Ppxlib__.Import.loc_start =
-                   {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
-                    pos_bol = 0; pos_cnum = -1};
-                  loc_end =
-                   {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
-                    pos_bol = 0; pos_cnum = -1};
-                  loc_ghost = true}},
-              None);
-            ppat_loc =
-             {Ppxlib__.Import.loc_start =
-               {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
-                pos_bol = 0; pos_cnum = -1};
-              loc_end =
-               {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
-                pos_bol = 0; pos_cnum = -1};
-              loc_ghost = true};
-            ppat_loc_stack = []; ppat_attributes = []},
-           {Ppxlib__.Import.pexp_desc =
-             Ppxlib__.Import.Pexp_ident
-              {Ppxlib__.Import.txt = Ppxlib__.Import.Lident "foo";
-               loc =
-                {Ppxlib__.Import.loc_start =
-                  {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
-                   pos_bol = 0; pos_cnum = -1};
-                 loc_end =
-                  {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
-                   pos_bol = 0; pos_cnum = -1};
-                 loc_ghost = true}};
-            pexp_loc =
-             {Ppxlib__.Import.loc_start =
-               {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
-                pos_bol = 0; pos_cnum = -1};
-              loc_end =
-               {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
-                pos_bol = 0; pos_cnum = -1};
-              loc_ghost = true};
-            pexp_loc_stack = []; pexp_attributes = []});
-         pexp_loc =
-          {Ppxlib__.Import.loc_start =
-            {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
-             pos_cnum = -1};
-           loc_end =
-            {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
-             pos_cnum = -1};
-           loc_ghost = true};
-         pexp_loc_stack = []; pexp_attributes = []};
-       pvb_attributes = [];
-       pvb_loc =
-        {Ppxlib__.Import.loc_start =
-          {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
-           pos_cnum = -1};
-         loc_end =
-          {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
-           pos_cnum = -1};
-         loc_ghost = true}}],
-     {Ppxlib__.Import.pexp_desc =
-       Ppxlib__.Import.Pexp_construct
-        ({Ppxlib__.Import.txt = Ppxlib__.Import.Lident "::";
-          loc =
-           {Ppxlib__.Import.loc_start =
-             {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
-              pos_bol = 0; pos_cnum = -1};
-            loc_end =
-             {Ppxlib__.Import.pos_fname = "_none_"; pos_lnum = 1;
-              pos_bol = 0; pos_cnum = -1};
-            loc_ghost = true}},
-        Some
-         {Ppxlib__.Import.pexp_desc =
-           Ppxlib__.Import.Pexp_tuple
-            [{Ppxlib__.Import.pexp_desc = Ppxlib__.Import.Pexp_apply (...);
-              pexp_loc = ...; pexp_loc_stack = ...; pexp_attributes = ...};
-             ...];
-          pexp_loc = ...; pexp_loc_stack = ...; pexp_attributes = ...});
-      pexp_loc = ...; pexp_loc_stack = ...; pexp_attributes = ...});
+           loc_end = ...; loc_ghost = ...};
+         ppat_loc_stack = ...; ppat_attributes = ...};
+       pvb_expr = ...; pvb_attributes = ...; pvb_loc = ...};
+      ...],
+     ...);
    pexp_loc = ...; pexp_loc_stack = ...; pexp_attributes = ...}
 |}]
 
 Pprintast.string_of_expression quoted;;
 [%%expect{|
-- : string = "let rec __1 () = bar\nand __0 () = foo in [__0 (); __1 ()]"
+- : string =
+"let rec __2 () = foo ()\nand __1 = bar\nand __0 = foo in [__0; __1; __2 ()]"
 |}]


### PR DESCRIPTION
Thinking about #317 again, I realized that quoting had already been ported to ppxlib, but I was completely unaware of it before (it was very easy to miss in the middle of all the autogenerated documentation).

This PR ports my optimization to the quoter from ppx_deriving to ppxlib: https://github.com/ocaml-ppx/ppx_deriving/pull/252.

Before doing that, I realized that the existing implementation was actually broken: it was missing application of `()` to the quoted name, so I fixed that first.
For identifier-only quoted expressions the two things somewhat cancel each other out, so the changes might be easier understood looking at the commits separately.

I guess nobody noticed it being broken for all these years because nobody is using `Ppxlib.Quoter` (also according to [Sherlocode](https://sherlocode.com/?q=Quoter)).