### PR TITLE
Downstream the sexplib0 constraint from opam-repo

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -19,6 +19,7 @@
   (ocaml-compiler-libs (>= v0.11.0))
   (ppx_derivers (>= 1.0))
   (sexplib0 (>= v0.12))
+  (sexplib0 (and :with-test (< "v0.15"))) ; Printexc.register_printer in sexplib0 changed
   stdlib-shims
   (ocamlfind :with-test)
   (re (and :with-test (>= 1.9.0)))

--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -25,6 +25,7 @@ depends: [
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ppx_derivers" {>= "1.0"}
   "sexplib0" {>= "v0.12"}
+  "sexplib0" {with-test & < "v0.15"}
   "stdlib-shims"
   "ocamlfind" {with-test}
   "re" {with-test & >= "1.9.0"}


### PR DESCRIPTION
Jane Street has now published its v0.15 release on opam which is breaking our CI, since sexplib0 has re-formatted one of its registered exception printers. To fix that, I'm simply downstreaming the fix the opam maintainers (probably @kit-ty-kate I'd guess) have come up with. Directly upgrading to sexplib0 >= v0.15.0 isn't viable yet, because ocamlformat isn't compatible with base.v0.15.0 yet. We should do that as soon as possible though.

@panglesd, if you could quickly review this 2-liner PR tomorrow (Tuesday) morning, that would be really great! Merging this will hopefully fix our CI and once the CI of the bump-AST PR passes, I'll merge the bump-AST PR and release. I'd love to do that tomorrow if possible.