### PR TITLE
Prefer embedding to raising when possible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,12 @@ unreleased
 - Documentation: Add a section on reporting errors by embedding extension nodes
   in the AST (#318, @panglesd)
 
+- Driver: In the case of ppxlib internal errors, embed those errors instead of
+  raising to return a meaningful AST (#329, @panglesd)
+
+- API: For each function that could raise a located error, add a function that
+  return a `result` instead (#329, @panglesd)
+
 0.26.0 (21/03/2022)
 -------------------
 

--- a/src/ast_pattern.ml
+++ b/src/ast_pattern.ml
@@ -5,17 +5,23 @@ let save_context ctx = ctx.matched
 let restore_context ctx backup = ctx.matched <- backup
 let incr_matched c = c.matched <- c.matched + 1
 
-let parse (T f) loc ?on_error x k =
-  try f { matched = 0 } loc x k
+let parse_res (T f) loc ?on_error x k =
+  try Ok (f { matched = 0 } loc x k)
   with Expected (loc, expected) -> (
     match on_error with
-    | None -> Location.raise_errorf ~loc "%s expected" expected
-    | Some f -> f ())
+    | None -> Error (Location.Error.createf ~loc "%s expected" expected, [])
+    | Some f -> Ok (f ()))
+
+let parse (T f) loc ?on_error x k =
+  match parse_res (T f) loc ?on_error x k with
+  | Ok r -> r
+  | Error (r, _) -> Location.Error.raise r
 
 module Packed = struct
   type ('a, 'b) t = T : ('a, 'b, 'c) Ast_pattern0.t * 'b -> ('a, 'c) t
 
   let create t f = T (t, f)
+  let parse_res (T (t, f)) loc x = parse_res t loc x f
   let parse (T (t, f)) loc x = parse t loc x f
 end
 

--- a/src/ast_pattern.mli
+++ b/src/ast_pattern.mli
@@ -83,7 +83,16 @@ type ('a, 'b, 'c) t = ('a, 'b, 'c) Ast_pattern0.t
 
 val parse :
   ('a, 'b, 'c) t -> Location.t -> ?on_error:(unit -> 'c) -> 'a -> 'b -> 'c
-(** Matches a value against a pattern. *)
+(** Matches a value against a pattern. Raise a located error in case of failure. *)
+
+val parse_res :
+  ('a, 'b, 'c) t ->
+  Location.t ->
+  ?on_error:(unit -> 'c) ->
+  'a ->
+  'b ->
+  ('c, Location.Error.t NonEmptyList.t) result
+(** Matches a value against a pattern and return a result. *)
 
 module Packed : sig
   type ('a, 'b, 'c) pattern = ('a, 'b, 'c) t
@@ -91,6 +100,12 @@ module Packed : sig
 
   val create : ('a, 'b, 'c) pattern -> 'b -> ('a, 'c) t
   val parse : ('a, 'b) t -> Location.t -> 'a -> 'b
+
+  val parse_res :
+    ('a, 'b) t ->
+    Location.t ->
+    'a ->
+    ('b, Location.Error.t NonEmptyList.t) result
 end
 with type ('a, 'b, 'c) pattern := ('a, 'b, 'c) t
 

--- a/src/attribute.ml
+++ b/src/attribute.ml
@@ -308,7 +308,7 @@ let explicitly_drop =
 let get_internal =
   let rec find_best_match t attributes longest_match =
     match attributes with
-    | [] -> longest_match
+    | [] -> Ok longest_match
     | ({ attr_name = name; _ } as attr) :: rest ->
         if Name.Pattern.matches t.name name.txt then
           match longest_match with
@@ -318,7 +318,10 @@ let get_internal =
               let len' = String.length name'.txt in
               if len > len' then find_best_match t rest (Some attr)
               else if len < len' then find_best_match t rest longest_match
-              else Location.raise_errorf ~loc:name.loc "Duplicated attribute"
+              else
+                Error
+                  ( Location.Error.createf ~loc:name.loc "Duplicated attribute",
+                    [] )
         else find_best_match t rest longest_match
   in
   fun t attributes -> find_best_match t attributes None
@@ -326,54 +329,80 @@ let get_internal =
 let convert ?(do_mark_as_seen = true) pattern attr =
   if do_mark_as_seen then mark_as_seen attr;
   let (Payload_parser (pattern, k)) = pattern in
-  Ast_pattern.parse pattern
+  Ast_pattern.parse_res pattern
     (Common.loc_of_payload attr)
     attr.attr_payload
     (k ~name_loc:attr.attr_name.loc)
 
-let get t ?mark_as_seen:do_mark_as_seen x =
+let get_res t ?mark_as_seen:do_mark_as_seen x =
+  let open Result in
   let attrs = Context.get_attributes t.context x in
-  match get_internal t attrs with
-  | None -> None
-  | Some attr -> Some (convert t.payload attr ?do_mark_as_seen)
+  get_internal t attrs >>= fun res ->
+  match res with
+  | None -> Ok None
+  | Some attr ->
+      convert t.payload attr ?do_mark_as_seen >>| fun value -> Some value
 
-let consume t x =
+let get t ?mark_as_seen:do_mark_as_seen x =
+  get_res t ?mark_as_seen:do_mark_as_seen x
+  |> Result.handle_error ~f:(fun (err, _) -> Location.Error.raise err)
+
+let consume_res t x =
+  let open Result in
   let attrs = Context.get_attributes t.context x in
-  match get_internal t attrs with
-  | None -> None
+  get_internal t attrs >>= fun res ->
+  match res with
+  | None -> Ok None
   | Some attr ->
       let attrs = List.filter attrs ~f:(fun attr' -> not (attr == attr')) in
       let x = Context.set_attributes t.context x attrs in
-      Some (x, convert t.payload attr)
+      convert t.payload attr >>| fun value -> Some (x, value)
 
-let remove_seen (type a) (context : a Context.t) packeds (x : a) =
+let consume t x =
+  consume_res t x
+  |> Result.handle_error ~f:(fun (err, _) -> Location.Error.raise err)
+
+let remove_seen_res (type a) (context : a Context.t) packeds (x : a) =
+  let open Result in
   let attrs = Context.get_attributes context x in
-  let matched =
-    let rec loop acc = function
-      | [] -> acc
-      | T t :: rest ->
-          if Context.equal t.context context then
-            match get_internal t attrs with
-            | None -> loop acc rest
-            | Some attr ->
-                let name = attr.attr_name in
-                if Attribute_table.mem not_seen name then loop acc rest
-                else loop (attr :: acc) rest
-          else loop acc rest
-    in
-    loop [] packeds
+  let rec loop acc = function
+    | [] -> Ok acc
+    | T t :: rest ->
+        if Context.equal t.context context then
+          get_internal t attrs >>= fun res ->
+          match res with
+          | None -> loop acc rest
+          | Some attr ->
+              let name = attr.attr_name in
+              if Attribute_table.mem not_seen name then loop acc rest
+              else loop (attr :: acc) rest
+        else loop acc rest
   in
+  loop [] packeds >>| fun matched ->
   let attrs =
     List.filter attrs ~f:(fun attr' -> not (List.memq ~set:matched attr'))
   in
   Context.set_attributes context x attrs
 
-let pattern t p =
+let remove_seen (type a) (context : a Context.t) packeds (x : a) =
+  remove_seen_res (context : a Context.t) packeds (x : a)
+  |> Result.handle_error ~f:(fun (err, _) -> Location.Error.raise err)
+
+let pattern_res t p =
+  let open Result in
   let f = Ast_pattern.to_func p in
   Ast_pattern.of_func (fun ctx loc x k ->
-      match consume t x with
+      consume_res t x >>| fun res ->
+      match res with
       | None -> f ctx loc x (k None)
       | Some (x, v) -> f ctx loc x (k (Some v)))
+
+let pattern t p =
+  pattern_res t p |> Ast_pattern.to_func
+  |> (fun f a b c d ->
+       f a b c d
+       |> Result.handle_error ~f:(fun (err, _) -> Location.Error.raise err))
+  |> Ast_pattern.of_func
 
 module Floating = struct
   module Context = Floating_context
@@ -394,9 +423,10 @@ module Floating = struct
       payload = Payload_parser (pattern, fun ~name_loc:_ -> k);
     }
 
-  let convert ts x =
+  let convert_res ts x =
+    let open Result in
     match ts with
-    | [] -> None
+    | [] -> Ok None
     | { context; _ } :: _ -> (
         assert (List.for_all ts ~f:(fun t -> Context.equal t.context context));
         let attr = Context.get_attribute context x in
@@ -404,16 +434,22 @@ module Floating = struct
         match
           List.filter ts ~f:(fun t -> Name.Pattern.matches t.name name.txt)
         with
-        | [] -> None
-        | [ t ] -> Some (convert t.payload attr)
+        | [] -> Ok None
+        | [ t ] -> convert t.payload attr >>| fun value -> Some value
         | l ->
-            Location.raise_errorf ~loc:name.loc
-              "Multiple match for floating attributes: %s"
-              (String.concat ~sep:", "
-                 (List.map l ~f:(fun t -> Name.Pattern.name t.name))))
+            Error
+              ( Location.Error.createf ~loc:name.loc
+                  "Multiple match for floating attributes: %s"
+                  (String.concat ~sep:", "
+                     (List.map l ~f:(fun t -> Name.Pattern.name t.name))),
+                [] ))
+
+  let convert ts x =
+    convert_res ts x
+    |> Result.handle_error ~f:(fun (err, _) -> Location.Error.raise err)
 end
 
-let check_attribute registrar context name =
+let collect_attribute_errors registrar context name =
   if
     (not
        (Name.Allowlisted.is_allowlisted ~kind:`Attribute name.txt
@@ -421,16 +457,209 @@ let check_attribute registrar context name =
     && Attribute_table.mem not_seen name
   then
     let allowlist = Name.Allowlisted.get_attribute_list () in
-    Name.Registrar.raise_errorf registrar context ~allowlist
-      "Attribute `%s' was not used" name
+    [
+      Name.Registrar.Error.createf registrar context ~allowlist
+        "Attribute `%s' was not used" name;
+    ]
+  else []
+
+let collect_unused_attributes_errors =
+  object (self)
+    inherit [Location.Error.t list] Ast_traverse.fold as super
+
+    method! attribute { attr_name = name; _ } _ =
+      [
+        Location.Error.createf ~loc:name.loc
+          "attribute not expected here, Ppxlib.Attribute needs updating!";
+      ]
+
+    method private check_node : type a.
+        a Context.t -> a -> a * Location.Error.t list =
+      fun context node ->
+        let attrs = Context.get_attributes context node in
+        match attrs with
+        | [] -> (node, [])
+        | _ ->
+            let errors =
+              List.map attrs
+                ~f:(fun
+                     ({ attr_name = name; attr_payload = payload; _ } as attr)
+                   ->
+                  let collected_errors =
+                    self#payload payload []
+                    @ collect_attribute_errors registrar (On_item context) name
+                  in
+                  (* If we allow the attribute to pass through, mark it as seen *)
+                  mark_as_seen attr;
+                  collected_errors)
+              |> List.concat
+            in
+            (Context.set_attributes context node [], errors)
+
+    method private check_floating : type a.
+        a Floating.Context.t -> a -> a * Location.Error.t list =
+      fun context node ->
+        match
+          Floating.Context.get_attribute_if_is_floating_node context node
+        with
+        | None -> (node, [])
+        | Some ({ attr_name = name; attr_payload = payload; _ } as attr) ->
+            let collected_errors =
+              self#payload payload []
+              @ collect_attribute_errors registrar (Floating context) name
+            in
+            mark_as_seen attr;
+            (Floating.Context.replace_by_dummy context node, collected_errors)
+
+    method! label_declaration x acc =
+      let res, errors = self#check_node Label_declaration x in
+      super#label_declaration res (acc @ errors)
+
+    method! constructor_declaration x acc =
+      let res, errors = self#check_node Constructor_declaration x in
+      super#constructor_declaration res (acc @ errors)
+
+    method! type_declaration x acc =
+      let res, errors = self#check_node Type_declaration x in
+      super#type_declaration res (acc @ errors)
+
+    method! type_extension x acc =
+      let res, errors = self#check_node Type_extension x in
+      super#type_extension res (acc @ errors)
+
+    method! type_exception x acc =
+      let res, errors = self#check_node Type_exception x in
+      super#type_exception res (acc @ errors)
+
+    method! extension_constructor x acc =
+      let res, errors = self#check_node Extension_constructor x in
+      super#extension_constructor res (acc @ errors)
+
+    method! pattern x acc =
+      let res, errors = self#check_node Pattern x in
+      super#pattern res (acc @ errors)
+
+    method! core_type x acc =
+      let res, errors = self#check_node Core_type x in
+      super#core_type res (acc @ errors)
+
+    method! expression x acc =
+      let res, errors = self#check_node Expression x in
+      super#expression res (acc @ errors)
+
+    method! value_description x acc =
+      let res, errors = self#check_node Value_description x in
+      super#value_description res (acc @ errors)
+
+    method! class_type x acc =
+      let res, errors = self#check_node Class_type x in
+      super#class_type res (acc @ errors)
+
+    method! class_infos f x acc =
+      let res, errors = self#check_node Class_infos x in
+      super#class_infos f res (acc @ errors)
+
+    method! class_expr x acc =
+      let res, errors = self#check_node Class_expr x in
+      super#class_expr res (acc @ errors)
+
+    method! module_type x acc =
+      let res, errors = self#check_node Module_type x in
+      super#module_type res (acc @ errors)
+
+    method! module_declaration x acc =
+      let res, errors = self#check_node Module_declaration x in
+      super#module_declaration res (acc @ errors)
+
+    method! module_type_declaration x acc =
+      let res, errors = self#check_node Module_type_declaration x in
+      super#module_type_declaration res (acc @ errors)
+
+    method! open_description x acc =
+      let res, errors = self#check_node Open_description x in
+      super#open_description res (acc @ errors)
+
+    method! open_declaration x acc =
+      let res, errors = self#check_node Open_declaration x in
+      super#open_declaration res (acc @ errors)
+
+    method! include_infos f x acc =
+      let res, errors = self#check_node Include_infos x in
+      super#include_infos f res (acc @ errors)
+
+    method! module_expr x acc =
+      let res, errors = self#check_node Module_expr x in
+      super#module_expr res (acc @ errors)
+
+    method! value_binding x acc =
+      let res, errors = self#check_node Value_binding x in
+      super#value_binding res (acc @ errors)
+
+    method! module_binding x acc =
+      let res, errors = self#check_node Module_binding x in
+      super#module_binding res (acc @ errors)
+
+    method! class_field x acc =
+      let x, errors1 = self#check_node Class_field x in
+      let x, errors2 = self#check_floating Class_field x in
+      super#class_field x (acc @ errors1 @ errors2)
+
+    method! class_type_field x acc =
+      let x, errors1 = self#check_node Class_type_field x in
+      let x, errors2 = self#check_floating Class_type_field x in
+      super#class_type_field x (acc @ errors1 @ errors2)
+
+    method! row_field x acc =
+      let x, errors =
+        match x.prf_desc with Rtag _ -> self#check_node Rtag x | _ -> (x, [])
+      in
+      super#row_field x (acc @ errors)
+
+    method! core_type_desc x acc =
+      let x, errors =
+        match x with
+        | Ptyp_object (fields, closed_flag) ->
+            let fields, errors =
+              List.map fields ~f:(self#check_node Object_type_field)
+              |> List.split
+            in
+            (Ptyp_object (fields, closed_flag), List.concat errors)
+        | _ -> (x, [])
+      in
+      super#core_type_desc x (acc @ errors)
+
+    method! structure_item item acc =
+      let item, errors = self#check_floating Structure_item item in
+      let item, errors2 =
+        match item.pstr_desc with
+        | Pstr_eval _ -> self#check_node Pstr_eval item
+        | Pstr_extension _ -> self#check_node Pstr_extension item
+        | _ -> (item, [])
+      in
+      super#structure_item item (acc @ errors @ errors2)
+
+    method! signature_item item acc =
+      let item, errors = self#check_floating Signature_item item in
+      let item, errors2 =
+        match item.psig_desc with
+        | Psig_extension _ -> self#check_node Psig_extension item
+        | _ -> (item, [])
+      in
+      super#signature_item item (acc @ errors @ errors2)
+  end
+
+let check_attribute registrar context name =
+  match collect_attribute_errors registrar context name with
+  | [] -> ()
+  | err :: _ -> Location.Error.raise err
+
+let raise_if_non_empty = function
+  | [] -> ()
+  | err :: _ -> Location.Error.raise err
 
 let check_unused =
   object (self)
     inherit Ast_traverse.iter as super
-
-    method! attribute { attr_name = name; _ } =
-      Location.raise_errorf ~loc:name.loc
-        "attribute not expected here, Ppxlib.Attribute needs updating!"
 
     method private check_node : type a. a Context.t -> a -> a =
       fun context node ->
@@ -447,120 +676,105 @@ let check_unused =
                 mark_as_seen attr);
             Context.set_attributes context node []
 
-    method private check_floating : type a. a Floating.Context.t -> a -> a =
-      fun context node ->
-        match
-          Floating.Context.get_attribute_if_is_floating_node context node
-        with
-        | None -> node
-        | Some ({ attr_name = name; attr_payload = payload; _ } as attr) ->
-            self#payload payload;
-            check_attribute registrar (Floating context) name;
-            mark_as_seen attr;
-            Floating.Context.replace_by_dummy context node
+    method! attribute { attr_name = name; _ } =
+      Location.raise_errorf ~loc:name.loc
+        "attribute not expected here, Ppxlib.Attribute needs updating!"
 
     method! label_declaration x =
-      super#label_declaration (self#check_node Label_declaration x)
+      collect_unused_attributes_errors#label_declaration x []
+      |> raise_if_non_empty
 
     method! constructor_declaration x =
-      super#constructor_declaration (self#check_node Constructor_declaration x)
+      collect_unused_attributes_errors#constructor_declaration x []
+      |> raise_if_non_empty
 
     method! type_declaration x =
-      super#type_declaration (self#check_node Type_declaration x)
+      collect_unused_attributes_errors#type_declaration x []
+      |> raise_if_non_empty
 
     method! type_extension x =
-      super#type_extension (self#check_node Type_extension x)
+      collect_unused_attributes_errors#type_extension x [] |> raise_if_non_empty
 
     method! type_exception x =
-      super#type_exception (self#check_node Type_exception x)
+      collect_unused_attributes_errors#type_exception x [] |> raise_if_non_empty
 
     method! extension_constructor x =
-      super#extension_constructor (self#check_node Extension_constructor x)
+      collect_unused_attributes_errors#extension_constructor x []
+      |> raise_if_non_empty
 
-    method! pattern x = super#pattern (self#check_node Pattern x)
-    method! core_type x = super#core_type (self#check_node Core_type x)
-    method! expression x = super#expression (self#check_node Expression x)
+    method! pattern x =
+      collect_unused_attributes_errors#pattern x [] |> raise_if_non_empty
+
+    method! core_type x =
+      collect_unused_attributes_errors#core_type x [] |> raise_if_non_empty
+
+    method! expression x =
+      collect_unused_attributes_errors#expression x [] |> raise_if_non_empty
 
     method! value_description x =
-      super#value_description (self#check_node Value_description x)
+      collect_unused_attributes_errors#value_description x []
+      |> raise_if_non_empty
 
-    method! class_type x = super#class_type (self#check_node Class_type x)
+    method! class_type x =
+      collect_unused_attributes_errors#class_type x [] |> raise_if_non_empty
 
     method! class_infos f x =
       super#class_infos f (self#check_node Class_infos x)
 
-    method! class_expr x = super#class_expr (self#check_node Class_expr x)
-    method! module_type x = super#module_type (self#check_node Module_type x)
+    method! class_expr x =
+      collect_unused_attributes_errors#class_expr x [] |> raise_if_non_empty
+
+    method! module_type x =
+      collect_unused_attributes_errors#module_type x [] |> raise_if_non_empty
 
     method! module_declaration x =
-      super#module_declaration (self#check_node Module_declaration x)
+      collect_unused_attributes_errors#module_declaration x []
+      |> raise_if_non_empty
 
     method! module_type_declaration x =
-      super#module_type_declaration (self#check_node Module_type_declaration x)
+      collect_unused_attributes_errors#module_type_declaration x []
+      |> raise_if_non_empty
 
     method! open_description x =
-      super#open_description (self#check_node Open_description x)
+      collect_unused_attributes_errors#open_description x []
+      |> raise_if_non_empty
 
     method! open_declaration x =
-      super#open_declaration (self#check_node Open_declaration x)
+      collect_unused_attributes_errors#open_declaration x []
+      |> raise_if_non_empty
 
     method! include_infos f x =
       super#include_infos f (self#check_node Include_infos x)
 
-    method! module_expr x = super#module_expr (self#check_node Module_expr x)
+    method! module_expr x =
+      collect_unused_attributes_errors#module_expr x [] |> raise_if_non_empty
 
     method! value_binding x =
-      super#value_binding (self#check_node Value_binding x)
+      collect_unused_attributes_errors#value_binding x [] |> raise_if_non_empty
 
     method! module_binding x =
-      super#module_binding (self#check_node Module_binding x)
+      collect_unused_attributes_errors#module_binding x [] |> raise_if_non_empty
 
     method! class_field x =
-      let x = self#check_node Class_field x in
-      let x = self#check_floating Class_field x in
-      super#class_field x
+      collect_unused_attributes_errors#class_field x [] |> raise_if_non_empty
 
     method! class_type_field x =
-      let x = self#check_node Class_type_field x in
-      let x = self#check_floating Class_type_field x in
-      super#class_type_field x
+      collect_unused_attributes_errors#class_type_field x []
+      |> raise_if_non_empty
 
     method! row_field x =
-      let x =
-        match x.prf_desc with Rtag _ -> self#check_node Rtag x | _ -> x
-      in
-      super#row_field x
+      collect_unused_attributes_errors#row_field x [] |> raise_if_non_empty
 
     method! core_type_desc x =
-      let x =
-        match x with
-        | Ptyp_object (fields, closed_flag) ->
-            let fields =
-              List.map fields ~f:(self#check_node Object_type_field)
-            in
-            Ptyp_object (fields, closed_flag)
-        | _ -> x
-      in
-      super#core_type_desc x
+      collect_unused_attributes_errors#core_type_desc x [] |> raise_if_non_empty
 
     method! structure_item item =
-      let item = self#check_floating Structure_item item in
-      let item =
-        match item.pstr_desc with
-        | Pstr_eval _ -> self#check_node Pstr_eval item
-        | Pstr_extension _ -> self#check_node Pstr_extension item
-        | _ -> item
-      in
-      super#structure_item item
+      collect_unused_attributes_errors#structure_item item []
+      |> raise_if_non_empty
 
     method! signature_item item =
-      let item = self#check_floating Signature_item item in
-      let item =
-        match item.psig_desc with
-        | Psig_extension _ -> self#check_node Psig_extension item
-        | _ -> item
-      in
-      super#signature_item item
+      collect_unused_attributes_errors#signature_item item []
+      |> raise_if_non_empty
   end
 
 let reset_checks () = Attribute_table.clear not_seen
@@ -576,13 +790,20 @@ let collect =
       Attribute_table.add not_seen name loc
   end
 
-let check_all_seen () =
-  let fail name loc =
+let collect_unseen_errors () =
+  let fail name loc acc =
     let txt = name.txt in
     if not (Name.ignore_checks txt) then
-      Location.raise_errorf ~loc "Attribute `%s' was silently dropped" txt
+      Location.Error.createf ~loc "Attribute `%s' was silently dropped" txt
+      :: acc
+    else acc
   in
-  Attribute_table.iter fail not_seen
+  Attribute_table.fold fail not_seen []
+
+let check_all_seen () =
+  match collect_unseen_errors () with
+  | [] -> ()
+  | err :: _ -> Location.Error.raise err
 
 let remove_attributes_present_in table =
   object

--- a/src/attribute.mli
+++ b/src/attribute.mli
@@ -130,18 +130,36 @@ val declare_with_name_loc :
 val name : _ t -> string
 val context : ('a, _) t -> 'a Context.t
 
+val get_res :
+  ('a, 'b) t ->
+  ?mark_as_seen:bool (** default [true] *) ->
+  'a ->
+  ('b option, Location.Error.t NonEmptyList.t) result
+(** Gets the associated attribute value. Marks the attribute as seen unless
+    [mark_as_seen=false]. Returns an [Error] if the attribute is duplicated *)
+
 val get :
   ('a, 'b) t -> ?mark_as_seen:bool (** default [true] *) -> 'a -> 'b option
-(** Gets the associated attribute value. Marks the attribute as seen unless
-    [mark_as_seen=false]. *)
+(** See {!get_res}. Raises a located error if the attribute is duplicated *)
 
-val consume : ('a, 'b) t -> 'a -> ('a * 'b) option
-(** [consume t x] returns the value associated to attribute [t] on [x] if
+val consume_res :
+  ('a, 'b) t -> 'a -> (('a * 'b) option, Location.Error.t NonEmptyList.t) result
+(** [consume_res t x] returns the value associated to attribute [t] on [x] if
     present as well as [x] with [t] removed. *)
 
-val remove_seen : 'a Context.t -> packed list -> 'a -> 'a
+val consume : ('a, 'b) t -> 'a -> ('a * 'b) option
+(** See {!consume_res}. Raises a located exception in case of error. *)
+
+val remove_seen_res :
+  'a Context.t ->
+  packed list ->
+  'a ->
+  ('a, Location.Error.t NonEmptyList.t) result
 (** [remove_seen x attrs] removes the set of attributes matched by elements of
     [attrs]. Only remove them if they where seen by {!get} or {!consume}. *)
+
+val remove_seen : 'a Context.t -> packed list -> 'a -> 'a
+(** See {!remove_seen_res}. Raises in case of error. *)
 
 module Floating : sig
   type ('context, 'payload) t
@@ -167,6 +185,10 @@ module Floating : sig
     ('a, 'c) t
 
   val name : _ t -> string
+
+  val convert_res :
+    ('a, 'b) t list -> 'a -> ('b option, Location.Error.t NonEmptyList.t) result
+
   val convert : ('a, 'b) t list -> 'a -> 'b option
 end
 
@@ -175,11 +197,16 @@ val explicitly_drop : Ast_traverse.iter
     object. All attributes inside will be marked as handled. *)
 
 val check_unused : Ast_traverse.iter
-(** Raise if there are unused attributes *)
+(** Raise if there are unused attributes. *)
+
+val collect_unused_attributes_errors : Location.Error.t list Ast_traverse.fold
+(** Collect all errors due to unused attributes. *)
 
 val collect : Ast_traverse.iter
 (** Collect all attribute names. To be used in conjunction with
     {!check_all_seen}. *)
+
+val collect_unseen_errors : unit -> Location.Error.t list
 
 val check_all_seen : unit -> unit
 (** Check that all attributes collected by {!freshen_and_collect} have been:
@@ -205,3 +232,11 @@ val pattern :
   ('a, 'b) t ->
   ('a, 'c, 'd) Ast_pattern.t ->
   ('a, 'b option -> 'c, 'd) Ast_pattern.t
+
+val pattern_res :
+  ('a, 'b) t ->
+  ('a, 'c, 'd) Ast_pattern.t ->
+  ( 'a,
+    'b option -> 'c,
+    ('d, Location.Error.t NonEmptyList.t) result )
+  Ast_pattern.t

--- a/src/code_matcher.ml
+++ b/src/code_matcher.ml
@@ -43,12 +43,15 @@ struct
           let loc =
             { Location.loc_start = pos; loc_end = pos; loc_ghost = false }
           in
-          Location.raise_errorf ~loc "ppxlib: [@@@@@@%s] attribute missing"
-            (Attribute.Floating.name M.end_marker)
+          Error
+            ( Location.Error.createf ~loc "ppxlib: [@@@@@@%s] attribute missing"
+                (Attribute.Floating.name M.end_marker),
+              [] )
       | x :: l -> (
-          match Attribute.Floating.convert [ M.end_marker ] x with
-          | None -> loop (x :: acc) l
-          | Some () -> (List.rev acc, (M.get_loc x).loc_start)
+          match Attribute.Floating.convert_res [ M.end_marker ] x with
+          | Ok None -> loop (x :: acc) l
+          | Ok (Some ()) -> Ok (List.rev acc, (M.get_loc x).loc_start)
+          | Error e -> Error e
           | exception Failure _ -> loop (x :: acc) l)
     in
     loop [] l
@@ -138,7 +141,8 @@ struct
         match_loop ~end_pos ~mismatch_handler ~expected ~source
 
   let do_match ~pos ~expected ~mismatch_handler source =
-    let source, end_pos = extract_prefix ~pos source in
+    let open Result in
+    extract_prefix ~pos source >>| fun (source, end_pos) ->
     match_loop ~end_pos ~mismatch_handler ~expected ~source
 end
 
@@ -176,5 +180,14 @@ end)
 
 (*$*)
 
-let match_structure = Str.do_match
-let match_signature = Sig.do_match
+let match_structure_res = Str.do_match
+
+let match_structure ~pos ~expected ~mismatch_handler l =
+  match_structure_res ~pos ~expected ~mismatch_handler l
+  |> Result.handle_error ~f:(fun (err, _) -> Location.Error.raise err)
+
+let match_signature_res = Sig.do_match
+
+let match_signature ~pos ~expected ~mismatch_handler l =
+  match_signature_res ~pos ~expected ~mismatch_handler l
+  |> Result.handle_error ~f:(fun (err, _) -> Location.Error.raise err)

--- a/src/code_matcher.mli
+++ b/src/code_matcher.mli
@@ -2,19 +2,35 @@
 
 open! Import
 
+val match_structure_res :
+  pos:Lexing.position ->
+  expected:structure ->
+  mismatch_handler:(Location.t -> structure -> unit) ->
+  structure ->
+  (unit, Location.Error.t NonEmptyList.t) result
+(** Checks that the given code starts with [expected] followed by
+    [@@@deriving.end] or [@@@end].
+
+    Returns an error if there is no [@@@deriving.end].
+
+    If some items don't match, it calls [mismatch_handler] with the location of
+    the source items and the expected code. *)
+
 val match_structure :
   pos:Lexing.position ->
   expected:structure ->
   mismatch_handler:(Location.t -> structure -> unit) ->
   structure ->
   unit
-(** Checks that the given code starts with [expected] followed by
-    [@@@deriving.end] or [@@@end].
+(** See {!match_structure_res}. Raises a located error in case of error. *)
 
-    Raises if there is no [@@@deriving.end].
-
-    If some items don't match, it calls [mismatch_handler] with the location of
-    the source items and the expected code. *)
+val match_signature_res :
+  pos:Lexing.position ->
+  expected:signature ->
+  mismatch_handler:(Location.t -> signature -> unit) ->
+  signature ->
+  (unit, Location.Error.t NonEmptyList.t) result
+(** Same for signatures *)
 
 val match_signature :
   pos:Lexing.position ->

--- a/src/common.mli
+++ b/src/common.mli
@@ -2,6 +2,10 @@ open! Import
 
 val lident : string -> Longident.t
 val core_type_of_type_declaration : type_declaration -> core_type
+
+val name_type_params_in_td_res :
+  type_declaration -> (type_declaration, Location.Error.t NonEmptyList.t) result
+
 val name_type_params_in_td : type_declaration -> type_declaration
 
 val combinator_type_of_type_declaration :
@@ -15,10 +19,17 @@ val gen_symbol : ?prefix:string -> unit -> string
 val string_of_core_type : core_type -> string
 val assert_no_attributes : attributes -> unit
 val assert_no_attributes_in : Ast_traverse.iter
+val attributes_errors : attributes -> Location.Error.t list
+val collect_attributes_errors : Location.Error.t list Ast_traverse.fold
+
+val get_type_param_name_res :
+  core_type * (variance * injectivity) ->
+  (string Loc.t, Location.Error.t NonEmptyList.t) result
+(** [get_type_param_name_res tp] returns the string identifier associated with
+    [tp] if it is a type parameter, as a result. *)
 
 val get_type_param_name : core_type * (variance * injectivity) -> string Loc.t
-(** [get_tparam_id tp] returns the string identifier associated with [tp] if it
-    is a type parameter. *)
+(** See {!get_type_param_name_res}. Raises a located error in case of failure. *)
 
 (** [(new type_is_recursive rec_flag tds)#go ()] returns whether [rec_flag, tds]
     is really a recursive type. We disregard recursive occurrences appearing in

--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -197,34 +197,43 @@ module Generated_code_hook = struct
 end
 
 let rec map_node_rec context ts super_call loc base_ctxt x =
+  let open Result in
   let ctxt =
     Expansion_context.Extension.make ~extension_point_loc:loc ~base:base_ctxt ()
   in
   match EC.get_extension context x with
-  | None -> super_call base_ctxt x
+  | None -> Ok (super_call base_ctxt x)
   | Some (ext, attrs) -> (
-      match E.For_context.convert ts ~ctxt ext with
-      | None -> super_call base_ctxt x
+      E.For_context.convert_res ts ~ctxt ext >>= fun converted ->
+      match converted with
+      | None -> Ok (super_call base_ctxt x)
       | Some x ->
-          map_node_rec context ts super_call loc base_ctxt
-            (EC.merge_attributes context x attrs))
+          EC.merge_attributes_res context x attrs >>= fun x ->
+          map_node_rec context ts super_call loc base_ctxt x)
 
 let map_node context ts super_call loc base_ctxt x ~hook =
+  let open Result in
   let ctxt =
     Expansion_context.Extension.make ~extension_point_loc:loc ~base:base_ctxt ()
   in
-  match EC.get_extension context x with
-  | None -> super_call base_ctxt x
-  | Some (ext, attrs) -> (
-      match E.For_context.convert ts ~ctxt ext with
-      | None -> super_call base_ctxt x
-      | Some x ->
-          let generated_code =
+  let res =
+    match EC.get_extension context x with
+    | None -> Ok (super_call base_ctxt x)
+    | Some (ext, attrs) -> (
+        E.For_context.convert_res ts ~ctxt ext >>= fun converted ->
+        match converted with
+        | None -> Ok (super_call base_ctxt x)
+        | Some x ->
             map_node_rec context ts super_call loc base_ctxt
               (EC.merge_attributes context x attrs)
-          in
-          Generated_code_hook.replace hook context loc (Single generated_code);
-          generated_code)
+            >>| fun generated_code ->
+            Generated_code_hook.replace hook context loc (Single generated_code);
+            generated_code)
+  in
+  match res with
+  | Ok e -> e
+  | Error (hd_err, _) ->
+      EC.node_of_extension context ~x (Location.Error.to_extension hd_err)
 
 let rec map_nodes context ts super_call get_loc base_ctxt l ~hook
     ~in_generated_code =
@@ -247,26 +256,36 @@ let rec map_nodes context ts super_call get_loc base_ctxt l ~hook
             Expansion_context.Extension.make ~extension_point_loc
               ~base:base_ctxt ()
           in
-          match E.For_context.convert_inline ts ~ctxt ext with
-          | None ->
+          match E.For_context.convert_inline_res ts ~ctxt ext with
+          | Ok None ->
               let x = super_call base_ctxt x in
               let l =
                 map_nodes context ts super_call get_loc base_ctxt l ~hook
                   ~in_generated_code
               in
               x :: l
-          | Some x ->
-              assert_no_attributes attrs;
-              let generated_code =
-                map_nodes context ts super_call get_loc base_ctxt x ~hook
-                  ~in_generated_code:true
-              in
-              if not in_generated_code then
-                Generated_code_hook.replace hook context extension_point_loc
-                  (Many generated_code);
-              generated_code
-              @ map_nodes context ts super_call get_loc base_ctxt l ~hook
-                  ~in_generated_code))
+          | Ok (Some converted) ->
+              let attributes_errors = attributes_errors attrs in
+              if List.length attributes_errors = 0 then (
+                let generated_code =
+                  map_nodes context ts super_call get_loc base_ctxt converted
+                    ~hook ~in_generated_code:true
+                in
+                if not in_generated_code then
+                  Generated_code_hook.replace hook context extension_point_loc
+                    (Many generated_code);
+                generated_code
+                @ map_nodes context ts super_call get_loc base_ctxt l ~hook
+                    ~in_generated_code)
+              else
+                attributes_errors
+                |> List.map ~f:Location.Error.to_extension
+                |> List.map ~f:(EC.node_of_extension context ~x)
+          | Error l ->
+              l
+              |> NonEmptyList.map ~f:Location.Error.to_extension
+              |> NonEmptyList.map ~f:(EC.node_of_extension context ~x)
+              |> NonEmptyList.to_list))
 
 let map_nodes = map_nodes ~in_generated_code:false
 
@@ -294,10 +313,13 @@ let table_of_special_functions special_functions =
    attached, [get_group] returns the equivalent of
    [Some (List.map ~f:(Attribute.get attr) l)]. *)
 let rec get_group attr l =
+  let open Result in
   match l with
-  | [] -> None
+  | [] -> Ok None
   | x :: l -> (
-      match (Attribute.get attr x, get_group attr l) with
+      get_group attr l >>= fun group ->
+      Attribute.get_res attr x >>| fun attr2 ->
+      match (attr2, group) with
       | None, None -> None
       | None, Some vals -> Some (None :: vals)
       | Some value, None -> Some (Some value :: List.map l ~f:(fun _ -> None))
@@ -323,8 +345,10 @@ let sort_attr_inline l =
         (Rule.Attr_inline.attr_name b))
 
 let context_free_attribute_modification ~loc =
-  Location.raise_errorf ~loc
-    "A context-free rule deleted or added attribues of a str/sig item"
+  Error
+    ( Location.Error.createf ~loc
+        "A context-free rule deleted or added attribues of a str/sig item",
+      [] )
 
 (* Returns the code generated by attribute handlers. We don't remove these attributes, as
    another pass might interpret them later. For instance both ppx_deriving and
@@ -334,12 +358,14 @@ let context_free_attribute_modification ~loc =
    of one element; it only has [@@deriving].
 *)
 let handle_attr_group_inline attrs rf ~items ~expanded_items ~loc ~base_ctxt =
-  List.fold_left attrs ~init:[] ~f:(fun acc (Rule.Attr_group_inline.T group) ->
-      match
-        ( get_group group.attribute items,
-          get_group group.attribute expanded_items )
-      with
-      | None, None -> acc
+  let open Result in
+  List.fold_left attrs ~init:(Ok [])
+    ~f:(fun acc (Rule.Attr_group_inline.T group) ->
+      acc >>= fun acc ->
+      get_group group.attribute items >>= fun g1 ->
+      get_group group.attribute expanded_items >>= fun g2 ->
+      match (g1, g2) with
+      | None, None -> Ok acc
       | None, Some _ | Some _, None -> context_free_attribute_modification ~loc
       | Some values, Some _ ->
           let ctxt =
@@ -347,14 +373,16 @@ let handle_attr_group_inline attrs rf ~items ~expanded_items ~loc ~base_ctxt =
               ~inline:group.expect ~base:base_ctxt ()
           in
           let expect_items = group.expand ~ctxt rf expanded_items values in
-          expect_items :: acc)
+          Ok (expect_items :: acc))
 
 let handle_attr_inline attrs ~item ~expanded_item ~loc ~base_ctxt =
-  List.fold_left attrs ~init:[] ~f:(fun acc (Rule.Attr_inline.T a) ->
-      match
-        (Attribute.get a.attribute item, Attribute.get a.attribute expanded_item)
-      with
-      | None, None -> acc
+  let open Result in
+  List.fold_left attrs ~init:(Ok []) ~f:(fun acc (Rule.Attr_inline.T a) ->
+      acc >>= fun acc ->
+      Attribute.get_res a.attribute item >>= fun g1 ->
+      Attribute.get_res a.attribute expanded_item >>= fun g2 ->
+      match (g1, g2) with
+      | None, None -> Ok acc
       | None, Some _ | Some _, None -> context_free_attribute_modification ~loc
       | Some value, Some _ ->
           let ctxt =
@@ -362,7 +390,7 @@ let handle_attr_inline attrs ~item ~expanded_item ~loc ~base_ctxt =
               ~inline:a.expect ~base:base_ctxt ()
           in
           let expect_items = a.expand ~ctxt expanded_item value in
-          expect_items :: acc)
+          Ok (expect_items :: acc))
 
 module Expect_mismatch_handler = struct
   type t = {
@@ -570,6 +598,7 @@ class map_top_down ?(expect_mismatch_handler = Expect_mismatch_handler.nop)
     (* TODO: try to factorize #structure and #signature without meta-programming *)
     (*$*)
     method! structure base_ctxt st =
+      let open Result in
       let rec with_extra_items item ~extra_items ~expect_items ~rest
           ~in_generated_code =
         let extra_items =
@@ -580,15 +609,16 @@ class map_top_down ?(expect_mismatch_handler = Expect_mismatch_handler.nop)
             (Many extra_items);
         let original_rest = rest in
         let rest = loop rest ~in_generated_code in
+        let open Result in
         (match expect_items with
-        | [] -> ()
+        | [] -> Ok ()
         | _ ->
             let expected = rev_concat expect_items in
             let pos = item.pstr_loc.loc_end in
-            Code_matcher.match_structure original_rest ~pos ~expected
+            Code_matcher.match_structure_res original_rest ~pos ~expected
               ~mismatch_handler:(fun loc repl ->
-                expect_mismatch_handler.f Structure_item loc repl));
-        item :: (extra_items @ rest)
+                expect_mismatch_handler.f Structure_item loc repl))
+        >>| fun () -> item :: (extra_items @ rest)
       and loop st ~in_generated_code =
         match st with
         | [] -> []
@@ -601,68 +631,90 @@ class map_top_down ?(expect_mismatch_handler = Expect_mismatch_handler.nop)
                   Expansion_context.Extension.make ~extension_point_loc
                     ~base:base_ctxt ()
                 in
-                match E.For_context.convert_inline structure_item ~ctxt ext with
-                | None ->
+                match
+                  E.For_context.convert_inline_res structure_item ~ctxt ext
+                with
+                | Ok None ->
                     let item = super#structure_item base_ctxt item in
                     let rest = self#structure base_ctxt rest in
                     item :: rest
-                | Some items ->
-                    assert_no_attributes attrs;
-                    let items = loop items ~in_generated_code:true in
-                    if not in_generated_code then
-                      Generated_code_hook.replace hook Structure_item
-                        item.pstr_loc (Many items);
-                    items @ loop rest ~in_generated_code)
+                | Ok (Some items) ->
+                    let attributes_errors = attributes_errors attrs in
+                    if List.length attributes_errors = 0 then (
+                      (* assert_no_attributes attrs; *)
+                      let items = loop items ~in_generated_code:true in
+                      if not in_generated_code then
+                        Generated_code_hook.replace hook Structure_item
+                          item.pstr_loc (Many items);
+                      items @ loop rest ~in_generated_code)
+                    else
+                      (attributes_errors
+                      |> List.map ~f:Location.Error.to_extension
+                      |> List.map
+                           ~f:(EC.node_of_extension EC.Structure_item ~x:item))
+                      @ loop rest ~in_generated_code
+                | Error err ->
+                    (err
+                    |> NonEmptyList.map ~f:Location.Error.to_extension
+                    |> NonEmptyList.map
+                         ~f:(EC.node_of_extension EC.Structure_item ~x:item)
+                    |> NonEmptyList.to_list)
+                    @ loop rest ~in_generated_code)
             | _ -> (
+                let error_of_extension e =
+                  (e
+                  |> NonEmptyList.map ~f:Location.Error.to_extension
+                  |> NonEmptyList.map ~f:(fun e ->
+                         Ast_builder.Default.pstr_extension ~loc:Location.none e
+                           [])
+                  |> NonEmptyList.to_list)
+                  @ loop rest ~in_generated_code
+                in
                 let expanded_item = super#structure_item base_ctxt item in
                 match (item.pstr_desc, expanded_item.pstr_desc) with
                 | Pstr_type (rf, tds), Pstr_type (exp_rf, exp_tds) ->
                     (* No context-free rule can rewrite rec flags atm, this
                        assert acts as a failsafe in case it ever changes *)
                     assert (Poly.(rf = exp_rf));
-                    let extra_items =
-                      handle_attr_group_inline attr_str_type_decls rf ~items:tds
-                        ~expanded_items:exp_tds ~loc ~base_ctxt
-                    in
-                    let expect_items =
-                      handle_attr_group_inline attr_str_type_decls_expect rf
-                        ~items:tds ~expanded_items:exp_tds ~loc ~base_ctxt
-                    in
-                    with_extra_items expanded_item ~extra_items ~expect_items
-                      ~rest ~in_generated_code
+                    handle_attr_group_inline attr_str_type_decls rf ~items:tds
+                      ~expanded_items:exp_tds ~loc ~base_ctxt
+                    >>= (fun extra_items ->
+                          handle_attr_group_inline attr_str_type_decls_expect rf
+                            ~items:tds ~expanded_items:exp_tds ~loc ~base_ctxt
+                          >>= fun expect_items ->
+                          with_extra_items expanded_item ~extra_items
+                            ~expect_items ~rest ~in_generated_code)
+                    |> handle_error ~f:error_of_extension
                 | Pstr_modtype mtd, Pstr_modtype exp_mtd ->
-                    let extra_items =
-                      handle_attr_inline attr_str_module_type_decls ~item:mtd
-                        ~expanded_item:exp_mtd ~loc ~base_ctxt
-                    in
-                    let expect_items =
-                      handle_attr_inline attr_str_module_type_decls_expect
-                        ~item:mtd ~expanded_item:exp_mtd ~loc ~base_ctxt
-                    in
-                    with_extra_items expanded_item ~extra_items ~expect_items
-                      ~rest ~in_generated_code
+                    handle_attr_inline attr_str_module_type_decls ~item:mtd
+                      ~expanded_item:exp_mtd ~loc ~base_ctxt
+                    >>= (fun extra_items ->
+                          handle_attr_inline attr_str_module_type_decls_expect
+                            ~item:mtd ~expanded_item:exp_mtd ~loc ~base_ctxt
+                          >>= fun expect_items ->
+                          with_extra_items expanded_item ~extra_items
+                            ~expect_items ~rest ~in_generated_code)
+                    |> handle_error ~f:error_of_extension
                 | Pstr_typext te, Pstr_typext exp_te ->
-                    let extra_items =
-                      handle_attr_inline attr_str_type_exts ~item:te
-                        ~expanded_item:exp_te ~loc ~base_ctxt
-                    in
-                    let expect_items =
-                      handle_attr_inline attr_str_type_exts_expect ~item:te
-                        ~expanded_item:exp_te ~loc ~base_ctxt
-                    in
-                    with_extra_items expanded_item ~extra_items ~expect_items
-                      ~rest ~in_generated_code
+                    handle_attr_inline attr_str_type_exts ~item:te
+                      ~expanded_item:exp_te ~loc ~base_ctxt
+                    >>= (fun extra_items ->
+                          handle_attr_inline attr_str_type_exts_expect ~item:te
+                            ~expanded_item:exp_te ~loc ~base_ctxt
+                          >>= fun expect_items ->
+                          with_extra_items expanded_item ~extra_items
+                            ~expect_items ~rest ~in_generated_code)
+                    |> handle_error ~f:error_of_extension
                 | Pstr_exception ec, Pstr_exception exp_ec ->
-                    let extra_items =
-                      handle_attr_inline attr_str_exceptions ~item:ec
-                        ~expanded_item:exp_ec ~loc ~base_ctxt
-                    in
-                    let expect_items =
-                      handle_attr_inline attr_str_exceptions_expect ~item:ec
-                        ~expanded_item:exp_ec ~loc ~base_ctxt
-                    in
-                    with_extra_items expanded_item ~extra_items ~expect_items
-                      ~rest ~in_generated_code
+                    handle_attr_inline attr_str_exceptions ~item:ec
+                      ~expanded_item:exp_ec ~loc ~base_ctxt
+                    >>= (fun extra_items ->
+                          handle_attr_inline attr_str_exceptions_expect ~item:ec
+                            ~expanded_item:exp_ec ~loc ~base_ctxt
+                          >>= fun expect_items ->
+                          with_extra_items expanded_item ~extra_items
+                            ~expect_items ~rest ~in_generated_code)
+                    |> handle_error ~f:error_of_extension
                 | _, _ ->
                     let rest = self#structure base_ctxt rest in
                     expanded_item :: rest))
@@ -671,6 +723,7 @@ class map_top_down ?(expect_mismatch_handler = Expect_mismatch_handler.nop)
 
     (*$ str_to_sig _last_text_block *)
     method! signature base_ctxt sg =
+      let open Result in
       let rec with_extra_items item ~extra_items ~expect_items ~rest
           ~in_generated_code =
         let extra_items =
@@ -681,15 +734,16 @@ class map_top_down ?(expect_mismatch_handler = Expect_mismatch_handler.nop)
             (Many extra_items);
         let original_rest = rest in
         let rest = loop rest ~in_generated_code in
+        let open Result in
         (match expect_items with
-        | [] -> ()
+        | [] -> Ok ()
         | _ ->
             let expected = rev_concat expect_items in
             let pos = item.psig_loc.loc_end in
-            Code_matcher.match_signature original_rest ~pos ~expected
+            Code_matcher.match_signature_res original_rest ~pos ~expected
               ~mismatch_handler:(fun loc repl ->
-                expect_mismatch_handler.f Signature_item loc repl));
-        item :: (extra_items @ rest)
+                expect_mismatch_handler.f Signature_item loc repl))
+        >>| fun () -> item :: (extra_items @ rest)
       and loop sg ~in_generated_code =
         match sg with
         | [] -> []
@@ -702,68 +756,90 @@ class map_top_down ?(expect_mismatch_handler = Expect_mismatch_handler.nop)
                   Expansion_context.Extension.make ~extension_point_loc
                     ~base:base_ctxt ()
                 in
-                match E.For_context.convert_inline signature_item ~ctxt ext with
-                | None ->
+                match
+                  E.For_context.convert_inline_res signature_item ~ctxt ext
+                with
+                | Ok None ->
                     let item = super#signature_item base_ctxt item in
                     let rest = self#signature base_ctxt rest in
                     item :: rest
-                | Some items ->
-                    assert_no_attributes attrs;
-                    let items = loop items ~in_generated_code:true in
-                    if not in_generated_code then
-                      Generated_code_hook.replace hook Signature_item
-                        item.psig_loc (Many items);
-                    items @ loop rest ~in_generated_code)
+                | Ok (Some items) ->
+                    let attributes_errors = attributes_errors attrs in
+                    if List.length attributes_errors = 0 then (
+                      (* assert_no_attributes attrs; *)
+                      let items = loop items ~in_generated_code:true in
+                      if not in_generated_code then
+                        Generated_code_hook.replace hook Signature_item
+                          item.psig_loc (Many items);
+                      items @ loop rest ~in_generated_code)
+                    else
+                      (attributes_errors
+                      |> List.map ~f:Location.Error.to_extension
+                      |> List.map
+                           ~f:(EC.node_of_extension EC.Signature_item ~x:item))
+                      @ loop rest ~in_generated_code
+                | Error err ->
+                    (err
+                    |> NonEmptyList.map ~f:Location.Error.to_extension
+                    |> NonEmptyList.map
+                         ~f:(EC.node_of_extension EC.Signature_item ~x:item)
+                    |> NonEmptyList.to_list)
+                    @ loop rest ~in_generated_code)
             | _ -> (
+                let error_of_extension e =
+                  (e
+                  |> NonEmptyList.map ~f:Location.Error.to_extension
+                  |> NonEmptyList.map ~f:(fun e ->
+                         Ast_builder.Default.psig_extension ~loc:Location.none e
+                           [])
+                  |> NonEmptyList.to_list)
+                  @ loop rest ~in_generated_code
+                in
                 let expanded_item = super#signature_item base_ctxt item in
                 match (item.psig_desc, expanded_item.psig_desc) with
                 | Psig_type (rf, tds), Psig_type (exp_rf, exp_tds) ->
                     (* No context-free rule can rewrite rec flags atm, this
                        assert acts as a failsafe in case it ever changes *)
                     assert (Poly.(rf = exp_rf));
-                    let extra_items =
-                      handle_attr_group_inline attr_sig_type_decls rf ~items:tds
-                        ~expanded_items:exp_tds ~loc ~base_ctxt
-                    in
-                    let expect_items =
-                      handle_attr_group_inline attr_sig_type_decls_expect rf
-                        ~items:tds ~expanded_items:exp_tds ~loc ~base_ctxt
-                    in
-                    with_extra_items expanded_item ~extra_items ~expect_items
-                      ~rest ~in_generated_code
+                    handle_attr_group_inline attr_sig_type_decls rf ~items:tds
+                      ~expanded_items:exp_tds ~loc ~base_ctxt
+                    >>= (fun extra_items ->
+                          handle_attr_group_inline attr_sig_type_decls_expect rf
+                            ~items:tds ~expanded_items:exp_tds ~loc ~base_ctxt
+                          >>= fun expect_items ->
+                          with_extra_items expanded_item ~extra_items
+                            ~expect_items ~rest ~in_generated_code)
+                    |> handle_error ~f:error_of_extension
                 | Psig_modtype mtd, Psig_modtype exp_mtd ->
-                    let extra_items =
-                      handle_attr_inline attr_sig_module_type_decls ~item:mtd
-                        ~expanded_item:exp_mtd ~loc ~base_ctxt
-                    in
-                    let expect_items =
-                      handle_attr_inline attr_sig_module_type_decls_expect
-                        ~item:mtd ~expanded_item:exp_mtd ~loc ~base_ctxt
-                    in
-                    with_extra_items expanded_item ~extra_items ~expect_items
-                      ~rest ~in_generated_code
+                    handle_attr_inline attr_sig_module_type_decls ~item:mtd
+                      ~expanded_item:exp_mtd ~loc ~base_ctxt
+                    >>= (fun extra_items ->
+                          handle_attr_inline attr_sig_module_type_decls_expect
+                            ~item:mtd ~expanded_item:exp_mtd ~loc ~base_ctxt
+                          >>= fun expect_items ->
+                          with_extra_items expanded_item ~extra_items
+                            ~expect_items ~rest ~in_generated_code)
+                    |> handle_error ~f:error_of_extension
                 | Psig_typext te, Psig_typext exp_te ->
-                    let extra_items =
-                      handle_attr_inline attr_sig_type_exts ~item:te
-                        ~expanded_item:exp_te ~loc ~base_ctxt
-                    in
-                    let expect_items =
-                      handle_attr_inline attr_sig_type_exts_expect ~item:te
-                        ~expanded_item:exp_te ~loc ~base_ctxt
-                    in
-                    with_extra_items expanded_item ~extra_items ~expect_items
-                      ~rest ~in_generated_code
+                    handle_attr_inline attr_sig_type_exts ~item:te
+                      ~expanded_item:exp_te ~loc ~base_ctxt
+                    >>= (fun extra_items ->
+                          handle_attr_inline attr_sig_type_exts_expect ~item:te
+                            ~expanded_item:exp_te ~loc ~base_ctxt
+                          >>= fun expect_items ->
+                          with_extra_items expanded_item ~extra_items
+                            ~expect_items ~rest ~in_generated_code)
+                    |> handle_error ~f:error_of_extension
                 | Psig_exception ec, Psig_exception exp_ec ->
-                    let extra_items =
-                      handle_attr_inline attr_sig_exceptions ~item:ec
-                        ~expanded_item:exp_ec ~loc ~base_ctxt
-                    in
-                    let expect_items =
-                      handle_attr_inline attr_sig_exceptions_expect ~item:ec
-                        ~expanded_item:exp_ec ~loc ~base_ctxt
-                    in
-                    with_extra_items expanded_item ~extra_items ~expect_items
-                      ~rest ~in_generated_code
+                    handle_attr_inline attr_sig_exceptions ~item:ec
+                      ~expanded_item:exp_ec ~loc ~base_ctxt
+                    >>= (fun extra_items ->
+                          handle_attr_inline attr_sig_exceptions_expect ~item:ec
+                            ~expanded_item:exp_ec ~loc ~base_ctxt
+                          >>= fun expect_items ->
+                          with_extra_items expanded_item ~extra_items
+                            ~expect_items ~rest ~in_generated_code)
+                    |> handle_error ~f:error_of_extension
                 | _, _ ->
                     let rest = self#signature base_ctxt rest in
                     expanded_item :: rest))

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -39,6 +39,16 @@ module Cookies = struct
         let e = Selected_ast.of_ocaml Expression e in
         Ast_pattern.parse pattern e.pexp_loc e Fn.id)
 
+  let get_res T name pattern =
+    match
+      Option.map (Astlib.Ast_metadata.get_cookie name) ~f:(fun e ->
+          let e = Selected_ast.of_ocaml Expression e in
+          Ast_pattern.parse_res pattern e.pexp_loc e Fn.id)
+    with
+    | None -> Ok None
+    | Some (Ok e) -> Ok (Some e)
+    | Some (Error e) -> Error e
+
   let set T name expr =
     Astlib.Ast_metadata.set_cookie name (Selected_ast.to_ocaml Expression expr)
 
@@ -607,19 +617,35 @@ let map_structure_gen st ~tool_name ~hook ~expect_mismatch_handler ~input_name
   in
   let cookies_and_check st =
     Cookies.call_post_handlers T;
-    if !perform_checks then (
-      (* TODO: these two passes could be merged, we now have more passes for
-         checks than for actual rewriting. *)
-      Attribute.check_unused#structure st;
-      if !perform_checks_on_extensions then Extension.check_unused#structure st;
-      Attribute.check_all_seen ();
-      if !perform_locations_check then
-        let open Location_check in
-        ignore
-          ((enforce_invariants !loc_fname)#structure st
-             Non_intersecting_ranges.empty
-            : Non_intersecting_ranges.t));
-    st
+    let errors =
+      if !perform_checks then (
+        (* TODO: these two passes could be merged, we now have more passes for
+           checks than for actual rewriting. *)
+        let unused_attributes_errors =
+          Attribute.collect_unused_attributes_errors#structure st []
+        in
+        let unused_extension_errors =
+          if !perform_checks_on_extensions then
+            Extension.collect_unhandled_extension_errors#structure st []
+          else []
+        in
+        let not_seen_errors = Attribute.collect_unseen_errors () in
+        (if !perform_locations_check then
+         let open Location_check in
+         ignore
+           ((enforce_invariants !loc_fname)#structure st
+              Non_intersecting_ranges.empty
+             : Non_intersecting_ranges.t));
+        let errors =
+          unused_attributes_errors @ unused_extension_errors @ not_seen_errors
+        in
+        errors
+        |> List.map ~f:Location.Error.to_extension
+        |> List.map ~f:(fun e ->
+               Ast_builder.Default.pstr_extension ~loc:Location.none e []))
+      else []
+    in
+    errors @ st
   in
   let file_path = File_path.get_default_path_str st in
   match
@@ -666,19 +692,35 @@ let map_signature_gen sg ~tool_name ~hook ~expect_mismatch_handler ~input_name
   in
   let cookies_and_check sg =
     Cookies.call_post_handlers T;
-    if !perform_checks then (
-      (* TODO: these two passes could be merged, we now have more passes for
-         checks than for actual rewriting. *)
-      Attribute.check_unused#signature sg;
-      if !perform_checks_on_extensions then Extension.check_unused#signature sg;
-      Attribute.check_all_seen ();
-      if !perform_locations_check then
-        let open Location_check in
-        ignore
-          ((enforce_invariants !loc_fname)#signature sg
-             Non_intersecting_ranges.empty
-            : Non_intersecting_ranges.t));
-    sg
+    let errors =
+      if !perform_checks then (
+        (* TODO: these two passes could be merged, we now have more passes for
+           checks than for actual rewriting. *)
+        let unused_attributes_errors =
+          Attribute.collect_unused_attributes_errors#signature sg []
+        in
+        let unused_extension_errors =
+          if !perform_checks_on_extensions then
+            Extension.collect_unhandled_extension_errors#signature sg []
+          else []
+        in
+        let not_seen_errors = Attribute.collect_unseen_errors () in
+        (if !perform_locations_check then
+         let open Location_check in
+         ignore
+           ((enforce_invariants !loc_fname)#signature sg
+              Non_intersecting_ranges.empty
+             : Non_intersecting_ranges.t));
+        let errors =
+          unused_attributes_errors @ unused_extension_errors @ not_seen_errors
+        in
+        errors
+        |> List.map ~f:Location.Error.to_extension
+        |> List.map ~f:(fun e ->
+               Ast_builder.Default.psig_extension ~loc:Location.none e []))
+      else []
+    in
+    errors @ sg
   in
   let file_path = File_path.get_default_path_sig sg in
   match

--- a/src/driver.mli
+++ b/src/driver.mli
@@ -15,7 +15,16 @@ module Cookies : sig
 
   val get : t -> string -> (expression, 'a -> 'a, 'b) Ast_pattern.t -> 'b option
   (** [get cookies name pattern] look for a cookie named [name] and parse it
-      using [pattern]. *)
+      using [pattern]. Raises if the parsing fails. *)
+
+  val get_res :
+    t ->
+    string ->
+    (expression, 'a -> 'a, 'b) Ast_pattern.t ->
+    ('b option, Location.Error.t NonEmptyList.t) result
+  (** [get cookies name pattern] look for a cookie named [name] and parse it
+      using [pattern], returning a [result] instead of raising when the parsing
+      fails. *)
 
   val set : t -> string -> expression -> unit
   (** [set cookies name expr] set cookie [name] to [expr]. *)

--- a/src/extension.ml
+++ b/src/extension.ml
@@ -104,27 +104,59 @@ module Context = struct
     | Ppx_import, type_decl -> get_ppx_import_extension type_decl
     | _ -> None
 
-  let merge_attributes : type a. a t -> a -> attributes -> a =
+  let node_of_extension :
+      type a. ?loc:Location.t -> ?x:a -> a t -> extension -> a =
+   fun ?(loc = Location.none) ?x t ->
+    let open Ast_builder.Default in
+    match (t, x) with
+    | Class_expr, _ -> pcl_extension ~loc
+    | Class_field, _ -> pcf_extension ~loc
+    | Class_type_field, _ -> pctf_extension ~loc
+    | Class_type, _ -> pcty_extension ~loc
+    | Core_type, _ -> ptyp_extension ~loc
+    | Expression, _ -> pexp_extension ~loc
+    | Module_expr, _ -> pmod_extension ~loc
+    | Module_type, _ -> pmty_extension ~loc
+    | Pattern, _ -> ppat_extension ~loc
+    | Signature_item, _ -> fun ext -> psig_extension ~loc ext []
+    | Structure_item, _ -> fun ext -> pstr_extension ~loc ext []
+    | Ppx_import, Some x ->
+        fun ext ->
+          {
+            x with
+            ptype_manifest = Some (Ast_builder.Default.ptyp_extension ~loc ext);
+          }
+    | Ppx_import, None ->
+        failwith
+          "Ppxlib internal error: Item not provided to build an extension node \
+           from a Ppx_import context."
+
+  let merge_attributes_res :
+      type a.
+      a t -> a -> attributes -> (a, Location.Error.t NonEmptyList.t) result =
    fun t x attrs ->
     match t with
-    | Class_expr -> { x with pcl_attributes = x.pcl_attributes @ attrs }
-    | Class_field -> { x with pcf_attributes = x.pcf_attributes @ attrs }
-    | Class_type -> { x with pcty_attributes = x.pcty_attributes @ attrs }
-    | Class_type_field -> { x with pctf_attributes = x.pctf_attributes @ attrs }
-    | Core_type -> { x with ptyp_attributes = x.ptyp_attributes @ attrs }
-    | Expression -> { x with pexp_attributes = x.pexp_attributes @ attrs }
-    | Module_expr -> { x with pmod_attributes = x.pmod_attributes @ attrs }
-    | Module_type -> { x with pmty_attributes = x.pmty_attributes @ attrs }
-    | Pattern -> { x with ppat_attributes = x.ppat_attributes @ attrs }
-    | Signature_item ->
-        assert_no_attributes attrs;
-        x
-    | Structure_item ->
-        assert_no_attributes attrs;
-        x
-    | Ppx_import ->
-        assert_no_attributes attrs;
-        x
+    | Class_expr -> Ok { x with pcl_attributes = x.pcl_attributes @ attrs }
+    | Class_field -> Ok { x with pcf_attributes = x.pcf_attributes @ attrs }
+    | Class_type -> Ok { x with pcty_attributes = x.pcty_attributes @ attrs }
+    | Class_type_field ->
+        Ok { x with pctf_attributes = x.pctf_attributes @ attrs }
+    | Core_type -> Ok { x with ptyp_attributes = x.ptyp_attributes @ attrs }
+    | Expression -> Ok { x with pexp_attributes = x.pexp_attributes @ attrs }
+    | Module_expr -> Ok { x with pmod_attributes = x.pmod_attributes @ attrs }
+    | Module_type -> Ok { x with pmty_attributes = x.pmty_attributes @ attrs }
+    | Pattern -> Ok { x with ppat_attributes = x.ppat_attributes @ attrs }
+    | Signature_item -> (
+        match attributes_errors attrs with [] -> Ok x | t :: q -> Error (t, q))
+    | Structure_item -> (
+        match attributes_errors attrs with [] -> Ok x | t :: q -> Error (t, q))
+    | Ppx_import -> (
+        match attributes_errors attrs with [] -> Ok x | t :: q -> Error (t, q))
+
+  let merge_attributes : type a. a t -> a -> attributes -> a =
+   fun t x attrs ->
+    merge_attributes_res t x attrs
+    |> Result.handle_error ~f:(fun (err, _) -> Location.Error.raise err)
 end
 
 let registrar =
@@ -176,29 +208,35 @@ struct
     let { txt = name; loc } = fst ext in
     let name, arg = Name.split_path name in
     match List.filter ts ~f:(fun t -> Name.Pattern.matches t.name name) with
-    | [] -> None
+    | [] -> Ok None
     | _ :: _ :: _ as l ->
-        Location.raise_errorf ~loc "Multiple match for extensions: %s"
-          (String.concat ~sep:", "
-             (List.map l ~f:(fun t -> Name.Pattern.name t.name)))
+        Error
+          ( Location.Error.createf ~loc "Multiple match for extensions: %s"
+              (String.concat ~sep:", "
+                 (List.map l ~f:(fun t -> Name.Pattern.name t.name))),
+            [] )
     | [ t ] ->
         if (not t.with_arg) && Option.is_some arg then
-          Location.raise_errorf ~loc
-            "Extension %s doesn't expect a path argument" name;
-        let arg =
-          Option.map arg ~f:(fun s ->
-              let shift = String.length name + 1 in
-              let start = loc.loc_start in
-              {
-                txt = Longident.parse s;
-                loc =
-                  {
-                    loc with
-                    loc_start = { start with pos_cnum = start.pos_cnum + shift };
-                  };
-              })
-        in
-        Some (t, arg)
+          Error
+            ( Location.Error.createf ~loc
+                "Extension %s doesn't expect a path argument" name,
+              [] )
+        else
+          let arg =
+            Option.map arg ~f:(fun s ->
+                let shift = String.length name + 1 in
+                let start = loc.loc_start in
+                {
+                  txt = Longident.parse s;
+                  loc =
+                    {
+                      loc with
+                      loc_start =
+                        { start with pos_cnum = start.pos_cnum + shift };
+                    };
+                })
+          in
+          Ok (Some (t, arg))
 end
 
 module Expert = struct
@@ -212,11 +250,18 @@ module Expert = struct
   let declare name ctx patt f =
     declare ~with_arg:false name ctx patt (fun ~arg:_ -> f)
 
-  let convert ts ~loc ext =
-    match find ts ext with
-    | None -> None
+  let convert_res ts ~loc ext =
+    let open Result in
+    find ts ext >>= fun r ->
+    match r with
+    | None -> Ok None
     | Some ({ payload = Payload_parser (pattern, f); _ }, arg) ->
-        Some (Ast_pattern.parse pattern loc (snd ext) (f ~arg))
+        Ast_pattern.parse_res pattern loc (snd ext) (f ~arg) >>| fun payload ->
+        Some payload
+
+  let convert ts ~loc ext =
+    convert_res ts ~loc ext
+    |> Result.handle_error ~f:(fun (err, _) -> Location.Error.raise err)
 end
 
 module M = Make (struct
@@ -229,23 +274,37 @@ type 'a expander_result = Simple of 'a | Inline of 'a list
 module For_context = struct
   type 'a t = ('a, 'a expander_result) M.t
 
-  let convert ts ~ctxt ext =
+  let convert_res ts ~ctxt ext =
     let loc = Expansion_context.Extension.extension_point_loc ctxt in
-    match M.find ts ext with
-    | None -> None
+    let open Result in
+    M.find ts ext >>= fun found ->
+    match found with
+    | None -> Ok None
     | Some ({ payload = M.Payload_parser (pattern, f); _ }, arg) -> (
-        match Ast_pattern.parse pattern loc (snd ext) (f ~ctxt ~arg) with
+        Ast_pattern.parse_res pattern loc (snd ext) (f ~ctxt ~arg)
+        >>| fun payload ->
+        match payload with
         | Simple x -> Some x
         | Inline _ -> failwith "Extension.convert")
 
-  let convert_inline ts ~ctxt ext =
+  let convert ts ~ctxt ext =
+    convert_res ts ~ctxt ext
+    |> Result.handle_error ~f:(fun (err, _) -> Location.Error.raise err)
+
+  let convert_inline_res ts ~ctxt ext =
     let loc = Expansion_context.Extension.extension_point_loc ctxt in
-    match M.find ts ext with
-    | None -> None
+    let open Result in
+    M.find ts ext >>= fun found ->
+    match found with
+    | None -> Ok None
     | Some ({ payload = M.Payload_parser (pattern, f); _ }, arg) -> (
-        match Ast_pattern.parse pattern loc (snd ext) (f ~ctxt ~arg) with
-        | Simple x -> Some [ x ]
-        | Inline l -> Some l)
+        Ast_pattern.parse_res pattern loc (snd ext) (f ~ctxt ~arg)
+        >>| fun payload ->
+        match payload with Simple x -> Some [ x ] | Inline l -> Some l)
+
+  let convert_inline ts ~ctxt ext =
+    convert_inline_res ts ~ctxt ext
+    |> Result.handle_error ~f:(fun (err, _) -> Location.Error.raise err)
 end
 
 type t = T : _ For_context.t -> t
@@ -271,72 +330,143 @@ let rec filter_by_context :
       | Eq -> t :: filter_by_context context rest
       | Ne -> filter_by_context context rest)
 
-let fail ctx (name, _) =
+let unhandled_extension_error ctx (name, _) =
   if
     not
       (Name.Allowlisted.is_allowlisted ~kind:`Extension name.txt
       || Name.ignore_checks name.txt)
   then
-    Name.Registrar.raise_errorf registrar (Context.T ctx)
-      "Extension `%s' was not translated" name
+    [
+      Name.Registrar.Error.createf registrar (Context.T ctx)
+        "Extension `%s' was not translated" name;
+    ]
+  else []
+
+let collect_unhandled_extension_errors =
+  object
+    inherit [Location.Error.t list] Ast_traverse.fold as super
+
+    method! extension (name, _) acc =
+      acc
+      @ [
+          Location.Error.createf ~loc:name.loc
+            "extension not expected here, Ppxlib.Extension needs updating!";
+        ]
+
+    method! core_type_desc x acc =
+      match x with
+      | Ptyp_extension ext -> acc @ unhandled_extension_error Core_type ext
+      | x -> super#core_type_desc x acc
+
+    method! pattern_desc x acc =
+      match x with
+      | Ppat_extension ext -> acc @ unhandled_extension_error Pattern ext
+      | x -> super#pattern_desc x acc
+
+    method! expression_desc x acc =
+      match x with
+      | Pexp_extension ext -> acc @ unhandled_extension_error Expression ext
+      | x -> super#expression_desc x acc
+
+    method! class_type_desc x acc =
+      match x with
+      | Pcty_extension ext -> acc @ unhandled_extension_error Class_type ext
+      | x -> super#class_type_desc x acc
+
+    method! class_type_field_desc x acc =
+      match x with
+      | Pctf_extension ext ->
+          acc @ unhandled_extension_error Class_type_field ext
+      | x -> super#class_type_field_desc x acc
+
+    method! class_expr_desc x acc =
+      match x with
+      | Pcl_extension ext -> acc @ unhandled_extension_error Class_expr ext
+      | x -> super#class_expr_desc x acc
+
+    method! class_field_desc x acc =
+      match x with
+      | Pcf_extension ext -> acc @ unhandled_extension_error Class_field ext
+      | x -> super#class_field_desc x acc
+
+    method! module_type_desc x acc =
+      match x with
+      | Pmty_extension ext -> acc @ unhandled_extension_error Module_type ext
+      | x -> super#module_type_desc x acc
+
+    method! signature_item_desc x acc =
+      match x with
+      | Psig_extension (ext, _) ->
+          acc @ unhandled_extension_error Signature_item ext
+      | x -> super#signature_item_desc x acc
+
+    method! module_expr_desc x acc =
+      match x with
+      | Pmod_extension ext -> acc @ unhandled_extension_error Module_expr ext
+      | x -> super#module_expr_desc x acc
+
+    method! structure_item_desc x acc =
+      match x with
+      | Pstr_extension (ext, _) ->
+          acc @ unhandled_extension_error Structure_item ext
+      | x -> super#structure_item_desc x acc
+  end
+
+let error_list_to_exception = function
+  | [] -> ()
+  | err :: _ -> Location.Error.raise err
 
 let check_unused =
   object
-    inherit Ast_traverse.iter as super
+    inherit Ast_traverse.iter
 
     method! extension (name, _) =
       Location.raise_errorf ~loc:name.loc
         "extension not expected here, Ppxlib.Extension needs updating!"
 
-    method! core_type_desc =
-      function
-      | Ptyp_extension ext -> fail Core_type ext | x -> super#core_type_desc x
+    method! core_type_desc x =
+      collect_unhandled_extension_errors#core_type_desc x []
+      |> error_list_to_exception
 
-    method! pattern_desc =
-      function
-      | Ppat_extension ext -> fail Pattern ext | x -> super#pattern_desc x
+    method! pattern_desc x =
+      collect_unhandled_extension_errors#pattern_desc x []
+      |> error_list_to_exception
 
-    method! expression_desc =
-      function
-      | Pexp_extension ext -> fail Expression ext | x -> super#expression_desc x
+    method! expression_desc x =
+      collect_unhandled_extension_errors#expression_desc x []
+      |> error_list_to_exception
 
-    method! class_type_desc =
-      function
-      | Pcty_extension ext -> fail Class_type ext | x -> super#class_type_desc x
+    method! class_type_desc x =
+      collect_unhandled_extension_errors#class_type_desc x []
+      |> error_list_to_exception
 
-    method! class_type_field_desc =
-      function
-      | Pctf_extension ext -> fail Class_type_field ext
-      | x -> super#class_type_field_desc x
+    method! class_type_field_desc x =
+      collect_unhandled_extension_errors#class_type_field_desc x []
+      |> error_list_to_exception
 
-    method! class_expr_desc =
-      function
-      | Pcl_extension ext -> fail Class_expr ext | x -> super#class_expr_desc x
+    method! class_expr_desc x =
+      collect_unhandled_extension_errors#class_expr_desc x []
+      |> error_list_to_exception
 
-    method! class_field_desc =
-      function
-      | Pcf_extension ext -> fail Class_field ext
-      | x -> super#class_field_desc x
+    method! class_field_desc x =
+      collect_unhandled_extension_errors#class_field_desc x []
+      |> error_list_to_exception
 
-    method! module_type_desc =
-      function
-      | Pmty_extension ext -> fail Module_type ext
-      | x -> super#module_type_desc x
+    method! module_type_desc x =
+      collect_unhandled_extension_errors#module_type_desc x []
+      |> error_list_to_exception
 
-    method! signature_item_desc =
-      function
-      | Psig_extension (ext, _) -> fail Signature_item ext
-      | x -> super#signature_item_desc x
+    method! signature_item_desc x =
+      collect_unhandled_extension_errors#signature_item_desc x []
+      |> error_list_to_exception
 
-    method! module_expr_desc =
-      function
-      | Pmod_extension ext -> fail Module_expr ext
-      | x -> super#module_expr_desc x
+    method! module_expr_desc x =
+      collect_unhandled_extension_errors#module_expr_desc x []
+      |> error_list_to_exception
 
-    method! structure_item_desc =
-      function
-      | Pstr_extension (ext, _) -> fail Structure_item ext
-      | x -> super#structure_item_desc x
+    method! structure_item_desc x =
+      collect_unhandled_extension_errors#structure_item_desc x []
+      |> error_list_to_exception
   end
 
 module V3 = struct

--- a/src/name.mli
+++ b/src/name.mli
@@ -54,11 +54,37 @@ module Registrar : sig
   val spellcheck :
     'context t -> 'context -> ?allowlist:string list -> string -> string option
 
+  module Error : sig
+    val createf :
+      'context t ->
+      'context ->
+      ?allowlist:string list ->
+      (string -> Location.Error.t, unit, string, Location.Error.t) format4 ->
+      string Loc.t ->
+      Location.Error.t
+
+    val raise_errorf :
+      'context t ->
+      'context ->
+      ?allowlist:string list ->
+      (string -> Location.Error.t, unit, string, Location.Error.t) format4 ->
+      string Loc.t ->
+      'a
+
+    val error_extensionf :
+      'context t ->
+      'context ->
+      ?allowlist:string list ->
+      (string -> Location.Error.t, unit, string, Location.Error.t) format4 ->
+      string Loc.t ->
+      extension
+  end
+
   val raise_errorf :
     'context t ->
     'context ->
     ?allowlist:string list ->
-    (string -> 'a, unit, string, 'c) format4 ->
+    (string -> Location.Error.t, unit, string, Location.Error.t) format4 ->
     string Loc.t ->
     'a
 end

--- a/test/driver/attributes/test.ml
+++ b/test/driver/attributes/test.ml
@@ -15,7 +15,7 @@ let f x = 1 [@@deprecatd "..."]
 [%%expect{|
 Line _, characters 15-24:
 Error: Attribute `deprecatd' was not used.
-Hint: Did you mean deprecated?
+       Hint: Did you mean deprecated?
 |}]
 
 let attr : _ Attribute.t =
@@ -31,9 +31,10 @@ type t = int [@blah]
 [%%expect{|
 Line _, characters 15-19:
 Error: Attribute `blah' was not used.
-Hint: `blah' is available for type declarations but is used here in the
-context of a core type.
-Did you put it at the wrong level?
+       Hint: `blah' is available for type declarations but is used here in
+       the
+       context of a core type.
+       Did you put it at the wrong level?
 |}]
 
 let attr : _ Attribute.t =
@@ -49,9 +50,10 @@ type t = int [@blah]
 [%%expect{|
 Line _, characters 15-19:
 Error: Attribute `blah' was not used.
-Hint: `blah' is available for expressions and type declarations but is used
-here in the context of a core type.
-Did you put it at the wrong level?
+       Hint: `blah' is available for expressions and type declarations but is
+       used
+       here in the context of a core type.
+       Did you put it at the wrong level?
 |}]
 
 (* Attribute drops *)

--- a/test/error_embedding/deriver.ml
+++ b/test/error_embedding/deriver.ml
@@ -1,0 +1,31 @@
+open Ppxlib
+
+let derive_a_string ~ctxt (_rec_flag, _type_declarations) =
+  let loc = Expansion_context.Deriver.derived_item_loc ctxt in
+  let open Ast_builder.Default in
+  [
+    pstr_value ~loc Nonrecursive
+      [
+        {
+          pvb_pat = ppat_any ~loc;
+          pvb_expr = estring ~loc "derived_string";
+          pvb_attributes = [];
+          pvb_loc = loc;
+        };
+      ];
+  ]
+
+let impl_generator_derive_a_string =
+  Deriving.Generator.V2.make_noarg derive_a_string
+
+let deriver_for_a_string =
+  Deriving.add "a_string" ~str_type_decl:impl_generator_derive_a_string
+
+let impl_generator_dependent =
+  Deriving.Generator.V2.make_noarg ~deps:[ deriver_for_a_string ]
+    derive_a_string
+
+let dependent_deriver =
+  Deriving.add "a_dependent_string" ~str_type_decl:impl_generator_dependent
+
+let () = Driver.standalone ()

--- a/test/error_embedding/dune
+++ b/test/error_embedding/dune
@@ -1,0 +1,6 @@
+(executables
+ (names extender deriver)
+ (libraries ppxlib))
+
+(cram
+ (deps extender.exe deriver.exe))

--- a/test/error_embedding/extender.ml
+++ b/test/error_embedding/extender.ml
@@ -1,0 +1,15 @@
+open Ppxlib
+
+let export_string ~ctxt e =
+  let loc = Expansion_context.Extension.extension_point_loc ctxt in
+  let open Ast_builder.Default in
+  estring ~loc e
+
+let export_string_extension =
+  Extension.V3.declare "export_string" Extension.Context.expression
+    Ast_pattern.(single_expr_payload (estring __))
+    export_string
+
+let rule = Ppxlib.Context_free.Rule.extension export_string_extension
+let () = Driver.register_transformation ~rules:[ rule ] "export_string"
+let () = Driver.standalone ()

--- a/test/error_embedding/run.t
+++ b/test/error_embedding/run.t
@@ -1,0 +1,75 @@
+Most errors happening during ppxlib rewriting process are ultimately turned into
+error extension nodes.
+
+Undefined derivers are turned into error nodes
+
+  $ echo "type t = int [@@deriving undefined]" >> undefined_deriver.ml
+  $ ./deriver.exe undefined_deriver.ml
+  type t = int[@@deriving undefined]
+  include
+    struct
+      let _ = fun (_ : t) -> ()
+      [%%ocaml.error
+        "Ppxlib.Deriving: 'undefined' is not a supported type deriving generator"]
+    end[@@ocaml.doc "@inline"][@@merlin.hide ]
+
+Error nodes are generated when parsing of payload fails.
+
+export_string expects only one argument, a string, and output it.
+Anything else will embed an error extension node
+
+  $ echo "let _ = [%export_string \"string\"]" > parsing_payload_extension.ml
+  $ echo "let _ = [%export_string \"string\" \"other\"]" >> parsing_payload_extension.ml
+  $ echo "let _ = [%export_string identifier]" >> parsing_payload_extension.ml
+  $ ./extender.exe parsing_payload_extension.ml
+  let _ = "string"
+  let _ = [%ocaml.error "constant expected"]
+  let _ = [%ocaml.error "constant expected"]
+
+  $ echo "type a = int [@@deriving a_string]" > parsing_payload_deriver.ml
+  $ echo "type b = int [@@deriving a_string unexpected_args]" >> parsing_payload_deriver.ml
+  $ ./deriver.exe parsing_payload_deriver.ml
+  type a = int[@@deriving a_string]
+  include struct let _ = fun (_ : a) -> ()
+                 let _ = "derived_string" end[@@ocaml.doc "@inline"][@@merlin.hide
+                                                                      ]
+  type b = int[@@deriving a_string unexpected_args]
+  include
+    struct
+      let _ = fun (_ : b) -> ()
+      [%%ocaml.error
+        "Ppxlib.Deriving: non-optional labelled argument or record expected"]
+    end[@@ocaml.doc "@inline"][@@merlin.hide ]
+
+Error nodes are generated when dependent derivers are not applied.
+
+  $ echo "type a = int [@@deriving a_dependent_string]" > dependent_derivers.ml
+  $ ./deriver.exe dependent_derivers.ml
+  type a = int[@@deriving a_dependent_string]
+  include
+    struct
+      let _ = fun (_ : a) -> ()
+      [%%ocaml.error
+        "Deriver a_string is needed for a_dependent_string, you need to add it before in the list"]
+      let _ = "derived_string"
+    end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  $ echo "type b = int [@@deriving a_dependent_string, a_string]" > dependent_derivers.ml
+  $ ./deriver.exe dependent_derivers.ml
+  type b = int[@@deriving (a_dependent_string, a_string)]
+  include
+    struct
+      let _ = fun (_ : b) -> ()
+      [%%ocaml.error
+        "Deriver a_string is needed for a_dependent_string, you need to add it before in the list"]
+      let _ = "derived_string"
+      let _ = "derived_string"
+    end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  $ echo "type b = int [@@deriving a_string, a_dependent_string]" > dependent_derivers.ml
+  $ ./deriver.exe dependent_derivers.ml
+  type b = int[@@deriving (a_string, a_dependent_string)]
+  include
+    struct
+      let _ = fun (_ : b) -> ()
+      let _ = "derived_string"
+      let _ = "derived_string"
+    end[@@ocaml.doc "@inline"][@@merlin.hide ]


### PR DESCRIPTION
This PR changes the behaviour of ppxlib in case of error.

As of now, ppxlib is raising located errors whenever it encounter an error: For instance, if the parsing of a payload fails, a located error is raised and nothing happen at all, including all other context-free rewriting.
This is obviously very bad for user experience with merlin.

This PR changes that to embed the error at the right place whenever it makes sense to do it.

This requires propagating the errors through a `result` type. In order to use the `Result` monadic let-bindings, a common error type is used: `Location.Error.t NonEmptyList.t`, even if there can only be one error (and not a list). If a function returns both values and errors, the return type is `value_type * Location.Error.t list`.
Public raising functions were kept for backward compatibility, and new `*_res` functions were created. To avoid duplication od code, the implementation of the raising functions is to call the non raising function, and raise in case of `Error` output.

In some case, I felt it still makes sense to raise (or we might have no choice), and I kept the exception. An example is when we have bad locations (for instance they overlap). 

I also added a few (non exhaustive but covering the most frequent cases I think) tests.

Compare (with `derive_accessors` and `get_env` from ppxlib's examples):
![image](https://user-images.githubusercontent.com/34110029/160811515-32685fe2-3342-4dcb-84b9-b37f21406da3.png)
(all errors are reported properly, `a` is defined as it should be), with
![image](https://user-images.githubusercontent.com/34110029/160811704-53566c23-97f5-435c-a9c4-3d50463255e1.png)
(`a` is not defined, the error on `get_env` is `Uninterpreted extension 'get_env'` so it is a misleading error, only the first error is reported properly)