### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ceastlund @NathanReb @pitag-ha
+* @ceastlund @panglesd @pitag-ha


### PR DESCRIPTION
I've already invited @panglesd to have maintaining access. As far as I understand, adding him to this codeowner file means that github will automatically add him as a reviewer for any PR.

@NathanReb has asked me to remove him from the codeowner file.