### PR TITLE
Allow toplevel_printer attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ unreleased
 
 - Fix quoter and optimize identifier quoting (#327, @sim642)
 
+- Driver, when run with `--check`: Allow `toplevel_printer` attributes (#340, @pitag-ha)
+
 0.26.0 (21/03/2022)
 -------------------
 

--- a/src/name.ml
+++ b/src/name.ml
@@ -92,6 +92,8 @@ module Whitelisted = struct
         "ocaml.warn_on_literal_pattern";
         "ocaml.warnerror";
         "ocaml.warning";
+        "ocaml.toplevel_printer" (*Interpreted by the toplevel/utop*);
+        "toplevel_printer" (*Interpreted by the toplevel/utop*);
       ]
 
   (* White list the following extensions.


### PR DESCRIPTION
The `toplevel_printer` attributes are interpreted by the toplevel/utop (see https://github.com/ocaml-community/utop/pull/269). This commit makes sure that the ppxlib driver doesn't complain when encountering them while running with attribute checks enabled.

Btw, we should rename the `Whitelisted` module to a less discriminatory name. If anyone has an idea for a better name, let me know (or, simply change it!).