### PR TITLE
implementing Code_path.enclosing_module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 unreleased
 ------------
 
+- Add `Code_path.enclosing_module` (#346, @ceastlund)
+
 - Fix Ast_pattern.many (#333, @nojb)
 
 - Fix quoter and optimize identifier quoting (#327, @sim642)

--- a/src/ast_traverse.ml
+++ b/src/ast_traverse.ml
@@ -103,7 +103,7 @@ class map_with_expansion_context =
             let name = self#loc (self#option self#string) ctxt name in
             let module_expr =
               self#module_expr
-                (ec_enter_module_opt ~loc:name.loc name.txt ctxt)
+                (ec_enter_module_opt ~loc:module_expr.pmod_loc name.txt ctxt)
                 module_expr
             in
             let body = self#expression ctxt body in

--- a/src/ast_traverse.ml
+++ b/src/ast_traverse.ml
@@ -94,8 +94,23 @@ class map_with_expansion_context =
   object (self)
     inherit [Expansion_context.Base.t] map_with_context as super
 
-    method! expression ctxt expr =
-      super#expression (Expansion_context.Base.enter_expr ctxt) expr
+    method! expression ctxt { pexp_desc; pexp_loc; pexp_loc_stack; pexp_attributes } =
+      let ctxt = Expansion_context.Base.enter_expr ctxt in
+      let pexp_desc =
+        match pexp_desc with
+        | Pexp_letmodule (name, module_expr, body) ->
+          let name = self#loc (self#option self#string) ctxt name in
+          let module_expr =
+            self#module_expr (ec_enter_module_opt ~loc:name.loc name.txt ctxt) module_expr
+          in
+          let body = self#expression ctxt body in
+          Pexp_letmodule (name, module_expr, body)
+        | _ -> self#expression_desc ctxt pexp_desc
+      in
+      let pexp_loc = self#location ctxt pexp_loc in
+      let pexp_loc_stack = self#list self#location ctxt pexp_loc_stack in
+      let pexp_attributes = self#attributes ctxt pexp_attributes in
+      { pexp_desc; pexp_loc; pexp_loc_stack; pexp_attributes }
 
     method! module_binding ctxt mb =
       super#module_binding

--- a/src/ast_traverse.ml
+++ b/src/ast_traverse.ml
@@ -94,17 +94,20 @@ class map_with_expansion_context =
   object (self)
     inherit [Expansion_context.Base.t] map_with_context as super
 
-    method! expression ctxt { pexp_desc; pexp_loc; pexp_loc_stack; pexp_attributes } =
+    method! expression ctxt
+        { pexp_desc; pexp_loc; pexp_loc_stack; pexp_attributes } =
       let ctxt = Expansion_context.Base.enter_expr ctxt in
       let pexp_desc =
         match pexp_desc with
         | Pexp_letmodule (name, module_expr, body) ->
-          let name = self#loc (self#option self#string) ctxt name in
-          let module_expr =
-            self#module_expr (ec_enter_module_opt ~loc:name.loc name.txt ctxt) module_expr
-          in
-          let body = self#expression ctxt body in
-          Pexp_letmodule (name, module_expr, body)
+            let name = self#loc (self#option self#string) ctxt name in
+            let module_expr =
+              self#module_expr
+                (ec_enter_module_opt ~loc:name.loc name.txt ctxt)
+                module_expr
+            in
+            let body = self#expression ctxt body in
+            Pexp_letmodule (name, module_expr, body)
         | _ -> self#expression_desc ctxt pexp_desc
       in
       let pexp_loc = self#location ctxt pexp_loc in

--- a/src/code_path.ml
+++ b/src/code_path.ml
@@ -45,7 +45,8 @@ let enter_expr t = { t with in_expr = true }
 let enter_module ~loc module_name t =
   if t.in_expr then { t with enclosing_module = module_name }
   else
-    { t with
+    {
+      t with
       submodule_path = { txt = module_name; loc } :: t.submodule_path;
       enclosing_module = module_name;
     }

--- a/src/code_path.ml
+++ b/src/code_path.ml
@@ -4,6 +4,7 @@ type t = {
   file_path : string;
   main_module_name : string;
   submodule_path : string loc list;
+  enclosing_module : string;
   value : string loc option;
   in_expr : bool;
 }
@@ -17,12 +18,14 @@ let top_level ~file_path =
     file_path;
     main_module_name;
     submodule_path = [];
+    enclosing_module = main_module_name;
     value = None;
     in_expr = false;
   }
 
 let file_path t = t.file_path
 let main_module_name t = t.main_module_name
+let enclosing_module t = t.enclosing_module
 
 let submodule_path t =
   List.rev_map ~f:(fun located -> located.txt) t.submodule_path
@@ -40,9 +43,12 @@ let fully_qualified_path t =
 let enter_expr t = { t with in_expr = true }
 
 let enter_module ~loc module_name t =
-  if t.in_expr then t
+  if t.in_expr then { t with enclosing_module = module_name }
   else
-    { t with submodule_path = { txt = module_name; loc } :: t.submodule_path }
+    { t with
+      submodule_path = { txt = module_name; loc } :: t.submodule_path;
+      enclosing_module = module_name;
+    }
 
 let enter_value ~loc value_name t =
   if t.in_expr then t else { t with value = Some { txt = value_name; loc } }

--- a/src/code_path.mli
+++ b/src/code_path.mli
@@ -14,6 +14,9 @@ val submodule_path : t -> string list
 (** Return the path within the main module this code path represents as a list
     of module names. *)
 
+val enclosing_module : t -> string
+(** Return the nearest enclosing module name. Does descend into expressions. *)
+
 val value : t -> string option
 (** Return the name of the value to which this code path leads or [None] if it
     leads to the toplevel of a module or submodule. *)

--- a/test/code_path/test.ml
+++ b/test/code_path/test.ml
@@ -1,6 +1,16 @@
 #require "base";;
 
+open Base
 open Ppxlib
+
+let sexp_of_code_path code_path =
+  Sexp.message
+    "code_path"
+    [ "main_module_name", sexp_of_string (Code_path.main_module_name code_path)
+    ; "submodule_path", sexp_of_list sexp_of_string (Code_path.submodule_path code_path)
+    ; "value", sexp_of_option sexp_of_string (Code_path.value code_path)
+    ; "fully_qualified_path", sexp_of_string (Code_path.fully_qualified_path code_path)
+    ]
 
 let () =
   Driver.register_transformation "test"
@@ -12,9 +22,10 @@ let () =
            let loc = Expansion_context.Extension.extension_point_loc ctxt in
            let code_path = Expansion_context.Extension.code_path ctxt in
            Ast_builder.Default.estring ~loc
-             (Code_path.fully_qualified_path code_path))
+             (Sexp.to_string (sexp_of_code_path code_path)))
     ]
 [%%expect{|
+val sexp_of_code_path : Code_path.t -> Sexp.t = <fun>
 |}]
 
 let s =
@@ -38,7 +49,8 @@ let s =
   in A.A'.a
 ;;
 [%%expect{|
-val s : string = "Test.s"
+val s : string =
+  "(code_path(main_module_name Test)(submodule_path())(value(s))(fully_qualified_path Test.s))"
 |}]
 
 let module M = struct
@@ -47,5 +59,6 @@ let module M = struct
   in
   M.m
 [%%expect{|
-- : string = "Test"
+- : string =
+"(code_path(main_module_name Test)(submodule_path())(value())(fully_qualified_path Test))"
 |}]

--- a/test/code_path/test.ml
+++ b/test/code_path/test.ml
@@ -8,6 +8,7 @@ let sexp_of_code_path code_path =
     "code_path"
     [ "main_module_name", sexp_of_string (Code_path.main_module_name code_path)
     ; "submodule_path", sexp_of_list sexp_of_string (Code_path.submodule_path code_path)
+    ; "enclosing_module", sexp_of_string (Code_path.enclosing_module code_path)
     ; "value", sexp_of_option sexp_of_string (Code_path.value code_path)
     ; "fully_qualified_path", sexp_of_string (Code_path.fully_qualified_path code_path)
     ]
@@ -50,7 +51,7 @@ let s =
 ;;
 [%%expect{|
 val s : string =
-  "(code_path(main_module_name Test)(submodule_path())(value(s))(fully_qualified_path Test.s))"
+  "(code_path(main_module_name Test)(submodule_path())(enclosing_module C')(value(s))(fully_qualified_path Test.s))"
 |}]
 
 let module M = struct
@@ -60,7 +61,7 @@ let module M = struct
   M.m
 [%%expect{|
 - : string =
-"(code_path(main_module_name Test)(submodule_path())(value())(fully_qualified_path Test))"
+"(code_path(main_module_name Test)(submodule_path())(enclosing_module Test)(value())(fully_qualified_path Test))"
 |}]
 
 module Outer = struct
@@ -72,7 +73,7 @@ let _ = Outer.Inner.code_path
 [%%expect{|
 module Outer : sig module Inner : sig val code_path : string end end
 - : string =
-"(code_path(main_module_name Test)(submodule_path(Outer Inner))(value(code_path))(fully_qualified_path Test.Outer.Inner.code_path))"
+"(code_path(main_module_name Test)(submodule_path(Outer Inner))(enclosing_module Inner)(value(code_path))(fully_qualified_path Test.Outer.Inner.code_path))"
 |}]
 
 module Functor() = struct
@@ -93,5 +94,5 @@ let _ = let module M = Functor() in !M.code_path
 [%%expect{|
 module Functor : functor () -> sig val code_path : string ref end
 - : string =
-"(code_path(main_module_name Test)(submodule_path(Functor _))(value(x))(fully_qualified_path Test.Functor._.x))"
+"(code_path(main_module_name Test)(submodule_path(Functor _))(enclosing_module _)(value(x))(fully_qualified_path Test.Functor._.x))"
 |}]

--- a/test/code_path/test.ml
+++ b/test/code_path/test.ml
@@ -61,7 +61,7 @@ let module M = struct
   M.m
 [%%expect{|
 - : string =
-"(code_path(main_module_name Test)(submodule_path())(enclosing_module Test)(value())(fully_qualified_path Test))"
+"(code_path(main_module_name Test)(submodule_path())(enclosing_module M)(value())(fully_qualified_path Test))"
 |}]
 
 module Outer = struct
@@ -94,5 +94,5 @@ let _ = let module M = Functor() in !M.code_path
 [%%expect{|
 module Functor : functor () -> sig val code_path : string ref end
 - : string =
-"(code_path(main_module_name Test)(submodule_path(Functor _))(enclosing_module _)(value(x))(fully_qualified_path Test.Functor._.x))"
+"(code_path(main_module_name Test)(submodule_path(Functor _))(enclosing_module First_class)(value(x))(fully_qualified_path Test.Functor._.x))"
 |}]


### PR DESCRIPTION
We have a ppx extension we use internally where knowing the nearest enclosing module name, including first class modules, would be handy. I've extended Code_path and its tests accordingly.