### PR TITLE
Add 5.0 support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 unreleased
 ------------
 
+- Add support for OCaml 5.0 (#348, @pitag-ha)
+
 - Add `Code_path.enclosing_value` (#349, @ceastlund)
 
 - Add `Code_path.enclosing_module` (#346, @ceastlund)

--- a/ast/ast_helper_lite.ml
+++ b/ast/ast_helper_lite.ml
@@ -17,7 +17,7 @@
 open Stdlib0
 module Location = Astlib.Location
 module Longident = Astlib.Longident
-open Astlib.Ast_414
+open Astlib.Ast_500
 
 [@@@warning "-9"]
 

--- a/ast/ast_helper_lite.mli
+++ b/ast/ast_helper_lite.mli
@@ -15,7 +15,7 @@
 
 (** Copy of Ast_helper from OCaml 4.14 with docstring related stuff removed *)
 
-open Astlib.Ast_414
+open Astlib.Ast_500
 open Asttypes
 open Parsetree
 

--- a/ast/import.ml
+++ b/ast/import.ml
@@ -4,7 +4,7 @@
    It must be opened in all modules, especially the ones coming from the compiler.
 *)
 
-module Js = Versions.OCaml_414
+module Js = Versions.OCaml_500
 module Ocaml = Versions.OCaml_current
 
 module Select_ast (Ocaml : Versions.OCaml_version) = struct

--- a/ast/supported_version/supported_version.ml
+++ b/ast/supported_version/supported_version.ml
@@ -15,9 +15,12 @@ let all =
     (4, 12);
     (4, 13);
     (4, 14);
+    (5, 0);
   ]
 
-let to_string (a, b) = Printf.sprintf "%d.%02d" a b
+let to_string (a, b) =
+  if a < 5 then Printf.sprintf "%d.%02d" a b else Printf.sprintf "%d.%d" a b
+
 let to_int (a, b) = (a * 100) + b
 
 let of_string s =

--- a/ast/versions.ml
+++ b/ast/versions.ml
@@ -499,6 +499,13 @@ module OCaml_414 = struct
   let string_version = "4.14"
 end
 let ocaml_414 : OCaml_414.types ocaml_version = (module OCaml_414)
+module OCaml_500 = struct
+  module Ast = Astlib.Ast_500
+  include Make_witness(Astlib.Ast_500)
+  let version = 500
+  let string_version = "5.0"
+end
+let ocaml_500 : OCaml_500.types ocaml_version = (module OCaml_500)
 (*$*)
 
 let all_versions : (module OCaml_version) list = [
@@ -517,6 +524,7 @@ let all_versions : (module OCaml_version) list = [
 (module OCaml_412 : OCaml_version);
 (module OCaml_413 : OCaml_version);
 (module OCaml_414 : OCaml_version);
+(module OCaml_500 : OCaml_version);
 (*$*)
 ]
 
@@ -549,6 +557,8 @@ include Register_migration(OCaml_412)(OCaml_413)
     (Astlib.Migrate_412_413)(Astlib.Migrate_413_412)
 include Register_migration(OCaml_413)(OCaml_414)
     (Astlib.Migrate_413_414)(Astlib.Migrate_414_413)
+include Register_migration(OCaml_414)(OCaml_500)
+    (Astlib.Migrate_414_500)(Astlib.Migrate_500_414)
 (*$*)
 
 module OCaml_current = OCaml_OCAML_VERSION

--- a/ast/versions.mli
+++ b/ast/versions.mli
@@ -128,6 +128,7 @@ module OCaml_411 : OCaml_version with module Ast = Astlib.Ast_411
 module OCaml_412 : OCaml_version with module Ast = Astlib.Ast_412
 module OCaml_413 : OCaml_version with module Ast = Astlib.Ast_413
 module OCaml_414 : OCaml_version with module Ast = Astlib.Ast_414
+module OCaml_500 : OCaml_version with module Ast = Astlib.Ast_500
 (*$*)
 
 (* An alias to the current compiler version *)

--- a/astlib/ast_500.ml
+++ b/astlib/ast_500.ml
@@ -1,0 +1,14 @@
+(* The only difference between 4.14 and 5.0 from a Parsetree point of view are the magic numbers *)
+
+module Asttypes = struct
+  include Ast_414.Asttypes
+end
+
+module Parsetree = struct
+  include Ast_414.Parsetree
+end
+
+module Config = struct
+  let ast_impl_magic_number = "Caml1999M032"
+  let ast_intf_magic_number = "Caml1999N032"
+end

--- a/astlib/astlib.ml
+++ b/astlib/astlib.ml
@@ -35,6 +35,7 @@ module Ast_411 = Ast_411
 module Ast_412 = Ast_412
 module Ast_413 = Ast_413
 module Ast_414 = Ast_414
+module Ast_500 = Ast_500
 (*$*)
 
 (* Manual migration between versions *)
@@ -67,6 +68,8 @@ module Migrate_412_413 = Migrate_412_413
 module Migrate_413_412 = Migrate_413_412
 module Migrate_413_414 = Migrate_413_414
 module Migrate_414_413 = Migrate_414_413
+module Migrate_414_500 = Migrate_414_500
+module Migrate_500_414 = Migrate_500_414
 (*$*)
 
 (* Compiler modules *)

--- a/astlib/cinaps/astlib_cinaps_helpers.ml
+++ b/astlib/cinaps/astlib_cinaps_helpers.ml
@@ -20,6 +20,7 @@ let supported_versions =
     ("412", "4.12");
     ("413", "4.13");
     ("414", "4.14");
+    ("500", "5.00");
   ]
 
 let foreach_version f =

--- a/astlib/config/gen.ml
+++ b/astlib/config/gen.ml
@@ -23,6 +23,9 @@ let () =
     | 4, 12 -> "412"
     | 4, 13 -> "413"
     | 4, 14 -> "414"
+    | 5, 0 ->
+        "414"
+        (* Ast_500 aliases Ast_414, since the AST hasn't changed between those two *)
     | _ ->
         Printf.eprintf "Unkown OCaml version %s\n" ocaml_version_str;
         exit 1)

--- a/astlib/migrate_414_500.ml
+++ b/astlib/migrate_414_500.ml
@@ -1,0 +1,40 @@
+module From = Ast_414
+module To = Ast_500
+
+let copy_structure : Ast_414.Parsetree.structure -> Ast_500.Parsetree.structure
+    =
+ fun x -> x
+
+let copy_signature : Ast_414.Parsetree.signature -> Ast_500.Parsetree.signature
+    =
+ fun x -> x
+
+let copy_toplevel_phrase :
+    Ast_414.Parsetree.toplevel_phrase -> Ast_500.Parsetree.toplevel_phrase =
+ fun x -> x
+
+let copy_core_type : Ast_414.Parsetree.core_type -> Ast_500.Parsetree.core_type
+    =
+ fun x -> x
+
+let copy_expression :
+    Ast_414.Parsetree.expression -> Ast_500.Parsetree.expression =
+ fun x -> x
+
+let copy_pattern : Ast_414.Parsetree.pattern -> Ast_500.Parsetree.pattern =
+ fun x -> x
+
+let copy_case : Ast_414.Parsetree.case -> Ast_500.Parsetree.case = fun x -> x
+
+let copy_type_declaration :
+    Ast_414.Parsetree.type_declaration -> Ast_500.Parsetree.type_declaration =
+ fun x -> x
+
+let copy_type_extension :
+    Ast_414.Parsetree.type_extension -> Ast_500.Parsetree.type_extension =
+ fun x -> x
+
+let copy_extension_constructor :
+    Ast_414.Parsetree.extension_constructor ->
+    Ast_500.Parsetree.extension_constructor =
+ fun x -> x

--- a/astlib/migrate_500_414.ml
+++ b/astlib/migrate_500_414.ml
@@ -1,0 +1,40 @@
+module From = Ast_500
+module To = Ast_414
+
+let copy_structure : Ast_500.Parsetree.structure -> Ast_414.Parsetree.structure
+    =
+ fun x -> x
+
+let copy_signature : Ast_500.Parsetree.signature -> Ast_414.Parsetree.signature
+    =
+ fun x -> x
+
+let copy_toplevel_phrase :
+    Ast_500.Parsetree.toplevel_phrase -> Ast_414.Parsetree.toplevel_phrase =
+ fun x -> x
+
+let copy_core_type : Ast_500.Parsetree.core_type -> Ast_414.Parsetree.core_type
+    =
+ fun x -> x
+
+let copy_expression :
+    Ast_500.Parsetree.expression -> Ast_414.Parsetree.expression =
+ fun x -> x
+
+let copy_pattern : Ast_500.Parsetree.pattern -> Ast_414.Parsetree.pattern =
+ fun x -> x
+
+let copy_case : Ast_500.Parsetree.case -> Ast_414.Parsetree.case = fun x -> x
+
+let copy_type_declaration :
+    Ast_500.Parsetree.type_declaration -> Ast_414.Parsetree.type_declaration =
+ fun x -> x
+
+let copy_type_extension :
+    Ast_500.Parsetree.type_extension -> Ast_414.Parsetree.type_extension =
+ fun x -> x
+
+let copy_extension_constructor :
+    Ast_500.Parsetree.extension_constructor ->
+    Ast_414.Parsetree.extension_constructor =
+ fun x -> x

--- a/dune-project
+++ b/dune-project
@@ -15,7 +15,7 @@
 (package
  (name ppxlib)
  (depends
-  (ocaml (and (>= 4.04.1) (< 4.15)))
+  (ocaml (and (>= 4.04.1) (< 5.1.0)))
   (ocaml-compiler-libs (>= v0.11.0))
   (ppx_derivers (>= 1.0))
   (sexplib0 (>= v0.12))

--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -21,7 +21,7 @@ doc: "https://ocaml-ppx.github.io/ppxlib/"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.04.1" & < "4.15"}
+  "ocaml" {>= "4.04.1" & < "5.1.0"}
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ppx_derivers" {>= "1.0"}
   "sexplib0" {>= "v0.12"}


### PR DESCRIPTION
This should make ppxlib compatible with OCaml 5.0.

The AST hasn't changed since 4.14. So I've just added direct identities between 4.14 and 5.0 instead of doing the deep migrations we usually do. I've also considered not adding a 5.0 module to Astlib at all (similarly to what I did in #319), but that would have gotten quite hacky since the compiler has bumped the magic numbers in the end.

This PR also directly bumps our ppxlib AST to 5.0, since that doesn't really change anything.