### PR TITLE
Updated expansion context to include value names only when unambiguous.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 unreleased
 ------------
 
+- Update expansion context to leave out value name when multiple are
+  defined at once. (#351, @ceastlund)
+
 - Add support for OCaml 5.0 (#348, @pitag-ha)
 
 - Add `Code_path.enclosing_value` (#349, @ceastlund)

--- a/src/ast_traverse.ml
+++ b/src/ast_traverse.ml
@@ -139,11 +139,10 @@ class map_with_expansion_context =
 
     method! value_binding ctxt { pvb_pat; pvb_expr; pvb_attributes; pvb_loc } =
       let all_var_names = var_names_of#pattern pvb_pat [] in
-      let var_name = Stdppx.List.last all_var_names in
       let in_binding_ctxt =
-        match var_name with
-        | None -> ctxt
-        | Some var_name ->
+        match all_var_names with
+        | [] | _ :: _ :: _ -> ctxt
+        | [ var_name ] ->
             Expansion_context.Base.enter_value ~loc:pvb_loc var_name ctxt
       in
       let pvb_pat = self#pattern ctxt pvb_pat in


### PR DESCRIPTION
I don't know if anyone else has a use case for selecting an arbitrary value name from multiple when using `Expansion_context`. For my purposes, it would be clearer if it either did not pick an arbitrary name, or presented all applicable names. The former is a smaller rewrite with no interface change, so that's what I've written here.

To be clear about what this means, assume we have a file `my_module.ml`:

```ocaml
let () = [%my_extension 0]
let first = [%my_extension 1]
let (second, third) = [%my_extension 2], [%my_extension 3]
```

Currently, while expanding the above code, `ppxlib` would report `Code_path.fully_qualified_path` as `My_module` for `[%my_extension 0]`, as `My_module.first` for `[%my_extension 1]`, `My_module.second` for `[%my_extension 2]`, and again `My_module.second` for `[%my_extension 3]`.  This is somewhat misleading, as `[%my_extension 3]` would in fact be bound as `My_module.third`. The expansion context code doesn't know anything about destructuring the pattern and expression together---and I think that's right, calculating data flow is not `ppxlib`'s job.

Given that this produces a misleading name for `[%my_extension 3]`, I think it would be clearer to just not present a value name in this context, as with `[%my_extension 0]`. So that's what this patch does.