### PR TITLE
Folding errors when AST traversing, to embed them at the toplovel structure/signature.

### DIFF
--- a/src/ast_traverse.ml
+++ b/src/ast_traverse.ml
@@ -30,6 +30,12 @@ class ['ctx] map_with_context =
     inherit ['ctx] Ast.map_with_context
   end
 
+class ['ctx, 'acc] fold_map_with_context =
+  object
+    inherit ['ctx, 'acc] Ppxlib_traverse_builtins.fold_map_with_context
+    inherit ['ctx, 'acc] Ast.fold_map_with_context
+  end
+
 class virtual ['res] lift =
   object
     inherit ['res] Ppxlib_traverse_builtins.lift

--- a/src/ast_traverse.ml
+++ b/src/ast_traverse.ml
@@ -158,6 +158,78 @@ class map_with_expansion_context =
       { pvb_pat; pvb_expr; pvb_attributes; pvb_loc }
   end
 
+class map_with_expansion_context_and_errors =
+  object (self)
+    inherit
+      [Expansion_context.Base.t, Location.Error.t list] fold_map_with_context as super
+
+    method! expression ctxt
+        { pexp_desc; pexp_loc; pexp_loc_stack; pexp_attributes } errors =
+      let ctxt = Expansion_context.Base.enter_expr ctxt in
+      let pexp_desc, errors =
+        match pexp_desc with
+        | Pexp_letmodule (name, module_expr, body) ->
+            let name, errors =
+              self#loc (self#option self#string) ctxt name errors
+            in
+            let module_expr, errors =
+              self#module_expr
+                (ec_enter_module_opt ~loc:module_expr.pmod_loc name.txt ctxt)
+                module_expr errors
+            in
+            let body, errors = self#expression ctxt body errors in
+            (Pexp_letmodule (name, module_expr, body), errors)
+        | _ -> self#expression_desc ctxt pexp_desc errors
+      in
+      let pexp_loc, errors = self#location ctxt pexp_loc errors in
+      let pexp_loc_stack, errors =
+        self#list self#location ctxt pexp_loc_stack errors
+      in
+      let pexp_attributes, errors =
+        self#attributes ctxt pexp_attributes errors
+      in
+      ({ pexp_desc; pexp_loc; pexp_loc_stack; pexp_attributes }, errors)
+
+    method! module_binding ctxt mb errors =
+      super#module_binding
+        (ec_enter_module_opt ~loc:mb.pmb_loc mb.pmb_name.txt ctxt)
+        mb errors
+
+    method! module_declaration ctxt md errors =
+      super#module_declaration
+        (ec_enter_module_opt ~loc:md.pmd_loc md.pmd_name.txt ctxt)
+        md errors
+
+    method! module_type_declaration ctxt mtd errors =
+      super#module_type_declaration
+        (Expansion_context.Base.enter_module ~loc:mtd.pmtd_loc mtd.pmtd_name.txt
+           ctxt)
+        mtd errors
+
+    method! value_description ctxt vd errors =
+      super#value_description
+        (Expansion_context.Base.enter_value ~loc:vd.pval_loc vd.pval_name.txt
+           ctxt)
+        vd errors
+
+    method! value_binding ctxt { pvb_pat; pvb_expr; pvb_attributes; pvb_loc }
+        errors =
+      let all_var_names = var_names_of#pattern pvb_pat [] in
+      let in_binding_ctxt =
+        match all_var_names with
+        | [] | _ :: _ :: _ -> ctxt
+        | [ var_name ] ->
+            Expansion_context.Base.enter_value ~loc:pvb_loc var_name ctxt
+      in
+      let pvb_pat, errors = self#pattern ctxt pvb_pat errors in
+      let pvb_expr, errors = self#expression in_binding_ctxt pvb_expr errors in
+      let pvb_attributes, errors =
+        self#attributes in_binding_ctxt pvb_attributes errors
+      in
+      let pvb_loc, errors = self#location ctxt pvb_loc errors in
+      ({ pvb_pat; pvb_expr; pvb_attributes; pvb_loc }, errors)
+  end
+
 class sexp_of =
   object
     inherit [Sexp.t] Ast.lift

--- a/src/ast_traverse.mli
+++ b/src/ast_traverse.mli
@@ -57,6 +57,12 @@ class ['ctx] map_with_context :
     inherit ['ctx] Ast.map_with_context
   end
 
+class ['ctx, 'acc] fold_map_with_context :
+  object
+    inherit ['ctx, 'acc] Ppxlib_traverse_builtins.fold_map_with_context
+    inherit ['ctx, 'acc] Ast.fold_map_with_context
+  end
+
 class map_with_path : [string] map_with_context
 class map_with_expansion_context : [Expansion_context.Base.t] map_with_context
 

--- a/src/ast_traverse.mli
+++ b/src/ast_traverse.mli
@@ -66,6 +66,9 @@ class ['ctx, 'acc] fold_map_with_context :
 class map_with_path : [string] map_with_context
 class map_with_expansion_context : [Expansion_context.Base.t] map_with_context
 
+class map_with_expansion_context_and_errors :
+  [Expansion_context.Base.t, Location.Error.t list] fold_map_with_context
+
 class virtual ['res] lift :
   object
     inherit ['res] Ppxlib_traverse_builtins.lift

--- a/src/context_free.mli
+++ b/src/context_free.mli
@@ -150,3 +150,11 @@ class map_top_down :
        Generated_code_hook.t (* default: Generated_code_hook.nop *)
   -> Rule.t list
   -> Ast_traverse.map_with_expansion_context
+
+class map_top_down_with_errors :
+  ?expect_mismatch_handler:
+    Expect_mismatch_handler.t (* default: Expect_mismatch_handler.nop *)
+  -> ?generated_code_hook:
+       Generated_code_hook.t (* default: Generated_code_hook.nop *)
+  -> Rule.t list
+  -> Ast_traverse.map_with_expansion_context_and_errors

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -175,7 +175,7 @@ module Transform = struct
       ~input_name =
     let { rules; enclose_impl; enclose_intf; impl; intf; _ } = t in
     let map =
-      new Context_free.map_top_down
+      new Context_free.map_top_down_with_errors
         rules ~generated_code_hook:hook ~expect_mismatch_handler
     in
     let gen_header_and_footer context whole_loc f =
@@ -212,7 +212,7 @@ module Transform = struct
       match input_name with Some input_name -> input_name | None -> "_none_"
     in
     let map_impl ctxt st_with_attrs =
-      let st =
+      let st, errors =
         let attrs, st =
           List.split_while st_with_attrs ~f:(function
             | { pstr_desc = Pstr_attribute _; _ } -> true
@@ -231,12 +231,21 @@ module Transform = struct
               in
               gen_header_and_footer Structure_item whole_loc (f base_ctxt)
         in
-        map#structure base_ctxt (List.concat [ attrs; header; st; footer ])
+        map#structure base_ctxt (List.concat [ attrs; header; st; footer ]) []
+      in
+      let st =
+        (errors
+        |> List.map ~f:Location.Error.to_extension
+        |> List.map
+             ~f:
+               (Extension.Context.node_of_extension
+                  Extension.Context.structure_item))
+        @ st
       in
       match impl with None -> st | Some f -> f ctxt st
     in
     let map_intf ctxt sg_with_attrs =
-      let sg =
+      let sg, errors =
         let attrs, sg =
           List.split_while sg_with_attrs ~f:(function
             | { psig_desc = Psig_attribute _; _ } -> true
@@ -255,7 +264,16 @@ module Transform = struct
               in
               gen_header_and_footer Signature_item whole_loc (f base_ctxt)
         in
-        map#signature base_ctxt (List.concat [ attrs; header; sg; footer ])
+        map#signature base_ctxt (List.concat [ attrs; header; sg; footer ]) []
+      in
+      let sg =
+        (errors
+        |> List.map ~f:Location.Error.to_extension
+        |> List.map
+             ~f:
+               (Extension.Context.node_of_extension
+                  Extension.Context.signature_item))
+        @ sg
       in
       match intf with None -> sg | Some f -> f ctxt sg
     in

--- a/test/error_embedding/run.t
+++ b/test/error_embedding/run.t
@@ -22,9 +22,11 @@ Anything else will embed an error extension node
   $ echo "let _ = [%export_string \"string\" \"other\"]" >> parsing_payload_extension.ml
   $ echo "let _ = [%export_string identifier]" >> parsing_payload_extension.ml
   $ ./extender.exe parsing_payload_extension.ml
+  [%%ocaml.error "constant expected"]
+  [%%ocaml.error "constant expected"]
   let _ = "string"
-  let _ = [%ocaml.error "constant expected"]
-  let _ = [%ocaml.error "constant expected"]
+  let _ = [%export_string "string" "other"]
+  let _ = [%export_string identifier]
 
   $ echo "type a = int [@@deriving a_string]" > parsing_payload_deriver.ml
   $ echo "type b = int [@@deriving a_string unexpected_args]" >> parsing_payload_deriver.ml

--- a/test/traverse/test.ml
+++ b/test/traverse/test.ml
@@ -38,6 +38,12 @@ class virtual ['ctx] map_with_context :
     method t : 'ctx -> t -> t
     method u : 'ctx -> u -> u
   end
+class virtual ['ctx, 'acc] fold_map_with_context :
+  object
+    method virtual int : 'ctx -> int -> 'acc -> int * 'acc
+    method t : 'ctx -> t -> 'acc -> t * 'acc
+    method u : 'ctx -> u -> 'acc -> u * 'acc
+  end
 class virtual ['res] lift :
   object
     method virtual constr : string -> 'res list -> 'res


### PR DESCRIPTION
Currently, when an error occurs during an AST traversal, it has to be embedded directly.

This is currently not a very big problem, since an error can happen only when rewriting an extension point, which is a very indicated place to embed the error directly.

However, there are few problems with this approach:
- First, only one error can be embedded, while several errors could happen: This happens [here](https://github.com/ocaml-ppx/ppxlib/blob/main/src/context_free.ml#L235), where only the first error is embeded, the rest are discarded.
- If we modify the ast traversal in a way that errors can happen in other nodes, where embedding even one error is not trivial, there is no way around. This happened in #352.

This PR implements another approach, where the AST traversal is a `fold_map`, where the fold is the list of errors.

The errors are then embedded by the driver at the beginning of the structure/signature.

Another advantages of this approach is that it opens the possibility for rewriters to output both a rewritten node and a list of "non fatal errors" that the driver will embed at the toplevel structure/signature, something currently impossible with context-free rewriters.

The code is ready to review, I still need to add a few tests, but I wanted to open the PR now to have feedback on the idea.