### PR TITLE
Esequence associativity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 unreleased
 -------------------
 
+- Make `esequence` right-associative. (#366, @ceastlund)
+
 - Deprecate unused attributes in `Deriving.Generator` (#368, @sim642)
 
 - Remove a pattern match on mutable state in a function argument. (#362, @ceastlund)

--- a/src/ast_builder.ml
+++ b/src/ast_builder.ml
@@ -116,10 +116,10 @@ module Default = struct
         pexp_fun ~loc Asttypes.Nolabel None p e)
 
   let esequence ~loc el =
-    match el with
+    match List.rev el with
     | [] -> eunit ~loc
     | hd :: tl ->
-        List.fold_left tl ~init:hd ~f:(fun acc e -> pexp_sequence ~loc acc e)
+        List.fold_left tl ~init:hd ~f:(fun acc e -> pexp_sequence ~loc e acc)
 
   let pconstruct cd arg =
     ppat_construct ~loc:cd.pcd_loc (Located.map_lident cd.pcd_name) arg

--- a/test/deriving/inline/example/ppx_deriving_example.ml
+++ b/test/deriving/inline/example/ppx_deriving_example.ml
@@ -7,7 +7,10 @@ include struct
 
   module Foo = struct end
 
-  let _ = [%foo]
+  let _ =
+    ();
+    ();
+    [%foo]
 end [@@ocaml.doc "@inline"]
 
 [@@@deriving.end]

--- a/test/deriving/inline/foo-deriver/ppx_foo_deriver.ml
+++ b/test/deriving/inline/foo-deriver/ppx_foo_deriver.ml
@@ -1,11 +1,12 @@
 open Ppxlib
+open Ast_builder.Default
 
 (*
    [[@@deriving foo]] expands to:
    {[
      module Foo = struct end
 
-     let _ = [%foo]
+     let _ = (); (); [%foo]
    ]}
 
    and then [[%foo]] expands to ["foo"].
@@ -55,7 +56,13 @@ let add_deriver () =
                           ppat_loc_stack = [];
                         };
                       pvb_expr =
-                        expr (Pexp_extension ({ loc; txt = "foo" }, PStr []));
+                        esequence ~loc
+                          [
+                            eunit ~loc;
+                            eunit ~loc;
+                            expr
+                              (Pexp_extension ({ loc; txt = "foo" }, PStr []));
+                          ];
                       pvb_attributes = [];
                       pvb_loc = loc;
                     };

--- a/test/deriving/inline/foo-deriver/ppx_foo_deriver.ml
+++ b/test/deriving/inline/foo-deriver/ppx_foo_deriver.ml
@@ -3,6 +3,8 @@ open Ppxlib
 (*
    [[@@deriving foo]] expands to:
    {[
+     module Foo = struct end
+
      let _ = [%foo]
    ]}
 


### PR DESCRIPTION
Addresses #363 about the associativity of `esequence`, and how this makes `deriving_inline` and `ocamlformat` clash.

While I'm at it, update comment in `ppx_foo_deriver.ml` to reflect the module definition it generates.