### PR TITLE
Deprecate unused attributes in `Deriving.Generator`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 unreleased
 -------------------
 
+- Deprecate unused attributes in `Deriving.Generator` (#368, @sim642)
+
 - Remove a pattern match on mutable state in a function argument. (#362, @ceastlund)
 
 - Add code-path manipulation attributes. (#352, @ceastlund)

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -141,7 +141,6 @@ module Generator = struct
         spec : ('c, 'a) Args.t;
         gen : ctxt:Expansion_context.Deriver.t -> 'b -> 'c;
         arg_names : String.Set.t;
-        attributes : Attribute.packed list;
         deps : deriver list;
       }
         -> ('a, 'b) t
@@ -149,9 +148,9 @@ module Generator = struct
   let deps (T t) = t.deps
 
   module V2 = struct
-    let make ?(attributes = []) ?(deps = []) spec gen =
+    let make ?attributes:(_ = []) ?(deps = []) spec gen =
       let arg_names = String.Set.of_list (Args.names spec) in
-      T { spec; gen; arg_names; attributes; deps }
+      T { spec; gen; arg_names; deps }
 
     let make_noarg ?attributes ?deps gen = make ?attributes ?deps Args.empty gen
   end
@@ -655,29 +654,6 @@ let wrap_sig ~loc ~hide sg =
   in
   if wrap then wrap_sig ~loc ~hide sg else sg
 
-(* +-----------------------------------------------------------------+
-   | Remove attributes used by syntax extensions                     |
-   +-----------------------------------------------------------------+ *)
-(*
-let remove generators =
-  let attributes =
-    List.concat_map generators ~f:(fun (_, actual_generators, _) ->
-      List.concat_map actual_generators ~f:(fun (Generator.T g) -> g.attributes))
-  in
-  object
-    inherit Ast_traverse.map
-
-    (* Don't recurse through attributes and extensions *)
-    method! attribute x = x
-    method! extension x = x
-
-    method! label_declaration ld =
-      Attribute.remove_seen Attribute.Context.label_declaration attributes ld
-
-    method! constructor_declaration cd =
-      Attribute.remove_seen Attribute.Context.constructor_declaration attributes cd
-  end
-*)
 (* +-----------------------------------------------------------------+
    | Main expansion                                                  |
    +-----------------------------------------------------------------+ *)

--- a/src/deriving.mli
+++ b/src/deriving.mli
@@ -46,31 +46,43 @@ module Generator : sig
   type ('output_ast, 'input_ast) t
 
   val make :
-    ?attributes:Attribute.packed list ->
+    ?attributes:Attribute.packed list (* deprecated, unused *) ->
     ?deps:deriver list ->
     ('f, 'output_ast) Args.t ->
     (loc:Location.t -> path:string -> 'input_ast -> 'f) ->
     ('output_ast, 'input_ast) t
+  (** [make args gen] creates a generator that can be passed to {!Deriving.add}
+      to generate an output AST from an input AST and generator arguments.
+
+      [deps] is a list of derivers that this generator depends on.
+
+      [attributes] is deprecated and unused. It is only kept for backward
+      compatibility. *)
 
   val make_noarg :
-    ?attributes:Attribute.packed list ->
+    ?attributes:Attribute.packed list (* deprecated, unused *) ->
     ?deps:deriver list ->
     (loc:Location.t -> path:string -> 'input_ast -> 'output_ast) ->
     ('output_ast, 'input_ast) t
+  (** Same as {!make}, but without arguments. *)
 
   module V2 : sig
     val make :
-      ?attributes:Attribute.packed list ->
+      ?attributes:Attribute.packed list (* deprecated, unused *) ->
       ?deps:deriver list ->
       ('f, 'output_ast) Args.t ->
       (ctxt:Expansion_context.Deriver.t -> 'input_ast -> 'f) ->
       ('output_ast, 'input_ast) t
+    (** Same as {!Generator.make}, but the generator has access to an expansion
+        context. *)
 
     val make_noarg :
-      ?attributes:Attribute.packed list ->
+      ?attributes:Attribute.packed list (* deprecated, unused *) ->
       ?deps:deriver list ->
       (ctxt:Expansion_context.Deriver.t -> 'input_ast -> 'output_ast) ->
       ('output_ast, 'input_ast) t
+    (** Same as {!Generator.make_noarg}, but the generator has access to an
+        expansion context. *)
   end
 
   val apply :


### PR DESCRIPTION
Closes #90.

Adds documentation to the `make` functions in order to have a place to deprecate the argument (similarly to `Driver.register_transformation` extensions).
Also removes the corresponding unused record field and the commented-out code, which used it.