### PR TITLE
Upgrade ocamlformat

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,6 @@
 
 #The commit upgrading to ocamlformat 0.20.0
 50c1f3736e58be5cf18ad02debf9653799625bfc
+
+#The commit upgrading to ocamlformat 0.24.1
+0970c3a7f91291bd92eb277331b5b6af20b608e9

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version=0.20.0
+version=0.24.1
 profile=conventional
 parse-docstrings=true

--- a/ast/ast.ml
+++ b/ast/ast.ml
@@ -221,7 +221,9 @@ and core_type_desc = Parsetree.core_type_desc =
             [Ppat_constraint]} node corresponding to a constraint on a
             let-binding:
 
-          {[ let x : 'a1 ... 'an. T = e ... ]}
+          {[
+            let x : 'a1 ... 'an. T = e ...
+          ]}
           - Under {{!class_field_kind.Cfk_virtual} [Cfk_virtual]} for methods
             (not values).
 

--- a/src/ast_pattern.mli
+++ b/src/ast_pattern.mli
@@ -13,11 +13,15 @@ open! Import
     To understand how to use it, let's consider the example of ppx_inline_test.
     We want to recognize patterns of the form:
 
-    {[ let%test "name" = expr ]}
+    {[
+      let%test "name" = expr
+    ]}
 
     Which is a syntactic sugar for:
 
-    {[ [%%test let "name" = expr] ]}
+    {[
+      [%%test let "name" = expr]
+    ]}
 
     If we wanted to write a function that recognizes the payload of [%%test]
     using normal pattern matching we would write:
@@ -62,7 +66,9 @@ open! Import
     Notice that the place-holders for [name] and [expr] have been replaced by
     [__]. The following pattern with have type:
 
-    {[ (payload, string -> expression -> 'a, 'a) Ast_pattern.t ]}
+    {[
+      (payload, string -> expression -> 'a, 'a) Ast_pattern.t
+    ]}
 
     which means that it matches values of type [payload] and captures a string
     and expression from it. The two captured elements comes from the use of
@@ -118,11 +124,15 @@ val __' : ('a, 'a Loc.t -> 'b, 'b) t
     Note: this should only be used for types that do not embed a location. For
     instance you can use it to capture a string constant:
 
-    {[ estring __' ]}
+    {[
+      estring __'
+    ]}
 
     but using it to capture an expression would not yield the expected result:
 
-    {[ pair (eint (int 42)) __' ]}
+    {[
+      pair (eint (int 42)) __'
+    ]}
 
     In the latter case you should use the [pexp_loc] field of the captured
     expression instead. *)

--- a/src/attribute.mli
+++ b/src/attribute.mli
@@ -108,7 +108,9 @@ val declare :
     "foo.default" declared in the previous example, on this code it will match
     the [@foo.default 0] attribute:
 
-    {[ type t = { x : int [@default 42] [@foo.default 0] } ]}
+    {[
+      type t = { x : int [@default 42] [@foo.default 0] }
+    ]}
 
     This is to allow the user to specify a [@default] attribute for all
     re-writers that use it but still put a specific one for one specific

--- a/src/driver.mli
+++ b/src/driver.mli
@@ -174,7 +174,9 @@ val register_code_transformation :
   [@@deprecated "[since 2015-11] use register_transformation instead"]
 (** Same as:
 
-    {[ register_transformation ~name ~impl ~intf () ]} *)
+    {[
+      register_transformation ~name ~impl ~intf ()
+    ]} *)
 
 val register_correction : loc:Location.t -> repl:string -> unit
 (** Rewriters might call this function to suggest a correction to the code

--- a/src/name.mli
+++ b/src/name.mli
@@ -27,7 +27,9 @@ val split_path : string -> string * string option
 val dot_suffixes : string -> string list
 (** [fold_dot_suffixes "foo.@bar.blah" ~init ~f] is
 
-    {[ [ "bar.blah"; "foo.bar.blah" ] ]} *)
+    {[
+      [ "bar.blah"; "foo.bar.blah" ]
+    ]} *)
 
 module Registrar : sig
   type 'context t


### PR DESCRIPTION
I'm upgrading ocamlformat which is good in general and also necessary for https://github.com/ocaml-ppx/ppxlib/pull/364. Luckily, it's just a few lines that are affected, but still, I'll wait for https://github.com/ocaml-ppx/ppxlib/pull/366 to be merged before emerging this.