### PR TITLE
[Fix I#377] Ensure fname isn't empty with input_name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 unreleased
 ------------------
 
+- Ensure get_default_path isn't empty when loc_start.pos_fname is empty (#380, @davesnx)
 
 0.28.0 (05/10/2022)
 -------------------

--- a/astlib/location.mli
+++ b/astlib/location.mli
@@ -10,6 +10,9 @@ type t = Ocaml_common.Location.t = {
 type 'a loc = 'a Ocaml_common.Location.loc = { txt : 'a; loc : t }
 (** A located type *)
 
+val input_name : string ref
+(** The name of the current input file. From Ocaml.common.Location.input_file *)
+
 module Error : sig
   type location
 

--- a/src/file_path.ml
+++ b/src/file_path.ml
@@ -6,7 +6,9 @@ let chop_prefix ~prefix x =
   else None
 
 let get_default_path (loc : Location.t) =
-  let fname = loc.loc_start.pos_fname in
+  let fname = match loc.loc_start.pos_fname with
+    | "" -> !Astlib.Location.input_name
+    | fname -> fname in
   match chop_prefix ~prefix:"./" fname with
   | Some fname -> fname
   | None -> fname

--- a/src/file_path.ml
+++ b/src/file_path.ml
@@ -6,9 +6,11 @@ let chop_prefix ~prefix x =
   else None
 
 let get_default_path (loc : Location.t) =
-  let fname = match loc.loc_start.pos_fname with
+  let fname =
+    match loc.loc_start.pos_fname with
     | "" -> !Astlib.Location.input_name
-    | fname -> fname in
+    | fname -> fname
+  in
   match chop_prefix ~prefix:"./" fname with
   | Some fname -> fname
   | None -> fname


### PR DESCRIPTION
Hi, it fixes https://github.com/ocaml-ppx/ppxlib/issues/377.

Installed cinaps and ocamlfind, but couldn't get the tests passing on main.
I'm unable to be sure about this diff, as well it's my first time contributing on a JS library, so all Import isn't clear if Astlib should expose input_name or If I should arrange modules differently. 

Opening this PR to solve both issues.

Side note: Now I'm touching Location maybe I should tackle this issue as well? https://github.com/ocaml-ppx/ppxlib/issues/179

