### PR TITLE
Add "ns" and "res" as reserved namespaces

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 unreleased
 ------------------
 
+- Add "ns" and "res" as reserved namespaces(#388, @davesnx)
+
 0.29.1 (14/02/2023)
 ------------------
 

--- a/src/name.ml
+++ b/src/name.ml
@@ -119,6 +119,8 @@ module Reserved_namespaces = struct
   let () = reserve "merlin"
   let () = reserve "reason"
   let () = reserve "refmt"
+  let () = reserve "ns"
+  let () = reserve "res"
   let () = reserve "metaocaml"
   let () = reserve "ocamlformat"
 

--- a/src/name.ml
+++ b/src/name.ml
@@ -118,9 +118,9 @@ module Reserved_namespaces = struct
   let reserve ns = Hashtbl.add_exn tbl ~key:ns ~data:()
   let () = reserve "merlin"
   let () = reserve "reason"
-  let () = reserve "refmt"
-  let () = reserve "ns"
-  let () = reserve "res"
+  let () = reserve "refmt" (* reason *)
+  let () = reserve "ns" (* rescript *)
+  let () = reserve "res" (* rescript *)
   let () = reserve "metaocaml"
   let () = reserve "ocamlformat"
 


### PR DESCRIPTION
Hi,

This PR adds 2 reserved namespaces "ns" and "res" which enables the possibility to use ppxlib with ReScript.

Further info: https://github.com/zth/rescript-relay/pull/372 and https://github.com/davesnx/styled-ppx/issues/308

### A little bit of context

Using ppxlib to write a ppx for ReScript is quite common (not so much for the parsetree versioning, but rather the ppxlib APIs) but I believe it could conflict with the idea of ppxlib to just be for OCaml/Reason development.

I might agree, but the change seems rather small and harmless. ppxlib can always remove the namespace in a new release and make ReScript team/community fork ppxlib or solve it their own way.

I would rather have ppxlib with this change and enjoy all new work than rather keep a fork with these 2 lines. 

### Commit references from zth/ppxlib
https://github.com/zth/ppxlib/commit/32f83395fb89693a873541298b6367449f23bc4a and https://github.com/zth/ppxlib/commit/b5b48e0bb2bc0a0fcf43ab6d99c0f98df0dda0e3