### PR TITLE
Add `Attribute.declare_with_attr_loc`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 unreleased
 ------------------
 
+- Add `Attribute.declare_with_attr_loc` (#396, @dvulakh)
+
 0.29.1 (14/02/2023)
 ------------------
 

--- a/src/attribute.mli
+++ b/src/attribute.mli
@@ -127,6 +127,14 @@ val declare_with_name_loc :
 (** Same as [declare] but the callback receives the location of the name of the
     attribute. *)
 
+val declare_with_attr_loc :
+  string ->
+  'a Context.t ->
+  (payload, 'b, 'c) Ast_pattern.t ->
+  (attr_loc:Location.t -> 'b) ->
+  ('a, 'c) t
+(** Same as [declare] but the callback receives the location of the attribute. *)
+
 val name : _ t -> string
 val context : ('a, _) t -> 'a Context.t
 


### PR DESCRIPTION
Adds a similar function to `Attribute.declare_with_name_loc`, but using the location of the entire attribute.