### PR TITLE
Make quoter `let` binding non-recursive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ unreleased
 
 - Add "ns" and "res" as reserved namespaces(#388, @davesnx)
 
+- Make quoter `let` binding non-recursive (#401, @sim642)
+
 0.29.1 (14/02/2023)
 ------------------
 

--- a/src/quoter.ml
+++ b/src/quoter.ml
@@ -12,7 +12,7 @@ let sanitize t e =
   | [] -> e
   | bindings ->
       let (module Ast) = Ast_builder.make e.pexp_loc in
-      Ast.pexp_let Recursive bindings e
+      Ast.pexp_let Nonrecursive bindings e
 
 let quote t (e : expression) =
   let loc = e.pexp_loc in

--- a/test/quoter/test.ml
+++ b/test/quoter/test.ml
@@ -143,7 +143,7 @@ let quoted =
 [%%expect{|
 val quoted : expression =
   {Ppxlib__.Import.pexp_desc =
-    Ppxlib__.Import.Pexp_let (Ppxlib__.Import.Recursive,
+    Ppxlib__.Import.Pexp_let (Ppxlib__.Import.Nonrecursive,
      [{Ppxlib__.Import.pvb_pat =
         {Ppxlib__.Import.ppat_desc =
           Ppxlib__.Import.Ppat_var
@@ -338,5 +338,5 @@ val quoted : expression =
 Pprintast.string_of_expression quoted;;
 [%%expect{|
 - : string =
-"let rec __2 () = foo ()\nand __1 = bar\nand __0 = foo in [__0; __1; __2 ()]"
+"let __2 () = foo ()\nand __1 = bar\nand __0 = foo in [__0; __1; __2 ()]"
 |}]


### PR DESCRIPTION
As discussed in https://github.com/ocaml-ppx/ppx_deriving/pull/263#discussion_r924289189 and https://github.com/ocaml-ppx/ppx_deriving/pull/263#pullrequestreview-1352543609, this makes the `let` binding produced by quoter to be non-recursive. This is how it has been in ppx_deriving for eternity and avoids unused `rec` flag warnings.