### PR TITLE
Ast_pattern: augment API with ebool, pbool helper, and a new map.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 unreleased
 ------------------
 
+- Ast_pattern now has ebool, pbool helper, and a new map.(#402, @burnleydev1)
+
 - multiple errors are now reported in `metaquot`. (#397, @burnleydev1)
 
 - Add `Attribute.declare_with_attr_loc` (#396, @dvulakh)

--- a/src/ast_pattern.ml
+++ b/src/ast_pattern.ml
@@ -65,6 +65,7 @@ let int32 v = cst ~to_string:Int32.to_string v
 let int64 v = cst ~to_string:Int64.to_string v
 let nativeint v = cst ~to_string:Nativeint.to_string v
 let bool v = cst ~to_string:Bool.to_string v
+let ebool (T func) = T (fun ctx loc x k -> func ctx loc (bool_of_string x) k)
 
 let false_ =
   T
@@ -158,7 +159,6 @@ let alt (T f1) (T f2) =
 
 let ( ||| ) = alt
 let map (T func) ~f = T (fun ctx loc x k -> func ctx loc x (f k))
-let map_value (T func) ~f = T (fun ctx loc x k -> func ctx loc (f x) k)
 let map' (T func) ~f = T (fun ctx loc x k -> func ctx loc x (f loc k))
 let map_result (T func) ~f = T (fun ctx loc x k -> f (func ctx loc x k))
 let ( >>| ) t f = map t ~f
@@ -175,6 +175,9 @@ let map1' (T func) ~f =
 
 let map2' (T func) ~f =
   T (fun ctx loc x k -> func ctx loc x (fun a b -> k (f loc a b)))
+
+let map_value (T func) ~f = T (fun ctx loc x k -> func ctx loc (f x) k)
+let map_value' (T func) ~f = T (fun ctx loc x k -> func ctx loc (f loc x) k)
 
 let alt_option some none =
   alt (map1 some ~f:(fun x -> Some x)) (map0 none ~f:None)

--- a/src/ast_pattern.ml
+++ b/src/ast_pattern.ml
@@ -158,6 +158,7 @@ let alt (T f1) (T f2) =
 
 let ( ||| ) = alt
 let map (T func) ~f = T (fun ctx loc x k -> func ctx loc x (f k))
+let map_value (T func) ~f = T (fun ctx loc x k -> func ctx loc (f x) k)
 let map' (T func) ~f = T (fun ctx loc x k -> func ctx loc x (f loc k))
 let map_result (T func) ~f = T (fun ctx loc x k -> f (func ctx loc x k))
 let ( >>| ) t f = map t ~f

--- a/src/ast_pattern.ml
+++ b/src/ast_pattern.ml
@@ -232,9 +232,8 @@ let pint64 t = ppat_constant (const_int64 t)
 let pnativeint t = ppat_constant (const_nativeint t)
 let single_expr_payload t = pstr (pstr_eval t nil ^:: nil)
 let no_label t = cst Asttypes.Nolabel ~to_string:(fun _ -> "Nolabel") ** t
-
-let ebool t = pexp_construct (lident (bool' t) )none
-let pbool t = ppat_construct (lident (bool' t) )none
+let ebool t = pexp_construct (lident (bool' t)) none
+let pbool t = ppat_construct (lident (bool' t)) none
 
 let extension (T f1) (T f2) =
   T

--- a/src/ast_pattern.ml
+++ b/src/ast_pattern.ml
@@ -65,7 +65,14 @@ let int32 v = cst ~to_string:Int32.to_string v
 let int64 v = cst ~to_string:Int64.to_string v
 let nativeint v = cst ~to_string:Nativeint.to_string v
 let bool v = cst ~to_string:Bool.to_string v
-let ebool (T func) = T (fun ctx loc x k -> func ctx loc (bool_of_string x) k)
+
+let bool' (T func) =
+  T
+    (fun ctx loc x k ->
+      match x with
+      | "true" -> func ctx loc true k
+      | "false" -> func ctx loc false k
+      | _ -> fail loc "Bool")
 
 let false_ =
   T

--- a/src/ast_pattern.ml
+++ b/src/ast_pattern.ml
@@ -234,6 +234,7 @@ let single_expr_payload t = pstr (pstr_eval t nil ^:: nil)
 let no_label t = cst Asttypes.Nolabel ~to_string:(fun _ -> "Nolabel") ** t
 
 let ebool t = pexp_construct (lident (bool' t) )none
+let pbool t = ppat_construct (lident (bool' t) )none
 
 let extension (T f1) (T f2) =
   T

--- a/src/ast_pattern.ml
+++ b/src/ast_pattern.ml
@@ -233,6 +233,8 @@ let pnativeint t = ppat_constant (const_nativeint t)
 let single_expr_payload t = pstr (pstr_eval t nil ^:: nil)
 let no_label t = cst Asttypes.Nolabel ~to_string:(fun _ -> "Nolabel") ** t
 
+let ebool t = pexp_construct (lident (bool' t) )none
+
 let extension (T f1) (T f2) =
   T
     (fun ctx loc ((name : _ Loc.t), payload) k ->

--- a/src/ast_pattern.mli
+++ b/src/ast_pattern.mli
@@ -131,7 +131,9 @@ val int32 : int32 -> (int32, 'a, 'a) t
 val int64 : int64 -> (int64, 'a, 'a) t
 val nativeint : nativeint -> (nativeint, 'a, 'a) t
 val bool : bool -> (bool, 'a, 'a) t
-val ebool : (bool, 'a, 'b) t -> (label, 'a, 'b) t
+val bool' : (bool, 'a, 'b) t -> (label, 'a, 'b) t
+(* val ebool : (bool, 'a, 'b) t -> (expression, 'c, 'd) t
+   val pbool : (bool, 'a, 'b) t -> (pattern, 'c, 'd) t *)
 
 val cst :
   to_string:('a -> string) -> ?equal:('a -> 'a -> bool) -> 'a -> ('a, 'b, 'b) t

--- a/src/ast_pattern.mli
+++ b/src/ast_pattern.mli
@@ -96,7 +96,7 @@ val ( ||| ) : ('a, 'b, 'c) t -> ('a, 'b, 'c) t -> ('a, 'b, 'c) t
 (** Same as [alt] *)
 
 val map : ('a, 'b, 'c) t -> f:('d -> 'b) -> ('a, 'd, 'c) t
-val map_value : ('a, 'b, 'c)t -> f:('d -> 'a) -> ('d, 'b, 'c)t
+val map_value : ('a, 'b, 'c) t -> f:('d -> 'a) -> ('d, 'b, 'c) t
 val map' : ('a, 'b, 'c) t -> f:(Location.t -> 'd -> 'b) -> ('a, 'd, 'c) t
 val map_result : ('a, 'b, 'c) t -> f:('c -> 'd) -> ('a, 'b, 'd) t
 

--- a/src/ast_pattern.mli
+++ b/src/ast_pattern.mli
@@ -131,7 +131,6 @@ val int32 : int32 -> (int32, 'a, 'a) t
 val int64 : int64 -> (int64, 'a, 'a) t
 val nativeint : nativeint -> (nativeint, 'a, 'a) t
 val bool : bool -> (bool, 'a, 'a) t
-val bool' : (bool, 'a, 'b) t -> (label, 'a, 'b) t
 val ebool : (bool, 'a, 'b) t -> (expression, 'a, 'b) t
 val pbool : (bool, 'a, 'b) t -> (pattern, 'a, 'b) t
 

--- a/src/ast_pattern.mli
+++ b/src/ast_pattern.mli
@@ -96,6 +96,7 @@ val ( ||| ) : ('a, 'b, 'c) t -> ('a, 'b, 'c) t -> ('a, 'b, 'c) t
 (** Same as [alt] *)
 
 val map : ('a, 'b, 'c) t -> f:('d -> 'b) -> ('a, 'd, 'c) t
+val map_value : ('a, 'b, 'c)t -> f:('d -> 'a) -> ('d, 'b, 'c)t
 val map' : ('a, 'b, 'c) t -> f:(Location.t -> 'd -> 'b) -> ('a, 'd, 'c) t
 val map_result : ('a, 'b, 'c) t -> f:('c -> 'd) -> ('a, 'b, 'd) t
 

--- a/src/ast_pattern.mli
+++ b/src/ast_pattern.mli
@@ -96,7 +96,6 @@ val ( ||| ) : ('a, 'b, 'c) t -> ('a, 'b, 'c) t -> ('a, 'b, 'c) t
 (** Same as [alt] *)
 
 val map : ('a, 'b, 'c) t -> f:('d -> 'b) -> ('a, 'd, 'c) t
-val map_value : ('a, 'b, 'c) t -> f:('d -> 'a) -> ('d, 'b, 'c) t
 val map' : ('a, 'b, 'c) t -> f:(Location.t -> 'd -> 'b) -> ('a, 'd, 'c) t
 val map_result : ('a, 'b, 'c) t -> f:('c -> 'd) -> ('a, 'b, 'd) t
 
@@ -119,6 +118,8 @@ val map2' :
   f:(Location.t -> 'v1 -> 'v2 -> 'v) ->
   ('a, 'v -> 'b, 'c) t
 
+val map_value : ('a, 'b, 'c) t -> f:('d -> 'a) -> ('d, 'b, 'c) t
+val map_value' : ('a, 'b, 'c) t -> f:(location -> 'd -> 'a) -> ('d, 'b, 'c) t
 val nil : (_ list, 'a, 'a) t
 val ( ^:: ) : ('a, 'b, 'c) t -> ('a list, 'c, 'd) t -> ('a list, 'b, 'd) t
 val many : ('a, 'b -> 'c, 'c) t -> ('a list, 'b list -> 'c, 'c) t
@@ -130,6 +131,7 @@ val int32 : int32 -> (int32, 'a, 'a) t
 val int64 : int64 -> (int64, 'a, 'a) t
 val nativeint : nativeint -> (nativeint, 'a, 'a) t
 val bool : bool -> (bool, 'a, 'a) t
+val ebool : (bool, 'a, 'b) t -> (label, 'a, 'b) t
 
 val cst :
   to_string:('a -> string) -> ?equal:('a -> 'a -> bool) -> 'a -> ('a, 'b, 'b) t

--- a/src/ast_pattern.mli
+++ b/src/ast_pattern.mli
@@ -133,7 +133,7 @@ val nativeint : nativeint -> (nativeint, 'a, 'a) t
 val bool : bool -> (bool, 'a, 'a) t
 val bool' : (bool, 'a, 'b) t -> (label, 'a, 'b) t
 val ebool : (bool, 'a, 'b) t -> (expression, 'a, 'b) t
-(*val pbool : (bool, 'a, 'b) t -> (pattern, 'c, 'd) t *)
+val pbool : (bool, 'a, 'b) t -> (pattern, 'a, 'b) t
 
 val cst :
   to_string:('a -> string) -> ?equal:('a -> 'a -> bool) -> 'a -> ('a, 'b, 'b) t

--- a/src/ast_pattern.mli
+++ b/src/ast_pattern.mli
@@ -132,8 +132,8 @@ val int64 : int64 -> (int64, 'a, 'a) t
 val nativeint : nativeint -> (nativeint, 'a, 'a) t
 val bool : bool -> (bool, 'a, 'a) t
 val bool' : (bool, 'a, 'b) t -> (label, 'a, 'b) t
-(* val ebool : (bool, 'a, 'b) t -> (expression, 'c, 'd) t
-   val pbool : (bool, 'a, 'b) t -> (pattern, 'c, 'd) t *)
+val ebool : (bool, 'a, 'b) t -> (expression, 'a, 'b) t
+(*val pbool : (bool, 'a, 'b) t -> (pattern, 'c, 'd) t *)
 
 val cst :
   to_string:('a -> string) -> ?equal:('a -> 'a -> bool) -> 'a -> ('a, 'b, 'b) t


### PR DESCRIPTION
fixes #399 

- [x]  Write a function map_value
- [x] Use the `map_value` function to turn a `(bool, 'c, 'd) Ast_pattern.t` into a `(string, c, d) Ast_pattern.t`
- [x] Combine `pexp_construct`, `lident` and the value previously created to define `ebool` and `pbool`