### PR TITLE
Bias the mapping from magic to version towards the current version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,10 @@ unreleased
 - Fix failure of 'lift_map_with_context' in traverse by compile-time
   evaluation of 'fst' and 'snd' (#390, @smuenzel)
 
+- Bias the mapping from magic to version towards the current version,
+  as it is usually the common case and it helps when magic numbers are
+  ambiguous (such as on development versions) (#409, @shym)
+
 0.29.1 (14/02/2023)
 ------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@ unreleased
 - Fix failure of 'lift_map_with_context' in traverse by compile-time
   evaluation of 'fst' and 'snd' (#390, @smuenzel)
 
-- Bias the mapping from magic to version towards the current version,
+- Driver: Bias the mapping from magic to version towards the current version,
   as it is usually the common case and it helps when magic numbers are
   ambiguous (such as on development versions) (#409, @shym)
 

--- a/ast/versions.ml
+++ b/ast/versions.ml
@@ -577,5 +577,10 @@ module Find_version = struct
           else
             loop tail
     in
-    loop all_versions
+    (* First check whether it could be the current version, probably
+       the most common use case.
+       This bias towards the current version also provides a way to
+       choose wisely between, say, `trunk` and the latest stable
+       release, for which the magic numbers are not distinguished *)
+    loop @@ ((module OCaml_current : OCaml_version) :: all_versions)
 end


### PR DESCRIPTION
When mapping from magic numbers to versions, first check whether it is the current version, which is probably the most common case It has the added benefit that, when the mapping is ambiguous (mostly between the latest stable release and the development version), this strategy makes the good choice for the test suite