### PR TITLE
Add a CI workflow to build `trunk-support` on `trunk`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: Build on `trunk`
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # Every weekday, at 5:43 UTC
+    - cron: '43 5 * * 1-5'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Pick up a robust cache prefix
+        id: setup
+        run: |
+          # Ensure that cache is flushed when trunk is updated
+          cache_prefix="$(git ls-remote https://github.com/ocaml/ocaml.git refs/heads/trunk | cut -f 1)"
+          echo "cache_prefix=$cache_prefix" >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
+
+      - name: Install OCaml compiler
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 'ocaml-variants.5.1.0+trunk'
+          dune-cache: true
+          cache-prefix: ${{ steps.setup.outputs.cache_prefix }}
+
+      - name: Install ppxlib dependencies
+        run: |
+          opam install ./ppxlib.opam --deps-only
+
+      - name: Show configuration
+        run: |
+          opam exec -- ocamlc -config
+          opam config list
+          opam exec -- dune printenv
+          opam list
+
+      - name: Build the ppxlib
+        run: opam exec -- dune build -p ppxlib

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Non-continuous `trunk`-support for Ppxlib
 
+[![Build on `trunk`](https://github.com/ocaml-ppx/ppxlib/actions/workflows/build.yml/badge.svg?branch=trunk-support)](https://github.com/ocaml-ppx/ppxlib/actions/workflows/build.yml)
+
 On this branch, we provide a Ppxlib version, which can be compiled with
 OCaml's `trunk` branch. Whenever you want to compile a project that
 (transitively) depends on PPXs with `trunk`, please pin Ppxlib to


### PR DESCRIPTION
This PR adds a CI workflow to build `trunk-support` on the latest `trunk` once a day and on updates on that branch. It also adds a badge to the README (hopefully I got those URLs right :thinking:), which might help maintain the branch; and  help users check whether possible issues were detected already.