### PR TITLE
Bump the 501 AST magic numbers

### DIFF
--- a/astlib/ast_501.ml
+++ b/astlib/ast_501.ml
@@ -1084,5 +1084,6 @@ module Parsetree = struct
 end
 
 module Config = struct
-  include Ast_500.Config
+  let ast_impl_magic_number = "Caml1999M033"
+  let ast_intf_magic_number = "Caml1999N033"
 end


### PR DESCRIPTION
The compiler has already tagged 5.1 and, with that, has bumped the AST magic numbers. So we need to bump them as well. Currently 5.1 and `trunk` have the same parsetree, so this should make this branch support both of them.

In a different PR, I'll create the 5.2 AST module and migration modules, so that we can keep on updating this branch to `trunk` parsetree modifications. Thanks to @shym's PR biasing the `ppxlib` marshalled AST reader into the current OCaml version, we can support both 5.1 and `trunk` here on the same branch.