### PR TITLE
Fix trunk compatibility on 4.04 and 4.05

### DIFF
--- a/astlib/migrate_500_501.ml
+++ b/astlib/migrate_500_501.ml
@@ -1,3 +1,4 @@
+open Stdlib0
 module From = Ast_500
 module To = Ast_501
 

--- a/astlib/migrate_501_500.ml
+++ b/astlib/migrate_501_500.ml
@@ -1,3 +1,4 @@
+open Stdlib0
 module From = Ast_501
 module To = Ast_500
 


### PR DESCRIPTION
Those versions do not have an `Option.map`.

It's important to have `trunk-support` support all versions, since we are likely to merge (part of) it when `5.1` is released!