### PR TITLE
Pr420 with clean history

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ unreleased
   as it is usually the common case and it helps when magic numbers are
   ambiguous (such as on development versions) (#409, @shym)
 
+- Remove unnecessary test dependencies towards base and stdio (#421, @kit-ty-kate)
+
 0.29.1 (14/02/2023)
 ------------------
 

--- a/astlib/ast_501.ml
+++ b/astlib/ast_501.ml
@@ -1031,17 +1031,18 @@ module Parsetree = struct
     | Pstr_attribute of attribute  (** [[\@\@\@id]] *)
     | Pstr_extension of extension * attributes  (** [[%%id]] *)
 
-  and poly_constraint (*IF_CURRENT = Parsetree.poly_constraint *) =
-    {
+  and value_constraint (*IF_CURRENT = Parsetree.value_constraint *) =
+    | Pvc_constraint of {
       locally_abstract_univars:string loc list;
       typ:core_type;
-    }
+      }
+    | Pvc_coercion of {ground:core_type option; coercion:core_type }
 
   and value_binding (*IF_CURRENT = Parsetree.value_binding *) =
     {
       pvb_pat: pattern;
       pvb_expr: expression;
-      pvb_constraint: poly_constraint option;
+      pvb_constraint: value_constraint option;
       pvb_attributes: attributes;
       pvb_loc: Location.t;
     }

--- a/astlib/ast_502.ml
+++ b/astlib/ast_502.ml
@@ -1031,17 +1031,18 @@ module Parsetree = struct
     | Pstr_attribute of attribute  (** [[\@\@\@id]] *)
     | Pstr_extension of extension * attributes  (** [[%%id]] *)
 
-  and poly_constraint (*IF_CURRENT = Parsetree.poly_constraint *) =
-    {
+  and value_constraint (*IF_CURRENT = Parsetree.value_constraint *) =
+    | Pvc_constraint of {
       locally_abstract_univars:string loc list;
       typ:core_type;
-    }
+      }
+    | Pvc_coercion of {ground:core_type option; coercion:core_type }
 
   and value_binding (*IF_CURRENT = Parsetree.value_binding *) =
     {
       pvb_pat: pattern;
       pvb_expr: expression;
-      pvb_constraint: poly_constraint option;
+      pvb_constraint: value_constraint option;
       pvb_attributes: attributes;
       pvb_loc: Location.t;
     }

--- a/astlib/migrate_501_502.ml
+++ b/astlib/migrate_501_502.ml
@@ -229,7 +229,7 @@ and copy_value_binding :
     Ast_502.Parsetree.pvb_pat = copy_pattern pvb_pat;
     Ast_502.Parsetree.pvb_expr = copy_expression pvb_expr;
     Ast_502.Parsetree.pvb_constraint =
-      Option.map copy_poly_constraint pvb_constraint;
+      Option.map copy_value_constraint pvb_constraint;
     Ast_502.Parsetree.pvb_attributes = copy_attributes pvb_attributes;
     Ast_502.Parsetree.pvb_loc = copy_location pvb_loc;
   }
@@ -299,14 +299,22 @@ and copy_pattern_desc :
   | Ast_501.Parsetree.Ppat_open (x0, x1) ->
       Ast_502.Parsetree.Ppat_open (copy_loc copy_Longident_t x0, copy_pattern x1)
 
-and copy_poly_constraint :
-    Ast_501.Parsetree.poly_constraint -> Ast_502.Parsetree.poly_constraint =
- fun { Ast_501.Parsetree.locally_abstract_univars; Ast_501.Parsetree.typ } ->
-  {
-    Ast_502.Parsetree.locally_abstract_univars =
-      List.map (copy_loc (fun x -> x)) locally_abstract_univars;
-    Ast_502.Parsetree.typ = copy_core_type typ;
-  }
+and copy_value_constraint :
+    Ast_501.Parsetree.value_constraint -> Ast_502.Parsetree.value_constraint =
+  function
+  | Ast_501.Parsetree.Pvc_constraint { locally_abstract_univars; typ } ->
+      Ast_502.Parsetree.Pvc_constraint
+        {
+          locally_abstract_univars =
+            List.map (copy_loc (fun x -> x)) locally_abstract_univars;
+          typ = copy_core_type typ;
+        }
+  | Ast_501.Parsetree.Pvc_coercion { ground; coercion } ->
+      Ast_502.Parsetree.Pvc_coercion
+        {
+          ground = Option.map copy_core_type ground;
+          coercion = copy_core_type coercion;
+        }
 
 and copy_core_type : Ast_501.Parsetree.core_type -> Ast_502.Parsetree.core_type
     =

--- a/astlib/migrate_502_501.ml
+++ b/astlib/migrate_502_501.ml
@@ -229,7 +229,7 @@ and copy_value_binding :
     Ast_501.Parsetree.pvb_pat = copy_pattern pvb_pat;
     Ast_501.Parsetree.pvb_expr = copy_expression pvb_expr;
     Ast_501.Parsetree.pvb_constraint =
-      Option.map copy_poly_constraint pvb_constraint;
+      Option.map copy_value_constraint pvb_constraint;
     Ast_501.Parsetree.pvb_attributes = copy_attributes pvb_attributes;
     Ast_501.Parsetree.pvb_loc = copy_location pvb_loc;
   }
@@ -299,14 +299,22 @@ and copy_pattern_desc :
   | Ast_502.Parsetree.Ppat_open (x0, x1) ->
       Ast_501.Parsetree.Ppat_open (copy_loc copy_Longident_t x0, copy_pattern x1)
 
-and copy_poly_constraint :
-    Ast_502.Parsetree.poly_constraint -> Ast_501.Parsetree.poly_constraint =
- fun { Ast_502.Parsetree.locally_abstract_univars; Ast_502.Parsetree.typ } ->
-  {
-    Ast_501.Parsetree.locally_abstract_univars =
-      List.map (copy_loc (fun x -> x)) locally_abstract_univars;
-    Ast_501.Parsetree.typ = copy_core_type typ;
-  }
+and copy_value_constraint :
+    Ast_502.Parsetree.value_constraint -> Ast_501.Parsetree.value_constraint =
+  function
+  | Ast_502.Parsetree.Pvc_constraint { locally_abstract_univars; typ } ->
+      Ast_501.Parsetree.Pvc_constraint
+        {
+          locally_abstract_univars =
+            List.map (copy_loc (fun x -> x)) locally_abstract_univars;
+          typ = copy_core_type typ;
+        }
+  | Ast_502.Parsetree.Pvc_coercion { ground; coercion } ->
+      Ast_501.Parsetree.Pvc_coercion
+        {
+          ground = Option.map copy_core_type ground;
+          coercion = copy_core_type coercion;
+        }
 
 and copy_core_type : Ast_502.Parsetree.core_type -> Ast_501.Parsetree.core_type
     =

--- a/dune-project
+++ b/dune-project
@@ -15,7 +15,7 @@
 (package
  (name ppxlib)
  (depends
-  (ocaml (>= 4.04.1))
+  (ocaml (and (>= 4.04.1) (<> 5.1.0~alpha1)))
   (ocaml-compiler-libs (>= v0.11.0))
   (ppx_derivers (>= 1.0))
   (sexplib0 (>= v0.12))

--- a/dune-project
+++ b/dune-project
@@ -23,9 +23,7 @@
   stdlib-shims
   (ocamlfind :with-test)
   (re (and :with-test (>= 1.9.0)))
-  (cinaps (and :with-test (>= v0.12.1)))
-  (base :with-test)
-  (stdio :with-test))
+  (cinaps (and :with-test (>= v0.12.1))))
  (conflicts
   (ocaml-migrate-parsetree (< 2.0.0))
   base-effects)

--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -21,7 +21,7 @@ doc: "https://ocaml-ppx.github.io/ppxlib/"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & != "5.1.0~alpha1"}
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ppx_derivers" {>= "1.0"}
   "sexplib0" {>= "v0.12"}

--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -30,8 +30,6 @@ depends: [
   "ocamlfind" {with-test}
   "re" {with-test & >= "1.9.0"}
   "cinaps" {with-test & >= "v0.12.1"}
-  "base" {with-test}
-  "stdio" {with-test}
   "odoc" {with-doc}
 ]
 conflicts: [

--- a/src/location_check.ml
+++ b/src/location_check.ml
@@ -161,7 +161,7 @@ let should_ignore loc attrs =
 
 let rec extract_constraint e =
   match e.pexp_desc with
-  | Pexp_constraint (e, ct) | Pexp_coerce (e, None, ct) -> Some (e, ct)
+  | Pexp_constraint (e, ct) | Pexp_coerce (e, _, ct) -> Some (e, ct)
   | Pexp_newtype (name, exp) ->
       Option.map (extract_constraint exp) ~f:(fun (exp, ct) ->
           ( {

--- a/test/501_migrations/compare_on.ml
+++ b/test/501_migrations/compare_on.ml
@@ -1,0 +1,30 @@
+let run () =
+  let example_fn, ppx =
+    let args = Sys.argv in
+    if not (Array.length args = 3) then failwith "expected exactly two args"
+    else (Array.get args 1, Array.get args 2)
+  in
+  let direct = "without_migrations" in
+  let migrations = "with_migrations" in
+  let direct_ec =
+    Sys.command ("ocamlc -dparsetree " ^ example_fn ^ " 2> " ^ direct)
+  in
+  if direct_ec > 0 then (
+    print_endline "compile error even without migrations";
+    let _ = Sys.command ("cat " ^ direct) in
+    ())
+  else
+    let migrations_ec =
+      Sys.command
+        ("ocamlc -dparsetree -ppx '" ^ ppx ^ " -as-ppx' " ^ example_fn ^ " 2> "
+       ^ migrations)
+    in
+    if migrations_ec > 0 then (
+      print_endline "compile error after migrations";
+      let _ = Sys.command ("cat " ^ migrations) in
+      ())
+    else
+      let _ = Sys.command ("diff -U 0 " ^ direct ^ " " ^ migrations) in
+      ()
+
+let () = run ()

--- a/test/501_migrations/dune
+++ b/test/501_migrations/dune
@@ -1,0 +1,36 @@
+(executable
+ (name identity_driver)
+ (modules identity_driver)
+ (libraries ppxlib))
+
+(executable
+ (name reverse_migrations)
+ (modules reverse_migrations)
+ (libraries ppxlib))
+
+(executable
+ (name compare_on)
+ (libraries unix)
+ (modules compare_on))
+
+(cram
+ (enabled_if
+  (and
+   (>= %{ocaml_version} "5.1.0~alpha2")
+   (< %{ocaml_version} "5.2.0")))
+ (applies_to normal_migrations)
+ (deps identity_driver.exe compare_on.exe))
+
+(cram
+ (enabled_if
+  (= %{ocaml_version} "5.0.0"))
+ (applies_to reverse_migrations)
+ (deps reverse_migrations.exe compare_on.exe))
+
+(cram
+ (enabled_if
+  (and
+   (>= %{ocaml_version} "5.0.0")
+   (< %{ocaml_version} "5.2.0")))
+ (applies_to one_migration)
+ (deps identity_driver.exe compare_on.exe))

--- a/test/501_migrations/identity_driver.ml
+++ b/test/501_migrations/identity_driver.ml
@@ -1,0 +1,1 @@
+let () = Ppxlib.Driver.standalone ()

--- a/test/501_migrations/normal_migrations.t
+++ b/test/501_migrations/normal_migrations.t
@@ -1,0 +1,131 @@
+The 501 parsetree contains a parsing modificacion.
+[compare_on.exe <file>] checks if there's a diff between the
+AST's resulting from
+1. parsing <file> on 5.1.0 directly
+2. parsing <file> on 5.1.0, migrating down to 5.0.0 and migrating back to 5.1.0
+We only expect a diff in one special case.
+
+  $ echo "let x : int = 5" > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+
+  $ echo "let (x) : int = 5" > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+
+  $ echo "let _ : int = 5" > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+
+  $ echo "let f : type a b c. a -> b -> c = fun x y -> assert false" > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+
+  $ echo "let f = (fun (type a) (type b) (type c) -> (fun x y -> assert false : a -> b -> c))" > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+
+  $ echo "let _ = (fun (type a) (type b) (type c) -> (fun x y -> assert false : a -> b -> c))" > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+
+  $ echo "let f : type a . a -> a = fun x -> x" > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+
+  $ echo "let (x, y) : (int * int) = assert false" > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+
+  $ echo "let f : type a . a = assert false" > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+
+  $ echo 'let x : [`A] :> [`A | `B] = `A' > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+
+  $ echo 'let x : [`A | `B] = (`A : [`A] :> [`A | `B])' > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+
+  $ echo 'let x : <m:int; n:int> :> <m:int> = object method m = 0 method n = 1 end' > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+
+  $ echo 'let x :> <m:int> = object method m = 0 method n = 1 end' > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+
+
+Here might be a problem in the upward migration: the 5.1.0 parser parses the constraint as a pattern constraint.
+However, the upward migration makes a value binding constraint out of it.
+  $ echo "let ((x,y) : (int*int)) = (assert false: int * int)" > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+  6,25c6,23
+  <         pattern (file.ml[1,0+4]..[1,0+23])
+  <           Ppat_constraint
+  <           pattern (file.ml[1,0+5]..[1,0+10])
+  <             Ppat_tuple
+  <             [
+  <               pattern (file.ml[1,0+6]..[1,0+7])
+  <                 Ppat_var "x" (file.ml[1,0+6]..[1,0+7])
+  <               pattern (file.ml[1,0+8]..[1,0+9])
+  <                 Ppat_var "y" (file.ml[1,0+8]..[1,0+9])
+  <             ]
+  <           core_type (file.ml[1,0+14]..[1,0+21])
+  <             Ptyp_tuple
+  <             [
+  <               core_type (file.ml[1,0+14]..[1,0+17])
+  <                 Ptyp_constr "int" (file.ml[1,0+14]..[1,0+17])
+  <                 []
+  <               core_type (file.ml[1,0+18]..[1,0+21])
+  <                 Ptyp_constr "int" (file.ml[1,0+18]..[1,0+21])
+  <                 []
+  <             ]
+  ---
+  >         pattern (file.ml[1,0+5]..[1,0+10])
+  >           Ppat_tuple
+  >           [
+  >             pattern (file.ml[1,0+6]..[1,0+7])
+  >               Ppat_var "x" (file.ml[1,0+6]..[1,0+7])
+  >             pattern (file.ml[1,0+8]..[1,0+9])
+  >               Ppat_var "y" (file.ml[1,0+8]..[1,0+9])
+  >           ]
+  >         core_type (file.ml[1,0+14]..[1,0+21])
+  >           Ptyp_tuple
+  >           [
+  >             core_type (file.ml[1,0+14]..[1,0+17])
+  >               Ptyp_constr "int" (file.ml[1,0+14]..[1,0+17])
+  >               []
+  >             core_type (file.ml[1,0+18]..[1,0+21])
+  >               Ptyp_constr "int" (file.ml[1,0+18]..[1,0+21])
+  >               []
+  >           ]
+
+  $ echo "let f: type a. a option -> _ = assert false" > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+
+
+Here we may expect a diff (downwards migrating should yield the same as in the example right above).
+However, those case are recoverable.
+
+First, both
+
+  $ echo "let f : 'a . 'a = (fun (type a) -> (assert false : a))" > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+
+and
+  $ echo "let f : type a . a = assert false" > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+
+are translated to the same 5.0 AST tree. But the locations on the expression
+constraint and pattern constraint are only the same in the second case.
+Thus, we can distinguish between the two.
+
+Similarly, the syntactic translation for
+
+  $ echo 'let x :> [`A | `B] = `A' > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+
+and
+
+  $ echo 'let x : [`A | `B] = (`A :> [ `A | `B ] )' > file.ml
+  $ ./compare_on.exe file.ml ./identity_driver.exe
+
+are pretty close: The former is translated to "let (x: ø .  [`A | `B]) = (`A :> [`A | `B])"
+whereas the latter is mapped to "let (x: ø .  [`A | `B]) = ((`A :> [`A | `B]): [`A | `B]) ".
+However, the two case can be distingued by the fact that we have either an outward coercion
+or an outward constraint associated to a `Ptyp_poly([],...)` pattern constraint.
+
+Let's make sure that in the examples with diffs,
+the location invariants are still fulfilled.
+  $ echo "let ((x,y) : (int*int)) = (assert false: int * int)" > file.ml
+  $ ./identity_driver.exe -check -locations-check file.ml > /dev/null

--- a/test/501_migrations/one_migration.t
+++ b/test/501_migrations/one_migration.t
@@ -1,0 +1,572 @@
+This test is enabled both on 5.0.0 and 5.1.0. The test makes sense for as long
+as the ppxlib AST is either 5.0.0 or 5.1.0. While the ppxlib AST is on 5.0.0, the
+test checks whether parsing on 5.0.0 (result of test running on 5.0.0) is the same as
+parsing on 5.1.0 and then migrating down to 5.0.0 (result of test running on 5.1.0).
+
+The test is mostly useful for debuggung problems in a full round-trip. Since Ppxlib's
+`dparsetree` option doesn't compactify or strip locations, its output is very long.
+So let's only keep one example.
+
+  $ echo "let x : int = 5" > file.ml
+  $ ./identity_driver.exe -dparsetree file.ml
+  (((pstr_desc
+     (Pstr_attribute
+      ((attr_name
+        ((txt ocaml.ppx.context)
+         (loc
+          ((loc_start
+            ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+           (loc_end
+            ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+           (loc_ghost true)))))
+       (attr_payload
+        (PStr
+         (((pstr_desc
+            (Pstr_eval
+             ((pexp_desc
+               (Pexp_record
+                ((((txt (Lident tool_name))
+                   (loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true))))
+                  ((pexp_desc
+                    (Pexp_constant
+                     (Pconst_string ppxlib_driver
+                      ((loc_start
+                        ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                         (pos_cnum -1)))
+                       (loc_end
+                        ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                         (pos_cnum -1)))
+                       (loc_ghost true))
+                      ())))
+                   (pexp_loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true)))
+                   (pexp_loc_stack ()) (pexp_attributes ())))
+                 (((txt (Lident include_dirs))
+                   (loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true))))
+                  ((pexp_desc
+                    (Pexp_construct
+                     ((txt (Lident []))
+                      (loc
+                       ((loc_start
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_end
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_ghost true))))
+                     ()))
+                   (pexp_loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true)))
+                   (pexp_loc_stack ()) (pexp_attributes ())))
+                 (((txt (Lident load_path))
+                   (loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true))))
+                  ((pexp_desc
+                    (Pexp_construct
+                     ((txt (Lident []))
+                      (loc
+                       ((loc_start
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_end
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_ghost true))))
+                     ()))
+                   (pexp_loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true)))
+                   (pexp_loc_stack ()) (pexp_attributes ())))
+                 (((txt (Lident open_modules))
+                   (loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true))))
+                  ((pexp_desc
+                    (Pexp_construct
+                     ((txt (Lident []))
+                      (loc
+                       ((loc_start
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_end
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_ghost true))))
+                     ()))
+                   (pexp_loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true)))
+                   (pexp_loc_stack ()) (pexp_attributes ())))
+                 (((txt (Lident for_package))
+                   (loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true))))
+                  ((pexp_desc
+                    (Pexp_construct
+                     ((txt (Lident None))
+                      (loc
+                       ((loc_start
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_end
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_ghost true))))
+                     ()))
+                   (pexp_loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true)))
+                   (pexp_loc_stack ()) (pexp_attributes ())))
+                 (((txt (Lident debug))
+                   (loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true))))
+                  ((pexp_desc
+                    (Pexp_construct
+                     ((txt (Lident false))
+                      (loc
+                       ((loc_start
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_end
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_ghost true))))
+                     ()))
+                   (pexp_loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true)))
+                   (pexp_loc_stack ()) (pexp_attributes ())))
+                 (((txt (Lident use_threads))
+                   (loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true))))
+                  ((pexp_desc
+                    (Pexp_construct
+                     ((txt (Lident false))
+                      (loc
+                       ((loc_start
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_end
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_ghost true))))
+                     ()))
+                   (pexp_loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true)))
+                   (pexp_loc_stack ()) (pexp_attributes ())))
+                 (((txt (Lident use_vmthreads))
+                   (loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true))))
+                  ((pexp_desc
+                    (Pexp_construct
+                     ((txt (Lident false))
+                      (loc
+                       ((loc_start
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_end
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_ghost true))))
+                     ()))
+                   (pexp_loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true)))
+                   (pexp_loc_stack ()) (pexp_attributes ())))
+                 (((txt (Lident recursive_types))
+                   (loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true))))
+                  ((pexp_desc
+                    (Pexp_construct
+                     ((txt (Lident false))
+                      (loc
+                       ((loc_start
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_end
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_ghost true))))
+                     ()))
+                   (pexp_loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true)))
+                   (pexp_loc_stack ()) (pexp_attributes ())))
+                 (((txt (Lident principal))
+                   (loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true))))
+                  ((pexp_desc
+                    (Pexp_construct
+                     ((txt (Lident false))
+                      (loc
+                       ((loc_start
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_end
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_ghost true))))
+                     ()))
+                   (pexp_loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true)))
+                   (pexp_loc_stack ()) (pexp_attributes ())))
+                 (((txt (Lident transparent_modules))
+                   (loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true))))
+                  ((pexp_desc
+                    (Pexp_construct
+                     ((txt (Lident false))
+                      (loc
+                       ((loc_start
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_end
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_ghost true))))
+                     ()))
+                   (pexp_loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true)))
+                   (pexp_loc_stack ()) (pexp_attributes ())))
+                 (((txt (Lident unboxed_types))
+                   (loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true))))
+                  ((pexp_desc
+                    (Pexp_construct
+                     ((txt (Lident false))
+                      (loc
+                       ((loc_start
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_end
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_ghost true))))
+                     ()))
+                   (pexp_loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true)))
+                   (pexp_loc_stack ()) (pexp_attributes ())))
+                 (((txt (Lident unsafe_string))
+                   (loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true))))
+                  ((pexp_desc
+                    (Pexp_construct
+                     ((txt (Lident false))
+                      (loc
+                       ((loc_start
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_end
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_ghost true))))
+                     ()))
+                   (pexp_loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true)))
+                   (pexp_loc_stack ()) (pexp_attributes ())))
+                 (((txt (Lident cookies))
+                   (loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true))))
+                  ((pexp_desc
+                    (Pexp_construct
+                     ((txt (Lident []))
+                      (loc
+                       ((loc_start
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_end
+                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                          (pos_cnum -1)))
+                        (loc_ghost true))))
+                     ()))
+                   (pexp_loc
+                    ((loc_start
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_end
+                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
+                       (pos_cnum -1)))
+                     (loc_ghost true)))
+                   (pexp_loc_stack ()) (pexp_attributes ()))))
+                ()))
+              (pexp_loc
+               ((loc_start
+                 ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+                (loc_end
+                 ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+                (loc_ghost true)))
+              (pexp_loc_stack ()) (pexp_attributes ()))
+             ()))
+           (pstr_loc
+            ((loc_start
+              ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+             (loc_end
+              ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+             (loc_ghost true)))))))
+       (attr_loc
+        ((loc_start
+          ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+         (loc_end ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+         (loc_ghost true))))))
+    (pstr_loc
+     ((loc_start ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+      (loc_end ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
+      (loc_ghost true))))
+   ((pstr_desc
+     (Pstr_value Nonrecursive
+      (((pvb_pat
+         ((ppat_desc
+           (Ppat_constraint
+            ((ppat_desc
+              (Ppat_var
+               ((txt x)
+                (loc
+                 ((loc_start
+                   ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 4)))
+                  (loc_end
+                   ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 5)))
+                  (loc_ghost false))))))
+             (ppat_loc
+              ((loc_start
+                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 4)))
+               (loc_end
+                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 5)))
+               (loc_ghost false)))
+             (ppat_loc_stack ()) (ppat_attributes ()))
+            ((ptyp_desc
+              (Ptyp_poly ()
+               ((ptyp_desc
+                 (Ptyp_constr
+                  ((txt (Lident int))
+                   (loc
+                    ((loc_start
+                      ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0)
+                       (pos_cnum 8)))
+                     (loc_end
+                      ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0)
+                       (pos_cnum 11)))
+                     (loc_ghost false))))
+                  ()))
+                (ptyp_loc
+                 ((loc_start
+                   ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 8)))
+                  (loc_end
+                   ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 11)))
+                  (loc_ghost false)))
+                (ptyp_loc_stack ()) (ptyp_attributes ()))))
+             (ptyp_loc
+              ((loc_start
+                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 8)))
+               (loc_end
+                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 11)))
+               (loc_ghost true)))
+             (ptyp_loc_stack ()) (ptyp_attributes ()))))
+          (ppat_loc
+           ((loc_start
+             ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 4)))
+            (loc_end
+             ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 11)))
+            (loc_ghost true)))
+          (ppat_loc_stack ()) (ppat_attributes ())))
+        (pvb_expr
+         ((pexp_desc
+           (Pexp_constraint
+            ((pexp_desc (Pexp_constant (Pconst_integer 5 ())))
+             (pexp_loc
+              ((loc_start
+                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 14)))
+               (loc_end
+                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 15)))
+               (loc_ghost false)))
+             (pexp_loc_stack ()) (pexp_attributes ()))
+            ((ptyp_desc
+              (Ptyp_constr
+               ((txt (Lident int))
+                (loc
+                 ((loc_start
+                   ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 8)))
+                  (loc_end
+                   ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 11)))
+                  (loc_ghost false))))
+               ()))
+             (ptyp_loc
+              ((loc_start
+                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 8)))
+               (loc_end
+                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 11)))
+               (loc_ghost false)))
+             (ptyp_loc_stack ()) (ptyp_attributes ()))))
+          (pexp_loc
+           ((loc_start
+             ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 4)))
+            (loc_end
+             ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 15)))
+            (loc_ghost false)))
+          (pexp_loc_stack ()) (pexp_attributes ())))
+        (pvb_attributes ())
+        (pvb_loc
+         ((loc_start
+           ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 0)))
+          (loc_end
+           ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 15)))
+          (loc_ghost false)))))))
+    (pstr_loc
+     ((loc_start ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 0)))
+      (loc_end ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 15)))
+      (loc_ghost false)))))

--- a/test/501_migrations/reverse_migrations.ml
+++ b/test/501_migrations/reverse_migrations.ml
@@ -1,0 +1,9 @@
+module Reverse = Ppxlib_ast.Select_ast (Ppxlib_ast__.Versions.OCaml_501)
+
+let () =
+  let impl str =
+    Reverse.Of_ocaml.copy_structure @@ Reverse.To_ocaml.copy_structure str
+  in
+  Ppxlib.Driver.register_transformation ~impl "reverse_migrations"
+
+let () = Ppxlib.Driver.standalone ()

--- a/test/501_migrations/reverse_migrations.t
+++ b/test/501_migrations/reverse_migrations.t
@@ -1,0 +1,164 @@
+The 501 parsetree contains a parsing modificacion.
+[compare_on.exe <file> ./reverse_migrations.exe] checks if there's a diff between the
+AST's resulting from
+1. parsing <file> on 5.0.0 directly
+2. parsing <file> on 5.0.0, migrating up to 5.1.0 and migrating back to 5.0.0
+
+  $ echo "let x : int = 5" > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe   | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo "let _ : int = 5" > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe   | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo "let f : type a b c. a -> b -> c = fun x y -> assert false" > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe   | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo "let f = (fun (type a) (type b) (type c) -> (fun x y -> assert false : a -> b -> c))" > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe  | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo "let _ = (fun (type a) (type b) (type c) -> (fun x y -> assert false : a -> b -> c))" > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe  | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo "let f : type a . a -> a = fun x -> x" > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe   | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo "let f: type a. a option -> _ = assert false" > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe   | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo "let f : 'a . 'a = (fun (type a) -> (assert false : a))" > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe   | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo "let f : type a . a = assert false" > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe   | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo 'let x :> [`A | `B] = `A' > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe   | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo 'let x : [`A] :> [`A | `B] = `A' > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe   | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo 'let x : [`A | `B] = (`A : [`A] :> [`A | `B])' > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe   | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo 'let x : <m:int; n:int> :> <m:int> = object method m = 0 method n = 1 end' > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe   | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo 'let x :> <m:int> = object method m = 0 method n = 1 end' > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe   | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+The downward migration isn't able to recover the whole pattern location range,
+since it doesn't track the location of the closing brackets.
+  $ echo "let (x, y) : (int * int) = assert false" > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe  | grep -v "without_migrations" | grep -v "with_migrations"
+  @@ -6 +6 @@
+  -        pattern (file.ml[1,0+4]..[1,0+24]) ghost
+  +        pattern (file.ml[1,0+4]..[1,0+23]) ghost
+
+  $ echo "let (x, y) : (int * int) = assert false" > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe  | grep -v "without_migrations" | grep -v "with_migrations"
+  @@ -6 +6 @@
+  -        pattern (file.ml[1,0+4]..[1,0+24]) ghost
+  +        pattern (file.ml[1,0+4]..[1,0+23]) ghost
+
+  $ echo "let f: type a. a option -> _ = assert false" > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe  | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo "let f : 'a . 'a = (fun (type a) -> (assert false : a))" > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe  | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo "let f : type a . a = assert false" > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe  | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo 'let x :> [`A | `B] = `A' > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe  | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo 'let x : [`A] :> [`A | `B] = `A' > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe  | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo 'let x : [`A | `B] = (`A : [`A] :> [`A | `B])' > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe  | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo 'let x : <m:int; n:int> :> <m:int> = object method m = 0 method n = 1 end' > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe  | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+  $ echo 'let x :> <m:int> = object method m = 0 method n = 1 end' > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe  | grep -v "without_migrations" | grep -v "with_migrations"
+  [1]
+
+The diffs are on locations. If the location modification
+at least preserved the location invariants, it might be acceptable.
+However, in several cases it doesn't.
+
+  $ echo "let x : int = 5" > file.ml
+  $ ./reverse_migrations.exe -check -locations-check file.ml > /dev/null
+
+  $ echo "let (x as y) : int = 5" > file.ml
+  $ ./reverse_migrations.exe -check -locations-check file.ml > /dev/null
+
+  $ cat > file.ml << EOF
+  > type t = {a : int}
+  > let {a} = {a = 5}
+  > EOF
+  $ ./reverse_migrations.exe -check -locations-check file.ml > /dev/null
+
+
+  $ echo "let _ : int = 5" > file.ml
+  $ ./reverse_migrations.exe -check -locations-check file.ml > /dev/null
+
+  $ echo "let f : type a b c. a -> b -> c = fun x y -> assert false" > file.ml
+  $ ./reverse_migrations.exe -check -locations-check file.ml > /dev/null
+
+  $ echo "let f = (fun (type a) (type b) (type c) -> (fun x y -> assert false : a -> b -> c))" > file.ml
+  $ ./reverse_migrations.exe -check -locations-check file.ml > /dev/null
+
+  $ echo "let _ = (fun (type a) (type b) (type c) -> (fun x y -> assert false : a -> b -> c))" > file.ml
+  $ ./reverse_migrations.exe -check -locations-check file.ml > /dev/null
+
+Here we're expecting a similar location diff as above. However, the downward
+migration is faulty: it turns [let (x) : int = 5] (constraint only on pattern)
+into [let x : int = 5] (contraint on both pattern an expression).
+  $ echo "let (x) : int = 5" > file.ml
+  $ ./compare_on.exe file.ml ./reverse_migrations.exe | grep -v "without_migrations" | grep -v "with_migrations"
+  @@ -9,0 +10,9 @@
+  +          core_type (file.ml[1,0+10]..[1,0+13]) ghost
+  +            Ptyp_poly
+  +            core_type (file.ml[1,0+10]..[1,0+13])
+  +              Ptyp_constr "int" (file.ml[1,0+10]..[1,0+13])
+  +              []
+  +        expression (file.ml[1,0+4]..[1,0+17])
+  +          Pexp_constraint
+  +          expression (file.ml[1,0+16]..[1,0+17])
+  +            Pexp_constant PConst_int (5,None)
+  @@ -13,2 +21,0 @@
+  -        expression (file.ml[1,0+16]..[1,0+17])
+  -          Pexp_constant PConst_int (5,None)
+
+Let's make sure that in the examples with diffs,
+the location invariants are still fulfilled.
+
+  $ echo "let (x, y) : (int * int) = assert false" > file.ml
+  $ ./reverse_migrations.exe -check -locations-check file.ml > /dev/null
+
+  $ echo "let (x) : int = 5" > file.ml
+  $ ./reverse_migrations.exe -check -locations-check file.ml > /dev/null

--- a/test/base/test.ml
+++ b/test/base/test.ml
@@ -1,10 +1,5 @@
-#require "base";;
-#require "stdio";;
-
 let () = Printexc.record_backtrace false
 
-open Base
-open Stdio
 open Ppxlib
 
 module N = Ppxlib_private.Name
@@ -14,9 +9,9 @@ module N = Ppxlib.Ppxlib_private.Name
 
 
 let dot_suffixes name =
-  Caml.Printf.sprintf "%s"
-    (Sexp.to_string_hum
-       (List.sexp_of_t String.sexp_of_t (N.dot_suffixes name)))
+  Printf.sprintf "%s"
+    (Sexplib0.Sexp.to_string_hum
+       (Sexplib0.Sexp_conv.sexp_of_list Sexplib0.Sexp_conv.sexp_of_string (N.dot_suffixes name)))
 [%%expect{|
 val dot_suffixes : string -> string = <fun>
 |}]
@@ -34,9 +29,9 @@ let _ = dot_suffixes "foo.@bar.baz"
 
 let split_path name =
     let a, b = N.split_path name in
-    Caml.Printf.sprintf "%s"
-      (Sexp.to_string_hum
-         (List [sexp_of_string a; Option.sexp_of_t sexp_of_string b]))
+    Printf.sprintf "%s"
+      (Sexplib0.Sexp.to_string_hum
+         (List [Sexplib0.Sexp_conv.sexp_of_string a; Sexplib0.Sexp_conv.sexp_of_option Sexplib0.Sexp_conv.sexp_of_string b]))
 [%%expect{|
 val split_path : string -> string = <fun>
 |}]
@@ -161,12 +156,12 @@ let _ =
 let _ =
   let open Ast_builder.Make (struct let loc = Location.none end) in
   let params decl =
-    List.map decl.ptype_params ~f:(fun (core_type, _) -> core_type.ptyp_desc)
+    List.map (fun (core_type, _) -> core_type.ptyp_desc) decl.ptype_params
   in
   let decl =
     type_declaration
       ~name:{ txt = "t"; loc = Location.none }
-      ~params:(List.init 3 ~f:(fun _ -> ptyp_any, (NoVariance, NoInjectivity)))
+      ~params:(List.init 3 (fun _ -> ptyp_any, (NoVariance, NoInjectivity)))
       ~cstrs:[]
       ~kind:Ptype_abstract
       ~private_:Public

--- a/test/code_path/test.ml
+++ b/test/code_path/test.ml
@@ -1,17 +1,14 @@
-#require "base";;
-
-open Base
 open Ppxlib
 
 let sexp_of_code_path code_path =
-  Sexp.message
+  Sexplib0.Sexp.message
     "code_path"
-    [ "main_module_name", sexp_of_string (Code_path.main_module_name code_path)
-    ; "submodule_path", sexp_of_list sexp_of_string (Code_path.submodule_path code_path)
-    ; "enclosing_module", sexp_of_string (Code_path.enclosing_module code_path)
-    ; "enclosing_value", sexp_of_option sexp_of_string (Code_path.enclosing_value code_path)
-    ; "value", sexp_of_option sexp_of_string (Code_path.value code_path)
-    ; "fully_qualified_path", sexp_of_string (Code_path.fully_qualified_path code_path)
+    [ "main_module_name", Sexplib0.Sexp_conv.sexp_of_string (Code_path.main_module_name code_path)
+    ; "submodule_path", Sexplib0.Sexp_conv.sexp_of_list Sexplib0.Sexp_conv.sexp_of_string (Code_path.submodule_path code_path)
+    ; "enclosing_module", Sexplib0.Sexp_conv.sexp_of_string (Code_path.enclosing_module code_path)
+    ; "enclosing_value", Sexplib0.Sexp_conv.sexp_of_option Sexplib0.Sexp_conv.sexp_of_string (Code_path.enclosing_value code_path)
+    ; "value", Sexplib0.Sexp_conv.sexp_of_option Sexplib0.Sexp_conv.sexp_of_string (Code_path.value code_path)
+    ; "fully_qualified_path", Sexplib0.Sexp_conv.sexp_of_string (Code_path.fully_qualified_path code_path)
     ]
 
 let () =
@@ -24,10 +21,10 @@ let () =
            let loc = Expansion_context.Extension.extension_point_loc ctxt in
            let code_path = Expansion_context.Extension.code_path ctxt in
            Ast_builder.Default.estring ~loc
-             (Sexp.to_string (sexp_of_code_path code_path)))
+             (Sexplib0.Sexp.to_string (sexp_of_code_path code_path)))
     ]
 [%%expect{|
-val sexp_of_code_path : Code_path.t -> Sexp.t = <fun>
+val sexp_of_code_path : Code_path.t -> Sexplib0.Sexp.t = <fun>
 |}]
 
 let s =

--- a/test/code_path/test_510.ml
+++ b/test/code_path/test_510.ml
@@ -1,17 +1,14 @@
-#require "base";;
-
-open Base
 open Ppxlib
 
 let sexp_of_code_path code_path =
-  Sexp.message
+  Sexplib0.Sexp.message
     "code_path"
-    [ "main_module_name", sexp_of_string (Code_path.main_module_name code_path)
-    ; "submodule_path", sexp_of_list sexp_of_string (Code_path.submodule_path code_path)
-    ; "enclosing_module", sexp_of_string (Code_path.enclosing_module code_path)
-    ; "enclosing_value", sexp_of_option sexp_of_string (Code_path.enclosing_value code_path)
-    ; "value", sexp_of_option sexp_of_string (Code_path.value code_path)
-    ; "fully_qualified_path", sexp_of_string (Code_path.fully_qualified_path code_path)
+    [ "main_module_name", Sexplib0.Sexp_conv.sexp_of_string (Code_path.main_module_name code_path)
+    ; "submodule_path", Sexplib0.Sexp_conv.sexp_of_list Sexplib0.Sexp_conv.sexp_of_string (Code_path.submodule_path code_path)
+    ; "enclosing_module", Sexplib0.Sexp_conv.sexp_of_string (Code_path.enclosing_module code_path)
+    ; "enclosing_value", Sexplib0.Sexp_conv.sexp_of_option Sexplib0.Sexp_conv.sexp_of_string (Code_path.enclosing_value code_path)
+    ; "value", Sexplib0.Sexp_conv.sexp_of_option Sexplib0.Sexp_conv.sexp_of_string (Code_path.value code_path)
+    ; "fully_qualified_path", Sexplib0.Sexp_conv.sexp_of_string (Code_path.fully_qualified_path code_path)
     ]
 
 let () =
@@ -24,10 +21,10 @@ let () =
            let loc = Expansion_context.Extension.extension_point_loc ctxt in
            let code_path = Expansion_context.Extension.code_path ctxt in
            Ast_builder.Default.estring ~loc
-             (Sexp.to_string (sexp_of_code_path code_path)))
+             (Sexplib0.Sexp.to_string (sexp_of_code_path code_path)))
     ]
 [%%expect{|
-val sexp_of_code_path : Code_path.t -> Sexp.t = <fun>
+val sexp_of_code_path : Code_path.t -> Sexplib0.Sexp.t = <fun>
 |}]
 
 let s =
@@ -51,7 +48,7 @@ let s =
   in A.A'.a
 ;;
 [%%expect{|
-val s : string/2 =
+val s : string =
   "(code_path(main_module_name Test_510)(submodule_path())(enclosing_module C')(enclosing_value(c))(value(s))(fully_qualified_path Test_510.s))"
 |}]
 
@@ -61,7 +58,7 @@ let module M = struct
   in
   M.m
 [%%expect{|
-- : string/2 =
+- : string =
 "(code_path(main_module_name Test_510)(submodule_path())(enclosing_module M)(enclosing_value(m))(value())(fully_qualified_path Test_510))"
 |}]
 
@@ -72,8 +69,8 @@ module Outer = struct
 end
 let _ = Outer.Inner.code_path
 [%%expect{|
-module Outer : sig module Inner : sig val code_path : string/2 end end
-- : string/2 =
+module Outer : sig module Inner : sig val code_path : string end end
+- : string =
 "(code_path(main_module_name Test_510)(submodule_path(Outer Inner))(enclosing_module Inner)(enclosing_value(code_path))(value(code_path))(fully_qualified_path Test_510.Outer.Inner.code_path))"
 |}]
 
@@ -93,7 +90,7 @@ module Functor() = struct
 end
 let _ = let module M = Functor() in !M.code_path
 [%%expect{|
-module Functor : functor () -> sig val code_path : string/2 ref end
+module Functor : functor () -> sig val code_path : string ref end
 Line _:
 Error (warning 73 [generative-application-expects-unit]): A generative functor
 should be applied to '()'; using '(struct end)' is deprecated.
@@ -105,9 +102,9 @@ end [@enter_module Dummy]
 let _ = Actual.code_path
 [%%expect{|
 
-module Actual : sig val code_path : string/2 end
+module Actual : sig val code_path : string end
 
-- : string/2 =
+- : string =
 "(code_path(main_module_name Test_510)(submodule_path(Actual Dummy))(enclosing_module Dummy)(enclosing_value(code_path))(value(code_path))(fully_qualified_path Test_510.Actual.Dummy.code_path))"
 |}]
 
@@ -117,9 +114,9 @@ end [@@do_not_enter_module]
 let _ = Ignore_me.code_path
 [%%expect{|
 
-module Ignore_me : sig val code_path : string/2 end
+module Ignore_me : sig val code_path : string end
 
-- : string/2 =
+- : string =
 "(code_path(main_module_name Test_510)(submodule_path())(enclosing_module Test_510)(enclosing_value(code_path))(value(code_path))(fully_qualified_path Test_510.code_path))"
 |}]
 
@@ -132,14 +129,14 @@ let _ =
   [@do_not_enter_module]
 [%%expect{|
 
-- : string/2 =
+- : string =
 "(code_path(main_module_name Test_510)(submodule_path())(enclosing_module Test_510)(enclosing_value(code_path))(value())(fully_qualified_path Test_510))"
 |}]
 
 let _ = ([%code_path] [@ppxlib.enter_value dummy])
 [%%expect{|
 
-- : string/2 =
+- : string =
 "(code_path(main_module_name Test_510)(submodule_path())(enclosing_module Test_510)(enclosing_value(dummy))(value(dummy))(fully_qualified_path Test_510.dummy))"
 |}]
 
@@ -150,6 +147,6 @@ let _ =
   ignore_me
 [%%expect{|
 
-- : string/2 =
+- : string =
 "(code_path(main_module_name Test_510)(submodule_path())(enclosing_module Test_510)(enclosing_value())(value())(fully_qualified_path Test_510))"
 |}]

--- a/test/deriving/test.ml
+++ b/test/deriving/test.ml
@@ -1,5 +1,3 @@
-#require "base";;
-
 open Ppxlib
 
 

--- a/test/deriving/test_510.ml
+++ b/test/deriving/test_510.ml
@@ -1,5 +1,3 @@
-#require "base";;
-
 open Ppxlib
 
 

--- a/test/driver/attributes/test.ml
+++ b/test/driver/attributes/test.ml
@@ -1,6 +1,3 @@
-#require "base";;
-
-open Stdppx
 open Ppxlib
 
 let () = Driver.enable_checks ()

--- a/test/driver/attributes/test_510.ml
+++ b/test/driver/attributes/test_510.ml
@@ -1,6 +1,3 @@
-#require "base";;
-
-open Stdppx
 open Ppxlib
 
 let () = Driver.enable_checks ()

--- a/test/driver/non-compressible-suffix/test.ml
+++ b/test/driver/non-compressible-suffix/test.ml
@@ -1,6 +1,3 @@
-#require "base";;
-#require "stdio";;
-
 open Ppxlib;;
 open Ast_builder.Default;;
 

--- a/test/quoter/test.ml
+++ b/test/quoter/test.ml
@@ -1,5 +1,3 @@
-#require "base";;
-
 open Ppxlib
 open Expansion_helpers
 


### PR DESCRIPTION
This is the same as #420, but with a clean git history and with signed commits. I care about the git history here because we'll need to cherry-pick these changes over to `main` (and I didn't want to clean up the history on the #420 branch, because people are using that branch).

When cherry-picking this over to `main`, we'll need changelog entries for both the 5.1.0 support, mentioning that this is incompatible with `5.1.0~alpha1`, and for the location-check change.