### PR TITLE
Remove misleading attribute hint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 unreleased
 ------------------
 
+- Clean up misleading attribute hints when declared for proper context. (#425, @ceastlund)
+
 - Ast_pattern now has ebool, pbool helper, and a new map.(#402, @burnleydev1)
 
 - multiple errors are now reported in `metaquot`. (#397, @burnleydev1)

--- a/src/name.ml
+++ b/src/name.ml
@@ -211,12 +211,13 @@ module Registrar = struct
           String.Map.add name t acc)
 
   let spellcheck t context ?(allowlist = []) name =
+    let all_for_context = get_all_for_context t context in
     let all =
-      let all = get_all_for_context t context in
-      String.Map.fold (fun key _ acc -> key :: acc) all.all []
+      String.Map.fold (fun key _ acc -> key :: acc) all_for_context.all []
     in
     match Spellcheck.spellcheck (all @ allowlist) name with
     | Some _ as x -> x
+    | None when String.Map.mem name all_for_context.all -> None
     | None -> (
         let other_contexts =
           Hashtbl.fold

--- a/test/driver/attributes/test.ml
+++ b/test/driver/attributes/test.ml
@@ -54,6 +54,16 @@ Error: Attribute `blah' was not used.
        Did you put it at the wrong level?
 |}]
 
+let _ = () [@blah]
+[%%expect{|
+Line _, characters 13-17:
+Error: Attribute `blah' was not used.
+       Hint: `blah' is available for type declarations but is used here in
+       the
+       context of an expression.
+       Did you put it at the wrong level?
+|}]
+
 (* Attribute drops *)
 
 let faulty_transformation = object

--- a/test/driver/attributes/test.ml
+++ b/test/driver/attributes/test.ml
@@ -57,11 +57,7 @@ Error: Attribute `blah' was not used.
 let _ = () [@blah]
 [%%expect{|
 Line _, characters 13-17:
-Error: Attribute `blah' was not used.
-       Hint: `blah' is available for type declarations but is used here in
-       the
-       context of an expression.
-       Did you put it at the wrong level?
+Error: Attribute `blah' was not used
 |}]
 
 (* Attribute drops *)


### PR DESCRIPTION
Fixes an odd case where ppxlib suggests you've used an attribute in the wrong context, even when the attribute is in fact declared in that context.

Previously ppxlib had reported cases where the attribute was declared in other contexts, whether or not it was also declared in the current context. In the first commit, we add a test demonstrating this behavior. In the second commit, we fix the error message and the test.