### PR TITLE
Replace Caml with Stdlib

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@ unreleased
 
 - Adopt the OCaml Code of Conduct on the repo (#426, @pitag-ha)
 
+- Replace `Caml` with `Stdlib`. (#427, @ceastlund)
+
 - Clean up misleading attribute hints when declared for proper context. (#425, @ceastlund)
 
 - Ast_pattern now has ebool, pbool helper, and a new map.(#402, @burnleydev1)

--- a/bench/drivers/identity/inputs/bap_knowledge.ml
+++ b/bench/drivers/identity/inputs/bap_knowledge.ml
@@ -24,9 +24,9 @@ type conflict = exn = ..
 module Conflict = struct
   type t = conflict = ..
 
-  let to_string = Caml.Printexc.to_string
+  let to_string = Stdlib.Printexc.to_string
   let pp ppf err = Format.fprintf ppf "%s" (to_string err)
-  let register_printer = Caml.Printexc.register_printer
+  let register_printer = Stdlib.Printexc.register_printer
   let sexp_of_t err = Sexp.Atom (to_string err)
 end
 
@@ -153,22 +153,22 @@ end = struct
 
     let rec find_exn t k =
       match t with
-      | Nil -> raise Caml.Not_found
+      | Nil -> raise Stdlib.Not_found
       | Tip (k', v) when k = k' -> v
-      | Tip _ -> raise Caml.Not_found
+      | Tip _ -> raise Stdlib.Not_found
       | Bin (k', l, r) -> (
           match Key.compare k' k with
-          | NA -> raise Caml.Not_found
+          | NA -> raise Stdlib.Not_found
           | LB -> find_exn l k
           | RB -> find_exn r k)
 
-    let find t k = try Some (find_exn t k) with Caml.Not_found -> None
+    let find t k = try Some (find_exn t k) with Stdlib.Not_found -> None
 
     let mem k t =
       try
         ignore (find_exn k t);
         true
-      with Caml.Not_found -> false
+      with Stdlib.Not_found -> false
 
     let node payload branching l r =
       match (l, r) with
@@ -359,7 +359,7 @@ end = struct
 
   let unescaped_exists_so_escape ?(skip_pos = -1) s =
     let buf = Buffer.create (String.length s + 1) in
-    Caml.StringLabels.iteri s ~f:(fun p c ->
+    Stdlib.StringLabels.iteri s ~f:(fun p c ->
         if p <> skip_pos && is_separator_unescaped s p c then
           Buffer.add_char buf escape_char;
         Buffer.add_char buf c);
@@ -555,7 +555,7 @@ end = struct
   let register ?(desc = "no description provided") ?package
       ?(reliability = trustworthy) name =
     let name = Name.create ?package name in
-    let agent = Caml.Digest.string (Name.show name) in
+    let agent = Stdlib.Digest.string (Name.show name) in
     if Hashtbl.mem agents agent then
       failwithf
         "An agent with name `%a' already exists, please choose another name"
@@ -2577,7 +2577,7 @@ module Knowledge = struct
         slot : Name.t;
         repr : string;
         error : Conflict.t;
-        trace : Caml.Printexc.raw_backtrace;
+        trace : Stdlib.Printexc.raw_backtrace;
       }
 
   let () =
@@ -2587,7 +2587,7 @@ module Knowledge = struct
           @@ Format.asprintf
                "Unable to update the slot %a of %s,\n%a\nBacktrace:\n%s" Name.pp
                slot repr Conflict.pp error
-               (Caml.Printexc.raw_backtrace_to_string trace)
+               (Stdlib.Printexc.raw_backtrace_to_string trace)
       | _ -> None)
 
   let non_monotonic slot obj error trace =
@@ -2626,7 +2626,7 @@ module Knowledge = struct
                     };
             }
         with Record.Merge_conflict err ->
-          non_monotonic slot obj err @@ Caml.Printexc.get_raw_backtrace ())
+          non_monotonic slot obj err @@ Stdlib.Printexc.get_raw_backtrace ())
 
   let notify { Slot.watchers } obj data =
     Hashtbl.data watchers
@@ -2698,7 +2698,7 @@ module Knowledge = struct
    fun slot obj ->
     objects slot.cls >>| fun { vals } ->
     match Oid.Tree.find_exn vals obj with
-    | exception Caml.Not_found -> Sleep
+    | exception Stdlib.Not_found -> Sleep
     | { data; comp = slots } -> (
         match Map.find slots (uid slot) with
         | Some (Work _) -> Awoke
@@ -2771,7 +2771,7 @@ module Knowledge = struct
    fun slot id ->
     objects slot.cls >>| fun { Env.vals } ->
     match Oid.Tree.find_exn vals id with
-    | exception Caml.Not_found -> slot.dom.empty
+    | exception Stdlib.Not_found -> slot.dom.empty
     | { data } -> Record.get slot.key slot.dom data
 
   let rec collect_inner : ('a, 'p) slot -> 'a obj -> _ -> _ =
@@ -3030,7 +3030,7 @@ module Knowledge = struct
     compute_value cls obj >>= fun () ->
     objects cls >>| fun { Env.vals } ->
     match Oid.Tree.find_exn vals obj with
-    | exception Caml.Not_found -> Value.empty cls
+    | exception Stdlib.Not_found -> Value.empty cls
     | { data = x } -> Value.create cls x
 
   let run cls obj s =

--- a/bench/drivers/ppx_sexp_conv/inputs/bap_knowledge.ml
+++ b/bench/drivers/ppx_sexp_conv/inputs/bap_knowledge.ml
@@ -24,9 +24,9 @@ type conflict = exn = ..
 module Conflict = struct
   type t = conflict = ..
 
-  let to_string = Caml.Printexc.to_string
+  let to_string = Stdlib.Printexc.to_string
   let pp ppf err = Format.fprintf ppf "%s" (to_string err)
-  let register_printer = Caml.Printexc.register_printer
+  let register_printer = Stdlib.Printexc.register_printer
   let sexp_of_t err = Sexp.Atom (to_string err)
 end
 
@@ -153,22 +153,22 @@ end = struct
 
     let rec find_exn t k =
       match t with
-      | Nil -> raise Caml.Not_found
+      | Nil -> raise Stdlib.Not_found
       | Tip (k', v) when k = k' -> v
-      | Tip _ -> raise Caml.Not_found
+      | Tip _ -> raise Stdlib.Not_found
       | Bin (k', l, r) -> (
           match Key.compare k' k with
-          | NA -> raise Caml.Not_found
+          | NA -> raise Stdlib.Not_found
           | LB -> find_exn l k
           | RB -> find_exn r k)
 
-    let find t k = try Some (find_exn t k) with Caml.Not_found -> None
+    let find t k = try Some (find_exn t k) with Stdlib.Not_found -> None
 
     let mem k t =
       try
         ignore (find_exn k t);
         true
-      with Caml.Not_found -> false
+      with Stdlib.Not_found -> false
 
     let node payload branching l r =
       match (l, r) with
@@ -359,7 +359,7 @@ end = struct
 
   let unescaped_exists_so_escape ?(skip_pos = -1) s =
     let buf = Buffer.create (String.length s + 1) in
-    Caml.StringLabels.iteri s ~f:(fun p c ->
+    Stdlib.StringLabels.iteri s ~f:(fun p c ->
         if p <> skip_pos && is_separator_unescaped s p c then
           Buffer.add_char buf escape_char;
         Buffer.add_char buf c);
@@ -555,7 +555,7 @@ end = struct
   let register ?(desc = "no description provided") ?package
       ?(reliability = trustworthy) name =
     let name = Name.create ?package name in
-    let agent = Caml.Digest.string (Name.show name) in
+    let agent = Stdlib.Digest.string (Name.show name) in
     if Hashtbl.mem agents agent then
       failwithf
         "An agent with name `%a' already exists, please choose another name"
@@ -2577,7 +2577,7 @@ module Knowledge = struct
         slot : Name.t;
         repr : string;
         error : Conflict.t;
-        trace : Caml.Printexc.raw_backtrace;
+        trace : Stdlib.Printexc.raw_backtrace;
       }
 
   let () =
@@ -2587,7 +2587,7 @@ module Knowledge = struct
           @@ Format.asprintf
                "Unable to update the slot %a of %s,\n%a\nBacktrace:\n%s" Name.pp
                slot repr Conflict.pp error
-               (Caml.Printexc.raw_backtrace_to_string trace)
+               (Stdlib.Printexc.raw_backtrace_to_string trace)
       | _ -> None)
 
   let non_monotonic slot obj error trace =
@@ -2626,7 +2626,7 @@ module Knowledge = struct
                     };
             }
         with Record.Merge_conflict err ->
-          non_monotonic slot obj err @@ Caml.Printexc.get_raw_backtrace ())
+          non_monotonic slot obj err @@ Stdlib.Printexc.get_raw_backtrace ())
 
   let notify { Slot.watchers } obj data =
     Hashtbl.data watchers
@@ -2698,7 +2698,7 @@ module Knowledge = struct
    fun slot obj ->
     objects slot.cls >>| fun { vals } ->
     match Oid.Tree.find_exn vals obj with
-    | exception Caml.Not_found -> Sleep
+    | exception Stdlib.Not_found -> Sleep
     | { data; comp = slots } -> (
         match Map.find slots (uid slot) with
         | Some (Work _) -> Awoke
@@ -2771,7 +2771,7 @@ module Knowledge = struct
    fun slot id ->
     objects slot.cls >>| fun { Env.vals } ->
     match Oid.Tree.find_exn vals id with
-    | exception Caml.Not_found -> slot.dom.empty
+    | exception Stdlib.Not_found -> slot.dom.empty
     | { data } -> Record.get slot.key slot.dom data
 
   let rec collect_inner : ('a, 'p) slot -> 'a obj -> _ -> _ =
@@ -3030,7 +3030,7 @@ module Knowledge = struct
     compute_value cls obj >>= fun () ->
     objects cls >>| fun { Env.vals } ->
     match Oid.Tree.find_exn vals obj with
-    | exception Caml.Not_found -> Value.empty cls
+    | exception Stdlib.Not_found -> Value.empty cls
     | { data = x } -> Value.create cls x
 
   let run cls obj s =

--- a/src/attribute.ml
+++ b/src/attribute.ml
@@ -304,7 +304,7 @@ let declare_flag name context =
   let continuation ~attr_loc:_ ~name_loc:_ = () in
   declare_with_all_args name context payload_pattern continuation
 
-module Attribute_table = Caml.Hashtbl.Make (struct
+module Attribute_table = Stdlib.Hashtbl.Make (struct
   type t = string loc
 
   let hash : t -> int = Hashtbl.hash

--- a/src/caller_id.ml
+++ b/src/caller_id.ml
@@ -1,7 +1,7 @@
 (** Small helper to find out who is the caller of a function *)
 
 open! Import
-module Printexc = Caml.Printexc
+module Printexc = Stdlib.Printexc
 
 type t = Printexc.location option
 

--- a/src/code_matcher.ml
+++ b/src/code_matcher.ml
@@ -1,7 +1,7 @@
 (*$ open Ppxlib_cinaps_helpers $*)
 open! Import
-module Format = Caml.Format
-module Filename = Caml.Filename
+module Format = Stdlib.Format
+module Filename = Stdlib.Filename
 
 (* TODO: make the "deriving." depend on the matching attribute name. *)
 let end_marker_sig =
@@ -72,7 +72,9 @@ struct
 
   let diff_asts ~generated ~round_trip =
     let with_temp_file f =
-      Exn.protectx (Filename.temp_file "ppxlib" "") ~finally:Caml.Sys.remove ~f
+      Exn.protectx
+        (Filename.temp_file "ppxlib" "")
+        ~finally:Stdlib.Sys.remove ~f
     in
     with_temp_file (fun fn1 ->
         with_temp_file (fun fn2 ->
@@ -93,7 +95,7 @@ struct
                     (Filename.quote out)
                 in
                 let ok =
-                  Caml.Sys.command cmd = 1
+                  Stdlib.Sys.command cmd = 1
                   ||
                   let cmd =
                     Printf.sprintf
@@ -102,7 +104,7 @@ struct
                       (Filename.quote fn1) (Filename.quote fn2)
                       (Filename.quote out)
                   in
-                  Caml.Sys.command cmd = 1
+                  Stdlib.Sys.command cmd = 1
                 in
                 if ok then In_channel.read_all out
                 else "<no differences produced by diff>")))

--- a/src/code_path.ml
+++ b/src/code_path.ml
@@ -12,7 +12,7 @@ type t = {
 
 let top_level ~file_path =
   let main_module_name =
-    file_path |> Caml.Filename.basename |> Caml.Filename.remove_extension
+    file_path |> Stdlib.Filename.basename |> Stdlib.Filename.remove_extension
     |> String.capitalize_ascii
   in
   {

--- a/src/common.ml
+++ b/src/common.ml
@@ -1,7 +1,7 @@
 open! Import
 open Ast_builder.Default
-module Buffer = Caml.Buffer
-module Format = Caml.Format
+module Buffer = Stdlib.Buffer
+module Format = Stdlib.Format
 
 let lident x = Longident.Lident x
 

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -10,7 +10,7 @@ let keep_w32_intf = ref false
 
 let () =
   let keep_w32_spec =
-    Caml.Arg.Symbol
+    Stdlib.Arg.Symbol
       ( [ "impl"; "intf"; "both" ],
         function
         | "impl" -> keep_w32_impl := true
@@ -21,7 +21,7 @@ let () =
         | _ -> assert false )
   in
   let conv_w32_spec =
-    Caml.Arg.Symbol
+    Stdlib.Arg.Symbol
       ( [ "code"; "attribute" ],
         function
         | "code" -> do_insert_unused_warning_attribute := false
@@ -44,7 +44,7 @@ let keep_w60_intf = ref false
 
 let () =
   let keep_w60_spec =
-    Caml.Arg.Symbol
+    Stdlib.Arg.Symbol
       ( [ "impl"; "intf"; "both" ],
         function
         | "impl" -> keep_w60_impl := true

--- a/src/driver.mli
+++ b/src/driver.mli
@@ -6,7 +6,7 @@
 
 open Import
 
-val add_arg : Caml.Arg.key -> Caml.Arg.spec -> doc:string -> unit
+val add_arg : Stdlib.Arg.key -> Stdlib.Arg.spec -> doc:string -> unit
 (** Add one argument to the command line *)
 
 (** Error reported by linters *)

--- a/src/location.ml
+++ b/src/location.ml
@@ -34,7 +34,7 @@ let of_lexbuf (lexbuf : Lexing.lexbuf) =
   }
 
 let print ppf t =
-  Caml.Format.fprintf ppf "File \"%s\", line %d, characters %d-%d:"
+  Stdlib.Format.fprintf ppf "File \"%s\", line %d, characters %d-%d:"
     t.loc_start.pos_fname t.loc_start.pos_lnum
     (t.loc_start.pos_cnum - t.loc_start.pos_bol)
     (t.loc_end.pos_cnum - t.loc_start.pos_bol)
@@ -76,6 +76,6 @@ let error_extensionf ~loc fmt =
 exception Error = L.Error
 
 let () =
-  Caml.Printexc.register_printer (function
+  Stdlib.Printexc.register_printer (function
     | Error e -> Some (Error.message e)
     | _ -> None)

--- a/src/location.mli
+++ b/src/location.mli
@@ -27,7 +27,8 @@ val init : Lexing.lexbuf -> string -> unit
 (** Set the file name and line number of the [lexbuf] to be the start of the
     named file. *)
 
-val raise_errorf : ?loc:t -> ('a, Caml.Format.formatter, unit, 'b) format4 -> 'a
+val raise_errorf :
+  ?loc:t -> ('a, Stdlib.Format.formatter, unit, 'b) format4 -> 'a
 (** Raise a located error. Should be avoided as much as possible, in favor of
     {!error_extensionf}. See the {{!"good-practices".handling_errors} relevant}
     part of the tutorial. *)
@@ -35,10 +36,10 @@ val raise_errorf : ?loc:t -> ('a, Caml.Format.formatter, unit, 'b) format4 -> 'a
 val of_lexbuf : Lexing.lexbuf -> t
 (** Return the location corresponding to the last matched regular expression *)
 
-val report_exception : Caml.Format.formatter -> exn -> unit
+val report_exception : Stdlib.Format.formatter -> exn -> unit
 (** Report an exception on the given formatter *)
 
-val print : Caml.Format.formatter -> t -> unit
+val print : Stdlib.Format.formatter -> t -> unit
 (** Prints [File "...", line ..., characters ...-...:] *)
 
 type nonrec 'a loc = 'a loc = { txt : 'a; loc : t }
@@ -59,7 +60,7 @@ module Error : sig
   val make : loc:location -> string -> sub:(location * string) list -> t
 
   val createf :
-    loc:location -> ('a, Caml.Format.formatter, unit, t) format4 -> 'a
+    loc:location -> ('a, Stdlib.Format.formatter, unit, t) format4 -> 'a
 
   val message : t -> string
   val set_message : t -> string -> t

--- a/src/name.ml
+++ b/src/name.ml
@@ -1,5 +1,5 @@
 open! Import
-module Format = Caml.Format
+module Format = Stdlib.Format
 
 let fold_dot_suffixes name ~init:acc ~f =
   let rec collapse_after_at = function
@@ -218,7 +218,7 @@ module Registrar = struct
     | Some e ->
         let declared_at = function
           | None -> ""
-          | Some (loc : Caml.Printexc.location) ->
+          | Some (loc : Stdlib.Printexc.location) ->
               Printf.sprintf " declared at %s:%d" loc.filename loc.line_number
         in
         let context =

--- a/src/reconcile.ml
+++ b/src/reconcile.ml
@@ -6,9 +6,9 @@ module Context = struct
     | Extension of 'a Extension.Context.t
     | Floating_attribute of 'a Attribute.Floating.Context.t
 
-  let paren pp ppf x = Caml.Format.fprintf ppf "(%a)" pp x
+  let paren pp ppf x = Stdlib.Format.fprintf ppf "(%a)" pp x
 
-  let printer : type a. a t -> Caml.Format.formatter -> a -> unit =
+  let printer : type a. a t -> Stdlib.Format.formatter -> a -> unit =
     let open Extension.Context in
     let open Attribute.Floating.Context in
     function
@@ -51,13 +51,13 @@ module Replacement = struct
         let s =
           let printer = Context.printer context in
           match generated with
-          | Single x -> Caml.Format.asprintf "%a" printer x
+          | Single x -> Stdlib.Format.asprintf "%a" printer x
           | Many l ->
-              Caml.Format.asprintf "%a"
+              Stdlib.Format.asprintf "%a"
                 (fun ppf l ->
                   List.iter l ~f:(fun x ->
                       printer ppf x;
-                      Caml.Format.pp_print_newline ppf ()))
+                      Stdlib.Format.pp_print_newline ppf ()))
                 l
         in
         let is_ws = function ' ' | '\t' | '\r' -> true | _ -> false in
@@ -169,24 +169,24 @@ let with_output ~styler ~(kind : Kind.t) fn ~f =
   | None -> with_output fn ~binary:false ~f
   | Some cmd ->
       let tmp_fn, oc =
-        Caml.Filename.open_temp_file "ppxlib_driver"
+        Stdlib.Filename.open_temp_file "ppxlib_driver"
           (match kind with Impl -> ".ml" | Intf -> ".mli")
       in
       let cmd =
         Printf.sprintf "%s %s%s" cmd
-          (Caml.Filename.quote tmp_fn)
+          (Stdlib.Filename.quote tmp_fn)
           (match fn with
           | None -> ""
-          | Some fn -> " > " ^ Caml.Filename.quote fn)
+          | Some fn -> " > " ^ Stdlib.Filename.quote fn)
       in
       let n =
-        Exn.protectx tmp_fn ~finally:Caml.Sys.remove ~f:(fun _ ->
+        Exn.protectx tmp_fn ~finally:Stdlib.Sys.remove ~f:(fun _ ->
             Exn.protectx oc ~finally:close_out ~f;
-            Caml.Sys.command cmd)
+            Stdlib.Sys.command cmd)
       in
       if n <> 0 then (
         Printf.eprintf "command exited with code %d: %s\n" n cmd;
-        Caml.exit 1)
+        Stdlib.exit 1)
 
 let reconcile ?styler (repls : Replacements.t) ~kind ~contents ~input_filename
     ~output ~input_name ~target =

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -9,8 +9,8 @@ module Kind = struct
   type t = Intf | Impl
 
   let of_filename fn : t option =
-    if Caml.Filename.check_suffix fn ".ml" then Some Impl
-    else if Caml.Filename.check_suffix fn ".mli" then Some Intf
+    if Stdlib.Filename.check_suffix fn ".ml" then Some Impl
+    else if Stdlib.Filename.check_suffix fn ".mli" then Some Intf
     else None
 
   let describe = function Impl -> "implementation" | Intf -> "interface"
@@ -213,9 +213,9 @@ module System = struct
   let run_preprocessor ~pp ~input ~output =
     let command =
       Printf.sprintf "%s %s > %s" pp
-        (if String.equal input "-" then "" else Caml.Filename.quote input)
-        (Caml.Filename.quote output)
+        (if String.equal input "-" then "" else Stdlib.Filename.quote input)
+        (Stdlib.Filename.quote output)
     in
-    if Caml.Sys.command command = 0 then Ok ()
+    if Stdlib.Sys.command command = 0 then Ok ()
     else Error (command, Ast_io.fall_back_input_version)
 end

--- a/stdppx/stdppx.ml
+++ b/stdppx/stdppx.ml
@@ -1,3 +1,5 @@
+module Caml = Stdlib [@@deprecated "[since 2023-06] use Stdlib instead"]
+open Stdlib
 open StdLabels
 module Sexp = Sexplib0.Sexp
 module Sexpable = Sexplib0.Sexpable

--- a/stdppx/stdppx.ml
+++ b/stdppx/stdppx.ml
@@ -1,5 +1,3 @@
-module Caml = Stdlib
-open Caml
 open StdLabels
 module Sexp = Sexplib0.Sexp
 module Sexpable = Sexplib0.Sexpable

--- a/test/driver/transformations/test.ml
+++ b/test/driver/transformations/test.ml
@@ -56,17 +56,17 @@ let () =
 [%%expect{|
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop]
+let _ = Stdlib.Printf.sprintf "%s\n" [%plop]
 [%%expect{|
 - : string = "-\n"
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop.Truc]
+let _ = Stdlib.Printf.sprintf "%s\n" [%plop.Truc]
 [%%expect{|
 - : string = "Truc\n"
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop.Truc.Bidule]
+let _ = Stdlib.Printf.sprintf "%s\n" [%plop.Truc.Bidule]
 [%%expect{|
 - : string = "Truc.Bidule\n"
 |}]
@@ -89,17 +89,17 @@ let () =
 [%%expect{|
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt]
+let _ = Stdlib.Printf.sprintf "%s\n" [%plop_ctxt]
 [%%expect{|
 - : string = "-\n"
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt.Truc]
+let _ = Stdlib.Printf.sprintf "%s\n" [%plop_ctxt.Truc]
 [%%expect{|
 - : string = "Truc\n"
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt.Truc.Bidule]
+let _ = Stdlib.Printf.sprintf "%s\n" [%plop_ctxt.Truc.Bidule]
 [%%expect{|
 - : string = "Truc.Bidule\n"
 |}]

--- a/test/driver/transformations/test_412.ml
+++ b/test/driver/transformations/test_412.ml
@@ -56,17 +56,17 @@ let () =
 [%%expect{|
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop]
+let _ = Stdlib.Printf.sprintf "%s\n" [%plop]
 [%%expect{|
 - : string = "-\n"
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop.Truc]
+let _ = Stdlib.Printf.sprintf "%s\n" [%plop.Truc]
 [%%expect{|
 - : string = "Truc\n"
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop.Truc.Bidule]
+let _ = Stdlib.Printf.sprintf "%s\n" [%plop.Truc.Bidule]
 [%%expect{|
 - : string = "Truc.Bidule\n"
 |}]
@@ -89,17 +89,17 @@ let () =
 [%%expect{|
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt]
+let _ = Stdlib.Printf.sprintf "%s\n" [%plop_ctxt]
 [%%expect{|
 - : string = "-\n"
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt.Truc]
+let _ = Stdlib.Printf.sprintf "%s\n" [%plop_ctxt.Truc]
 [%%expect{|
 - : string = "Truc\n"
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt.Truc.Bidule]
+let _ = Stdlib.Printf.sprintf "%s\n" [%plop_ctxt.Truc.Bidule]
 [%%expect{|
 - : string = "Truc.Bidule\n"
 |}]

--- a/test/driver/transformations/test_510.ml
+++ b/test/driver/transformations/test_510.ml
@@ -56,19 +56,19 @@ let () =
 [%%expect{|
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop]
+let _ = Stdlib.Printf.sprintf "%s\n" [%plop]
 [%%expect{|
 
 - : string = "-\n"
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop.Truc]
+let _ = Stdlib.Printf.sprintf "%s\n" [%plop.Truc]
 [%%expect{|
 
 - : string = "Truc\n"
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop.Truc.Bidule]
+let _ = Stdlib.Printf.sprintf "%s\n" [%plop.Truc.Bidule]
 [%%expect{|
 
 - : string = "Truc.Bidule\n"
@@ -92,19 +92,19 @@ let () =
 [%%expect{|
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt]
+let _ = Stdlib.Printf.sprintf "%s\n" [%plop_ctxt]
 [%%expect{|
 
 - : string = "-\n"
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt.Truc]
+let _ = Stdlib.Printf.sprintf "%s\n" [%plop_ctxt.Truc]
 [%%expect{|
 
 - : string = "Truc\n"
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt.Truc.Bidule]
+let _ = Stdlib.Printf.sprintf "%s\n" [%plop_ctxt.Truc.Bidule]
 [%%expect{|
 
 - : string = "Truc.Bidule\n"


### PR DESCRIPTION
Use `Stdlib` instead of the now-unnecessary alias `Caml`.