### PR TITLE
Add Extension.V3.declare_with_path_arg

### DIFF
--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -36,6 +36,8 @@ test/driver/attributes/test_510.ml
 test/driver/instrument/test.ml
 test/driver/non-compressible-suffix/test.ml
 test/driver/transformations/test.ml
+test/driver/transformations/test_412.ml
+test/driver/transformations/test_510.ml
 test/expand-header-and-footer/test.ml
 test/expansion_helpers/mangle/test.ml
 test/expansion_inside_payloads/test.ml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+unreleased
+-------------------
+
+- Restore the "path_arg" functionality in the V3 API as "additional_arg" (#431, @ELLIOTTCABLE)
+
 0.30.0 (20/06/2023)
 -------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 unreleased
 -------------------
 
-- Restore the "path_arg" functionality in the V3 API as "additional_arg" (#431, @ELLIOTTCABLE)
+- Restore the "path_arg" functionality in the V3 API (#431, @ELLIOTTCABLE)
 
 0.30.0 (20/06/2023)
 -------------------

--- a/src/extension.ml
+++ b/src/extension.ml
@@ -452,19 +452,19 @@ module V3 = struct
            k ~ctxt))
 
   let declare_inline name context pattern k =
-    check_context_for_inline context ~func:"Extension.declare_inline";
+    check_context_for_inline context ~func:"Extension.V3.declare_inline";
     let pattern = Ast_pattern.map_result pattern ~f:(fun x -> Inline x) in
     T
       (M.declare ~with_arg:false name context pattern (fun ~ctxt ~arg:_ ->
            k ~ctxt))
 
-  let declare_with_path_arg name context pattern k =
+  let declare_with_additional_arg name context pattern k =
     let pattern = Ast_pattern.map_result pattern ~f:(fun x -> Simple x) in
     T (M.declare ~with_arg:true name context pattern k)
 
-  let declare_inline_with_path_arg name context pattern k =
+  let declare_inline_with_additional_arg name context pattern k =
     check_context_for_inline context
-      ~func:"Extension.declare_inline_with_path_arg";
+      ~func:"Extension.V3.declare_inline_with_additional_arg";
     let pattern = Ast_pattern.map_result pattern ~f:(fun x -> Inline x) in
     T (M.declare ~with_arg:true name context pattern k)
 end

--- a/src/extension.ml
+++ b/src/extension.ml
@@ -452,19 +452,19 @@ module V3 = struct
            k ~ctxt))
 
   let declare_inline name context pattern k =
-    check_context_for_inline context ~func:"Extension.V3.declare_inline";
+    check_context_for_inline context ~func:"Extension.declare_inline";
     let pattern = Ast_pattern.map_result pattern ~f:(fun x -> Inline x) in
     T
       (M.declare ~with_arg:false name context pattern (fun ~ctxt ~arg:_ ->
            k ~ctxt))
 
-  let declare_with_additional_arg name context pattern k =
+  let declare_with_path_arg name context pattern k =
     let pattern = Ast_pattern.map_result pattern ~f:(fun x -> Simple x) in
     T (M.declare ~with_arg:true name context pattern k)
 
-  let declare_inline_with_additional_arg name context pattern k =
+  let declare_inline_with_path_arg name context pattern k =
     check_context_for_inline context
-      ~func:"Extension.V3.declare_inline_with_additional_arg";
+      ~func:"Extension.declare_inline_with_path_arg";
     let pattern = Ast_pattern.map_result pattern ~f:(fun x -> Inline x) in
     T (M.declare ~with_arg:true name context pattern k)
 end

--- a/src/extension.ml
+++ b/src/extension.ml
@@ -457,6 +457,16 @@ module V3 = struct
     T
       (M.declare ~with_arg:false name context pattern (fun ~ctxt ~arg:_ ->
            k ~ctxt))
+
+  let declare_with_path_arg name context pattern k =
+    let pattern = Ast_pattern.map_result pattern ~f:(fun x -> Simple x) in
+    T (M.declare ~with_arg:true name context pattern k)
+
+  let declare_inline_with_path_arg name context pattern k =
+    check_context_for_inline context
+      ~func:"Extension.declare_inline_with_path_arg";
+    let pattern = Ast_pattern.map_result pattern ~f:(fun x -> Inline x) in
+    T (M.declare ~with_arg:true name context pattern k)
 end
 
 let declare name context pattern f =

--- a/src/extension.mli
+++ b/src/extension.mli
@@ -72,10 +72,7 @@ val declare_with_path_arg :
     {[
       let%map.Foo.Bar x = 1 in
       ...
-    ]}
-
-    (In V3, this has been renamed to
-    {!Extension.V3.declare_with_additional_arg}.) *)
+    ]} *)
 
 val declare_inline :
   string ->
@@ -201,7 +198,7 @@ module V3 : sig
     (ctxt:Expansion_context.Extension.t -> 'a) ->
     t
 
-  val declare_with_additional_arg :
+  val declare_with_path_arg :
     string ->
     'context Context.t ->
     (payload, 'a, 'context) Ast_pattern.t ->
@@ -209,20 +206,17 @@ module V3 : sig
     arg:Longident.t Asttypes.loc option ->
     'a) ->
     t
-  (** Same as [declare] except that the extension name takes an additional
-      argument. This argument is the part of the name that start with a
-      capitalized component. For instance in the following, the extension
-      ["map"] would receive the additional argument [Foo.Bar]:
+  (** Same as [declare] except that the extension name takes an additional path
+      argument. The path is the part of the name that start with a capitalized
+      component. For instance in the following, the extension ["map"] would
+      receive the path argument [Foo.Bar]:
 
       {[
         let%map.Foo.Bar x = 1 in
         ...
-      ]}
+      ]} *)
 
-      (This was previously known as a "path_arg", but was renamed for V3 for
-      clarity and to disambiguate from the [code_path].) *)
-
-  val declare_inline_with_additional_arg :
+  val declare_inline_with_path_arg :
     string ->
     'context Context.t ->
     (payload, 'a, 'context list) Ast_pattern.t ->

--- a/src/extension.mli
+++ b/src/extension.mli
@@ -72,7 +72,10 @@ val declare_with_path_arg :
     {[
       let%map.Foo.Bar x = 1 in
       ...
-    ]} *)
+    ]}
+
+    (In V3, this has been renamed to
+    {!Extension.V3.declare_with_additional_arg}.) *)
 
 val declare_inline :
   string ->
@@ -198,7 +201,7 @@ module V3 : sig
     (ctxt:Expansion_context.Extension.t -> 'a) ->
     t
 
-  val declare_with_path_arg :
+  val declare_with_additional_arg :
     string ->
     'context Context.t ->
     (payload, 'a, 'context) Ast_pattern.t ->
@@ -206,17 +209,20 @@ module V3 : sig
     arg:Longident.t Asttypes.loc option ->
     'a) ->
     t
-  (** Same as [declare] except that the extension name takes an additional path
-      argument. The path is the part of the name that start with a capitalized
-      component. For instance in the following, the extension ["map"] would
-      receive the path argument [Foo.Bar]:
+  (** Same as [declare] except that the extension name takes an additional
+      argument. This argument is the part of the name that start with a
+      capitalized component. For instance in the following, the extension
+      ["map"] would receive the additional argument [Foo.Bar]:
 
       {[
         let%map.Foo.Bar x = 1 in
         ...
-      ]} *)
+      ]}
 
-  val declare_inline_with_path_arg :
+      (This was previously known as a "path_arg", but was renamed for V3 for
+      clarity and to disambiguate from the [code_path].) *)
+
+  val declare_inline_with_additional_arg :
     string ->
     'context Context.t ->
     (payload, 'a, 'context list) Ast_pattern.t ->

--- a/src/extension.mli
+++ b/src/extension.mli
@@ -197,6 +197,33 @@ module V3 : sig
     (payload, 'a, 'context list) Ast_pattern.t ->
     (ctxt:Expansion_context.Extension.t -> 'a) ->
     t
+
+  val declare_with_path_arg :
+    string ->
+    'context Context.t ->
+    (payload, 'a, 'context) Ast_pattern.t ->
+    (ctxt:Expansion_context.Extension.t ->
+    arg:Longident.t Asttypes.loc option ->
+    'a) ->
+    t
+  (** Same as [declare] except that the extension name takes an additional path
+      argument. The path is the part of the name that start with a capitalized
+      component. For instance in the following, the extension ["map"] would
+      receive the path argument [Foo.Bar]:
+
+      {[
+        let%map.Foo.Bar x = 1 in
+        ...
+      ]} *)
+
+  val declare_inline_with_path_arg :
+    string ->
+    'context Context.t ->
+    (payload, 'a, 'context list) Ast_pattern.t ->
+    (ctxt:Expansion_context.Extension.t ->
+    arg:Longident.t Asttypes.loc option ->
+    'a) ->
+    t
 end
 
 (**/**)

--- a/test/driver/transformations/dune
+++ b/test/driver/transformations/dune
@@ -1,3 +1,5 @@
+; The error-reporting format changed in 4.12; thus the expect-tests need to be duplicated
+
 (rule
  (alias runtest)
  (enabled_if
@@ -13,3 +15,21 @@
    (progn
     (run expect-test %{test})
     (diff? %{test} %{test}.corrected)))))
+
+(rule
+ (alias runtest)
+ (enabled_if
+  (>= %{ocaml_version} "4.12.0"))
+ (deps
+  (:test test.ml)
+  (:t test_412.ml)
+  (package ppxlib))
+ (action
+  (chdir
+   %{project_root}
+   (progn
+    (run mv %{t} %{t}.old)
+    (run cp %{test} %{t})
+    (run expect-test %{t})
+    (run mv %{t}.old %{t})
+    (diff? %{t} %{t}.corrected)))))

--- a/test/driver/transformations/dune
+++ b/test/driver/transformations/dune
@@ -19,10 +19,30 @@
 (rule
  (alias runtest)
  (enabled_if
-  (>= %{ocaml_version} "4.12.0"))
+  (and
+   (>= %{ocaml_version} "4.12.0")
+   (< %{ocaml_version} "5.1.0")))
  (deps
   (:test test.ml)
   (:t test_412.ml)
+  (package ppxlib))
+ (action
+  (chdir
+   %{project_root}
+   (progn
+    (run mv %{t} %{t}.old)
+    (run cp %{test} %{t})
+    (run expect-test %{t})
+    (run mv %{t}.old %{t})
+    (diff? %{t} %{t}.corrected)))))
+
+(rule
+ (alias runtest)
+ (enabled_if
+  (>= %{ocaml_version} "5.1.0"))
+ (deps
+  (:test test.ml)
+  (:t test_510.ml)
   (package ppxlib))
  (action
   (chdir

--- a/test/driver/transformations/test.ml
+++ b/test/driver/transformations/test.ml
@@ -72,12 +72,12 @@ let _ = Caml.Printf.sprintf "%s\n" [%plop.Truc.Bidule]
 |}]
 
 
-(* Extension with a path argument and cxtx *)
+(* Extension with a path argument and ctxt *)
 
 let () =
-  Driver.register_transformation "plop"
+  Driver.register_transformation "plop_ctxt"
     ~rules:[Context_free.Rule.extension
-              (Extension.V3.declare_with_path_arg "plop"
+              (Extension.V3.declare_with_path_arg "plop_ctxt"
                  Expression
                  Ast_pattern.(pstr nil)
                  (fun ~ctxt ~arg ->
@@ -89,17 +89,18 @@ let () =
 [%%expect{|
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop]
+let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt]
+[%%expect{|
 [%%expect{|
 - : string = "-\n"
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop.Truc]
+let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt.Truc]
 [%%expect{|
 - : string = "Truc\n"
 |}]
 
-let _ = Caml.Printf.sprintf "%s\n" [%plop.Truc.Bidule]
+let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt.Truc.Bidule]
 [%%expect{|
 - : string = "Truc.Bidule\n"
 |}]

--- a/test/driver/transformations/test.ml
+++ b/test/driver/transformations/test.ml
@@ -70,3 +70,36 @@ let _ = Caml.Printf.sprintf "%s\n" [%plop.Truc.Bidule]
 [%%expect{|
 - : string = "Truc.Bidule\n"
 |}]
+
+
+(* Extension with a path argument and cxtx *)
+
+let () =
+  Driver.register_transformation "plop"
+    ~rules:[Context_free.Rule.extension
+              (Extension.V3.declare_with_path_arg "plop"
+                 Expression
+                 Ast_pattern.(pstr nil)
+                 (fun ~ctxt ~arg ->
+                    let open Ast_builder.Default in
+                    let loc = Expansion_context.Extension.extension_point_loc ctxt in
+                    match arg with
+                    | None -> estring ~loc "-"
+                    | Some { loc; txt } -> estring ~loc (Longident.name txt)))]
+[%%expect{|
+|}]
+
+let _ = Caml.Printf.sprintf "%s\n" [%plop]
+[%%expect{|
+- : string = "-\n"
+|}]
+
+let _ = Caml.Printf.sprintf "%s\n" [%plop.Truc]
+[%%expect{|
+- : string = "Truc\n"
+|}]
+
+let _ = Caml.Printf.sprintf "%s\n" [%plop.Truc.Bidule]
+[%%expect{|
+- : string = "Truc.Bidule\n"
+|}]

--- a/test/driver/transformations/test.ml
+++ b/test/driver/transformations/test.ml
@@ -91,7 +91,6 @@ let () =
 
 let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt]
 [%%expect{|
-[%%expect{|
 - : string = "-\n"
 |}]
 

--- a/test/driver/transformations/test_412.ml
+++ b/test/driver/transformations/test_412.ml
@@ -1,0 +1,105 @@
+#require "base";;
+
+open Stdppx
+open Ppxlib
+
+
+(* Linters *)
+
+let lint = object
+  inherit [Driver.Lint_error.t list] Ast_traverse.fold as super
+
+  method! type_declaration td acc =
+    let acc = super#type_declaration td acc in
+    match td.ptype_kind with
+    | Ptype_record lds ->
+      if Poly.(<>)
+           (List.sort lds ~cmp:(fun a b -> String.compare a.pld_name.txt b.pld_name.txt))
+           lds
+      then
+        Driver.Lint_error.of_string { td.ptype_loc with loc_ghost = true }
+          "Fields are not sorted!"
+        :: acc
+      else
+        acc
+    | _ -> acc
+end
+let () =
+  Driver.register_transformation "lint" ~lint_impl:(fun st -> lint#structure st [])
+[%%expect{|
+val lint : Driver.Lint_error.t list Ast_traverse.fold = <obj>
+|}]
+
+type t =
+  { b : int
+  ; a : int
+  }
+[%%expect{|
+Line _, characters 0-36:
+Error (warning 22 [preprocessor]): Fields are not sorted!
+|}]
+
+
+(* Extension with a path argument *)
+
+let () =
+  Driver.register_transformation "plop"
+    ~rules:[Context_free.Rule.extension
+              (Extension.declare_with_path_arg "plop"
+                 Expression
+                 Ast_pattern.(pstr nil)
+                 (fun ~loc ~path:_ ~arg ->
+                    let open Ast_builder.Default in
+                    match arg with
+                    | None -> estring ~loc "-"
+                    | Some { loc; txt } -> estring ~loc (Longident.name txt)))]
+[%%expect{|
+|}]
+
+let _ = Caml.Printf.sprintf "%s\n" [%plop]
+[%%expect{|
+- : string = "-\n"
+|}]
+
+let _ = Caml.Printf.sprintf "%s\n" [%plop.Truc]
+[%%expect{|
+- : string = "Truc\n"
+|}]
+
+let _ = Caml.Printf.sprintf "%s\n" [%plop.Truc.Bidule]
+[%%expect{|
+- : string = "Truc.Bidule\n"
+|}]
+
+
+(* Extension with a path argument and ctxt *)
+
+let () =
+  Driver.register_transformation "plop_ctxt"
+    ~rules:[Context_free.Rule.extension
+              (Extension.V3.declare_with_path_arg "plop_ctxt"
+                 Expression
+                 Ast_pattern.(pstr nil)
+                 (fun ~ctxt ~arg ->
+                    let open Ast_builder.Default in
+                    let loc = Expansion_context.Extension.extension_point_loc ctxt in
+                    match arg with
+                    | None -> estring ~loc "-"
+                    | Some { loc; txt } -> estring ~loc (Longident.name txt)))]
+[%%expect{|
+|}]
+
+let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt]
+[%%expect{|
+- : string = "-\n"
+|}]
+
+let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt.Truc]
+[%%expect{|
+- : string = "Truc\n"
+|}]
+
+let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt.Truc.Bidule]
+[%%expect{|
+- : string = "Truc.Bidule\n"
+|}]

--- a/test/driver/transformations/test_510.ml
+++ b/test/driver/transformations/test_510.ml
@@ -69,8 +69,8 @@ let _ = Caml.Printf.sprintf "%s\n" [%plop.Truc]
 |}]
 
 let _ = Caml.Printf.sprintf "%s\n" [%plop.Truc.Bidule]
-
 [%%expect{|
+
 - : string = "Truc.Bidule\n"
 |}]
 

--- a/test/driver/transformations/test_510.ml
+++ b/test/driver/transformations/test_510.ml
@@ -1,0 +1,111 @@
+#require "base";;
+
+open Stdppx
+open Ppxlib
+
+
+(* Linters *)
+
+let lint = object
+  inherit [Driver.Lint_error.t list] Ast_traverse.fold as super
+
+  method! type_declaration td acc =
+    let acc = super#type_declaration td acc in
+    match td.ptype_kind with
+    | Ptype_record lds ->
+      if Poly.(<>)
+           (List.sort lds ~cmp:(fun a b -> String.compare a.pld_name.txt b.pld_name.txt))
+           lds
+      then
+        Driver.Lint_error.of_string { td.ptype_loc with loc_ghost = true }
+          "Fields are not sorted!"
+        :: acc
+      else
+        acc
+    | _ -> acc
+end
+let () =
+  Driver.register_transformation "lint" ~lint_impl:(fun st -> lint#structure st [])
+[%%expect{|
+val lint : Driver.Lint_error.t list Ast_traverse.fold = <obj>
+|}]
+
+type t =
+  { b : int
+  ; a : int
+  }
+[%%expect{|
+Line _, characters 0-36:
+Error (warning 22 [preprocessor]): Fields are not sorted!
+|}]
+
+
+(* Extension with a path argument *)
+
+let () =
+  Driver.register_transformation "plop"
+    ~rules:[Context_free.Rule.extension
+              (Extension.declare_with_path_arg "plop"
+                 Expression
+                 Ast_pattern.(pstr nil)
+                 (fun ~loc ~path:_ ~arg ->
+                    let open Ast_builder.Default in
+                    match arg with
+                    | None -> estring ~loc "-"
+                    | Some { loc; txt } -> estring ~loc (Longident.name txt)))]
+[%%expect{|
+|}]
+
+let _ = Caml.Printf.sprintf "%s\n" [%plop]
+[%%expect{|
+
+- : string = "-\n"
+|}]
+
+let _ = Caml.Printf.sprintf "%s\n" [%plop.Truc]
+[%%expect{|
+
+- : string = "Truc\n"
+|}]
+
+let _ = Caml.Printf.sprintf "%s\n" [%plop.Truc.Bidule]
+
+[%%expect{|
+- : string = "Truc.Bidule\n"
+|}]
+
+
+(* Extension with a path argument and ctxt *)
+
+let () =
+  Driver.register_transformation "plop_ctxt"
+    ~rules:[Context_free.Rule.extension
+              (Extension.V3.declare_with_path_arg "plop_ctxt"
+                 Expression
+                 Ast_pattern.(pstr nil)
+                 (fun ~ctxt ~arg ->
+                    let open Ast_builder.Default in
+                    let loc = Expansion_context.Extension.extension_point_loc ctxt in
+                    match arg with
+                    | None -> estring ~loc "-"
+                    | Some { loc; txt } -> estring ~loc (Longident.name txt)))]
+[%%expect{|
+|}]
+
+let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt]
+[%%expect{|
+
+- : string = "-\n"
+|}]
+
+let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt.Truc]
+[%%expect{|
+
+- : string = "Truc\n"
+|}]
+
+let _ = Caml.Printf.sprintf "%s\n" [%plop_ctxt.Truc.Bidule]
+[%%expect{|
+
+- : string = "Truc.Bidule\n"
+|}]


### PR DESCRIPTION
Seems like an oversight in the new API; came up in [this Discuss thread](https://discuss.ocaml.org/t/in-ppx-rewriters-producing-the-fully-qualified-module-name-of-an-annotated-binding/12450/9?u=elliottcable).

`make` builds; `make test` passes. However, `make test` passes _no matter what I do_. Can't verify that my added test actually passes — but it's a trivial addition, it _should_ be "if it compiles, it works." 🙈 

(Could use a `CONTRIBUTING` section in the README with instructions as to how to build/test/PR, etc. hahaha.)