### PR TITLE
Added ?warning flag to Deriving.Generator.make to enable warnings in derived code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 0.30.0 (20/06/2023)
 -------------------
 
+- Add `?warning` flag to `Deriving.Generator.make`. (#440, @jacksonzou123 via @ceastlund)
+
 - Adopt the OCaml Code of Conduct on the repo (#426, @pitag-ha)
 
 - Clean up misleading attribute hints when declared for proper context. (#425, @ceastlund)

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -610,6 +610,7 @@ let inline_doc_attr =
     attr_loc = loc;
   }
 
+(* wrap a structure in extra attributes *)
 let wrap_str ~loc ~hide st =
   let include_infos = include_infos ~loc (pmod_structure ~loc st) in
   let pincl_attributes =
@@ -618,6 +619,7 @@ let wrap_str ~loc ~hide st =
   in
   [ pstr_include ~loc { include_infos with pincl_attributes } ]
 
+(* decide what to wrap a structure in, then call above [wrap_str] *)
 let wrap_str ~loc ~hide ~unused_code_warnings st =
   let loc = { loc with loc_ghost = true } in
   let warnings, st =
@@ -639,11 +641,13 @@ let wrap_str ~loc ~hide ~unused_code_warnings st =
   in
   if wrap then wrap_str ~loc ~hide st else st
 
+(* wrap blocks that share [unused_code_warnings], using above [wrap_str] above *)
 let wrap_str ~loc ~hide list =
   List.concat_map list ~f:(fun { items; unused_code_warnings } ->
       if List.is_empty items then []
       else wrap_str ~loc ~hide ~unused_code_warnings items)
 
+(* wrap a signature in extra attributes *)
 let wrap_sig ~loc ~hide st =
   let include_infos = include_infos ~loc (pmty_signature ~loc st) in
   let pincl_attributes =
@@ -652,6 +656,7 @@ let wrap_sig ~loc ~hide st =
   in
   [ psig_include ~loc { include_infos with pincl_attributes } ]
 
+(* decide what to wrap a signature in, then call above [wrap_sig] *)
 let wrap_sig ~loc ~hide ~unused_code_warnings sg =
   let loc = { loc with loc_ghost = true } in
   let warnings =
@@ -671,6 +676,7 @@ let wrap_sig ~loc ~hide ~unused_code_warnings sg =
   in
   if wrap then wrap_sig ~loc ~hide sg else sg
 
+(* wrap blocks that share [unused_code_warnings], using above [wrap_sig] above *)
 let wrap_sig ~loc ~hide list =
   List.concat_map list ~f:(fun { items; unused_code_warnings } ->
       if List.is_empty items then []

--- a/src/deriving.mli
+++ b/src/deriving.mli
@@ -48,6 +48,7 @@ module Generator : sig
   val make :
     ?attributes:Attribute.packed list (* deprecated, unused *) ->
     ?deps:deriver list ->
+    ?unused_code_warnings:bool ->
     ('f, 'output_ast) Args.t ->
     (loc:Location.t -> path:string -> 'input_ast -> 'f) ->
     ('output_ast, 'input_ast) t
@@ -57,11 +58,16 @@ module Generator : sig
       [deps] is a list of derivers that this generator depends on.
 
       [attributes] is deprecated and unused. It is only kept for backward
-      compatibility. *)
+      compatibility.
+
+      [unused_code_warning] controls whether unused code warnings (e.g. warnings
+      32 and 60) are enabled or suppressed in emitted code. Default is [false],
+      which suppresses the warnings. *)
 
   val make_noarg :
     ?attributes:Attribute.packed list (* deprecated, unused *) ->
     ?deps:deriver list ->
+    ?unused_code_warnings:bool ->
     (loc:Location.t -> path:string -> 'input_ast -> 'output_ast) ->
     ('output_ast, 'input_ast) t
   (** Same as {!make}, but without arguments. *)
@@ -70,6 +76,7 @@ module Generator : sig
     val make :
       ?attributes:Attribute.packed list (* deprecated, unused *) ->
       ?deps:deriver list ->
+      ?unused_code_warnings:bool ->
       ('f, 'output_ast) Args.t ->
       (ctxt:Expansion_context.Deriver.t -> 'input_ast -> 'f) ->
       ('output_ast, 'input_ast) t
@@ -79,6 +86,7 @@ module Generator : sig
     val make_noarg :
       ?attributes:Attribute.packed list (* deprecated, unused *) ->
       ?deps:deriver list ->
+      ?unused_code_warnings:bool ->
       (ctxt:Expansion_context.Deriver.t -> 'input_ast -> 'output_ast) ->
       ('output_ast, 'input_ast) t
     (** Same as {!Generator.make_noarg}, but the generator has access to an

--- a/test/deriving_warning/dune
+++ b/test/deriving_warning/dune
@@ -1,0 +1,4 @@
+(library
+ (name ppx_warning_flags_testing_on_tests)
+ (preprocess
+  (pps ppx_warning_flags_testing)))

--- a/test/deriving_warning/ppx/dune
+++ b/test/deriving_warning/ppx/dune
@@ -1,0 +1,6 @@
+(library
+ (name ppx_warning_flags_testing)
+ (kind ppx_deriver)
+ (libraries ppxlib)
+ (preprocess
+  (pps ppxlib.metaquot)))

--- a/test/deriving_warning/ppx/ppx_warning_flags.ml
+++ b/test/deriving_warning/ppx/ppx_warning_flags.ml
@@ -1,0 +1,95 @@
+open Ppxlib
+
+let () =
+  let unused_code_warnings = true in
+  Deriving.add "zero_do_warn"
+    ~str_type_decl:
+      (Deriving.Generator.make_noarg ~unused_code_warnings
+         (fun ~loc ~path:_ _ ->
+           [%str
+             module Zero = struct
+               type t = T0
+             end
+
+             let zero = Zero.T0]))
+    ~sig_type_decl:
+      (Deriving.Generator.make_noarg ~unused_code_warnings
+         (fun ~loc ~path:_ _ ->
+           [%sig:
+             module Zero : sig
+               type t
+             end
+
+             val zero : Zero.t]))
+  |> Deriving.ignore
+
+let () =
+  let unused_code_warnings = false in
+  Deriving.add "one_no_warn"
+    ~str_type_decl:
+      (Deriving.Generator.make_noarg ~unused_code_warnings
+         (fun ~loc ~path:_ _ ->
+           [%str
+             module One = struct
+               type 'a t = T1 of 'a
+             end
+
+             let one = One.T1 zero]))
+    ~sig_type_decl:
+      (Deriving.Generator.make_noarg ~unused_code_warnings
+         (fun ~loc ~path:_ _ ->
+           [%sig:
+             module One : sig
+               type 'a t
+             end
+
+             val one : Zero.t One.t]))
+  |> Deriving.ignore
+
+let () =
+  let unused_code_warnings = true in
+  Deriving.add "two_do_warn"
+    ~str_type_decl:
+      (Deriving.Generator.make_noarg ~unused_code_warnings
+         (fun ~loc ~path:_ _ ->
+           [%str
+             module Two = struct
+               type ('a, 'b) t = T2 of 'a * 'b
+             end
+
+             let two = Two.T2 (zero, one)]))
+    ~sig_type_decl:
+      (Deriving.Generator.make_noarg ~unused_code_warnings
+         (fun ~loc ~path:_ _ ->
+           [%sig:
+             module Two : sig
+               type ('a, 'b) t
+             end
+
+             val two : (Zero.t, Zero.t One.t) Two.t]))
+  |> Deriving.ignore
+
+let () =
+  let alias_do_warn =
+    let unused_code_warnings = true in
+    Deriving.add "alias_do_warn"
+      ~str_type_decl:
+        (Deriving.Generator.make_noarg ~unused_code_warnings
+           (fun ~loc ~path:_ _ -> [%str let unit_one = ()]))
+      ~sig_type_decl:
+        (Deriving.Generator.make_noarg ~unused_code_warnings
+           (fun ~loc ~path:_ _ -> [%sig: val unit_one : unit]))
+  in
+  let alias_no_warn =
+    let unused_code_warnings = false in
+    Deriving.add "alias_no_warn"
+      ~str_type_decl:
+        (Deriving.Generator.make_noarg ~unused_code_warnings
+           (fun ~loc ~path:_ _ -> [%str let unit_two = unit_one]))
+      ~sig_type_decl:
+        (Deriving.Generator.make_noarg ~unused_code_warnings
+           (fun ~loc ~path:_ _ -> [%sig: val unit_two : unit]))
+  in
+  (* The derivers are added from right to left *)
+  Deriving.add_alias "alias_warn" [ alias_no_warn; alias_do_warn ]
+  |> Deriving.ignore

--- a/test/deriving_warning/ppx/ppx_warning_flags.mli
+++ b/test/deriving_warning/ppx/ppx_warning_flags.mli
@@ -1,0 +1,1 @@
+(*_ This signature is deliberately empty. *)

--- a/test/deriving_warning/ppx_warning_flags_test.ml
+++ b/test/deriving_warning/ppx_warning_flags_test.ml
@@ -1,0 +1,37 @@
+type t = int [@@deriving_inline zero_do_warn, one_no_warn, two_do_warn]
+
+let _ = fun (_ : t) -> ()
+
+module Zero = struct
+  type t = T0
+end
+
+let zero = Zero.T0
+
+include struct
+  [@@@ocaml.warning "-60"]
+
+  module One = struct
+    type 'a t = T1 of 'a
+  end
+
+  let one = One.T1 zero
+  let _ = one
+end [@@ocaml.doc "@inline"]
+
+module Two = struct
+  type ('a, 'b) t = T2 of 'a * 'b
+end
+
+let two = Two.T2 (zero, one)
+
+[@@@end]
+
+type s = int [@@deriving_inline alias_warn]
+
+let _ = fun (_ : s) -> ()
+let unit_one = ()
+let unit_two = unit_one
+let _ = unit_two
+
+[@@@end]

--- a/test/deriving_warning/ppx_warning_flags_test.mli
+++ b/test/deriving_warning/ppx_warning_flags_test.mli
@@ -1,0 +1,39 @@
+type t [@@deriving_inline zero_do_warn, one_no_warn, two_do_warn]
+
+module Zero : sig
+  type t
+end
+
+val zero : Zero.t
+
+include sig
+  [@@@ocaml.warning "-32-60"]
+
+  module One : sig
+    type 'a t
+  end
+
+  val one : Zero.t One.t
+end
+[@@ocaml.doc "@inline"]
+
+module Two : sig
+  type ('a, 'b) t
+end
+
+val two : (Zero.t, Zero.t One.t) Two.t
+
+[@@@end]
+
+type s = int [@@deriving_inline alias_warn]
+
+val unit_one : unit
+
+include sig
+  [@@@ocaml.warning "-32"]
+
+  val unit_two : unit
+end
+[@@ocaml.doc "@inline"]
+
+[@@@end]


### PR DESCRIPTION
Adds the ability for ppx derivers to opt in to unused code warnings, which ppxlib would otherwise disable for derived code. This will help, over time, clean up unused code from derivers.

We made this property opt-in because currently, many ppxes are not compatible with these warnings. For example, `ppx_hash` derives `hash` and `hash_fold_t`. If one were used and not the other, there's no way to derive "half" of the ppx. So we can't opt `ppx_hash` in until we have a way to request it piecemeal. Over time, we'll have to make more ppxes compatible with this option in order to clean up unused code.