### PR TITLE
Preserve quoted attributes on antiquoted payloads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ unreleased
 
 - Expose migration/copying/etc. functions for all AST types needed by `Pprintast` (#454, @antalsz)
 
+- Preserve quoted attributes on antiquotes in metaquot (#441, @ncik-roberts)
+
 0.30.0 (20/06/2023)
 -------------------
 

--- a/metaquot/dune
+++ b/metaquot/dune
@@ -4,5 +4,5 @@
  (kind ppx_rewriter)
  (flags
   (:standard -safe-string))
- (libraries ppxlib ppxlib_traverse_builtins ppxlib_metaquot_lifters)
+ (libraries astlib ppxlib ppxlib_traverse_builtins ppxlib_metaquot_lifters)
  (ppx_runtime_libraries ppxlib_ast))

--- a/metaquot/ppxlib_metaquot.ml
+++ b/metaquot/ppxlib_metaquot.ml
@@ -239,10 +239,6 @@ module Patt = Make (struct
         (match attrs with
         | None -> ()
         | Some { quoted_attributes; field_name = _ } ->
-            (* We can't construct a pattern that searches for [quoted_attributes]
-               at the end of [p]'s attribute list -- the pattern language isn't
-               expressive enough. Instead, we fail.
-            *)
             assert_no_attributes quoted_attributes);
         self#typed p type_name
     | PPat (_, Some e) ->

--- a/metaquot/ppxlib_metaquot.ml
+++ b/metaquot/ppxlib_metaquot.ml
@@ -244,15 +244,15 @@ module Patt = Make (struct
   let cast self ext attrs ~type_name =
     match snd ext with
     | PPat (p, None) ->
-      (match attrs with
-       | None -> ()
-       | Some { quoted_attributes; field_name = _ } ->
-         (* We can't construct a pattern that searches for [quoted_attributes]
-            at the end of [p]'s attribute list -- the pattern language isn't
-            expressive enough. Instead, we fail.
-         *)
-         assert_no_attributes quoted_attributes);
-      self#typed p type_name
+        (match attrs with
+        | None -> ()
+        | Some { quoted_attributes; field_name = _ } ->
+            (* We can't construct a pattern that searches for [quoted_attributes]
+               at the end of [p]'s attribute list -- the pattern language isn't
+               expressive enough. Instead, we fail.
+            *)
+            assert_no_attributes quoted_attributes);
+        self#typed p type_name
     | PPat (_, Some e) ->
         Ast_builder.Default.(
           ppat_extension ~loc:e.pexp_loc

--- a/metaquot/ppxlib_metaquot.ml
+++ b/metaquot/ppxlib_metaquot.ml
@@ -157,7 +157,7 @@ module Expr = Make (struct
   let fresh_name =
     let counter = ref 0 in
     fun () ->
-      let var = "_ppx_metaquot_helper_var%d" ^ Int.to_string !counter in
+      let var = "_ppx_metaquot_helper_var%d" ^ string_of_int !counter in
       incr counter;
       var
 
@@ -177,7 +177,8 @@ module Expr = Make (struct
     | [] -> self#typed e type_name
     | _ :: _ ->
         let loc = { loc with loc_ghost = true } in
-        let open (val Ast_builder.make loc) in
+        let module Ast_builder_with_loc = (val Ast_builder.make loc) in
+        let open Ast_builder_with_loc in
         let var = fresh_name () in
         let var_expr = pexp_ident (Located.mk (Lident var)) in
         let field_name = Located.mk (Lident field_name) in

--- a/metaquot/ppxlib_metaquot.ml
+++ b/metaquot/ppxlib_metaquot.ml
@@ -3,11 +3,26 @@ open Ast_builder.Default
 module E = Extension
 module A = Ast_pattern
 
+type quoted_attributes =
+  { quoted_attributes : attributes
+  (* The attributes that appear quoted, e.g. [@foo] in [%expr [%e e] [@foo]] *)
+  ; field_name : string
+  (* The field name where attributes are stored for the kind of ASt the quoted attributes
+     are placed on, e.g. pexp_attributes. *)
+  }
+
 module Make (M : sig
   type result
 
   val annotate : result -> core_type -> result
-  val cast : extension -> result
+
+  val cast
+    :  < attributes : attributes -> result; .. >
+      (* The instance of the [std_lifters] class being used. *)
+    -> extension
+    -> quoted_attributes option
+    -> result
+
   val location : location -> result
   val location_stack : (location -> result) option
   val attributes : (location -> result) option
@@ -48,48 +63,74 @@ struct
       method! expression e =
         match e.pexp_desc with
         | Pexp_extension (({ txt = "e"; _ }, _) as ext) ->
-            self#typed (M.cast ext) "expression"
+            let attributes =
+              { quoted_attributes = e.pexp_attributes
+              ; field_name = "pexp_attributes"
+              }
+            in
+            self#typed (M.cast self ext (Some attributes)) "expression"
         | _ -> super#expression e
 
       method! pattern p =
         match p.ppat_desc with
         | Ppat_extension (({ txt = "p"; _ }, _) as ext) ->
-            self#typed (M.cast ext) "pattern"
+            let attributes =
+              { quoted_attributes = p.ppat_attributes
+              ; field_name = "ppat_attributes"
+              }
+            in
+            self#typed (M.cast self ext (Some attributes)) "pattern"
         | _ -> super#pattern p
 
       method! core_type t =
         match t.ptyp_desc with
         | Ptyp_extension (({ txt = "t"; _ }, _) as ext) ->
-            self#typed (M.cast ext) "core_type"
+            let attributes =
+              { quoted_attributes = t.ptyp_attributes
+              ; field_name = "ptyp_attributes"
+              }
+            in
+            self#typed (M.cast self ext (Some attributes)) "core_type"
         | _ -> super#core_type t
 
       method! module_expr m =
         match m.pmod_desc with
         | Pmod_extension (({ txt = "m"; _ }, _) as ext) ->
-            self#typed (M.cast ext) "module_expr"
+            let attributes =
+              { quoted_attributes = m.pmod_attributes
+              ; field_name = "pmod_attributes"
+              }
+            in
+            self#typed (M.cast self ext (Some attributes)) "module_expr"
         | _ -> super#module_expr m
 
       method! module_type m =
         match m.pmty_desc with
         | Pmty_extension (({ txt = "m"; _ }, _) as ext) ->
-            self#typed (M.cast ext) "module_type"
+            let attributes =
+              { quoted_attributes = m.pmty_attributes
+              ; field_name = "pmty_attributes"
+              }
+            in
+            self#typed (M.cast self ext (Some attributes)) "module_type"
         | _ -> super#module_type m
 
       method! structure_item i =
         match i.pstr_desc with
         | Pstr_extension ((({ txt = "i"; _ }, _) as ext), attrs) ->
             assert_no_attributes attrs;
-            self#typed (M.cast ext) "structure_item"
+            self#typed (M.cast self ext None) "structure_item"
         | _ -> super#structure_item i
 
       method! signature_item i =
         match i.psig_desc with
         | Psig_extension ((({ txt = "i"; _ }, _) as ext), attrs) ->
             assert_no_attributes attrs;
-            self#typed (M.cast ext) "signature_item"
+            self#typed (M.cast self ext None) "signature_item"
         | _ -> super#signature_item i
     end
 end
+
 
 module Expr = Make (struct
   type result = expression
@@ -102,11 +143,66 @@ module Expr = Make (struct
 
   let annotate e core_type = pexp_constraint ~loc:core_type.ptyp_loc e core_type
 
-  let cast ext =
+  let fresh_name =
+    let counter = ref 0 in
+    fun () ->
+      let var = "_ppx_metaquot_helper_var%d" ^ Int.to_string !counter in
+      incr counter;
+      var
+
+  (* Append the quoted attributes to the attributes present on the
+     antiquoted construct. Take this as example:
+
+     [%expr [%e e] [@attr]]
+
+     Suppose e has pexp_attributes = [attr1]. Then the resulting attributes
+     are [ attr1; [@attr] ]. The decision to put outer attributes (here,
+     [@attr]) at the end of the list is consistent with other parts of ppxlib
+     that accumulate attributes.
+  *)
+  let add_quoted_attributes self e { quoted_attributes; field_name } ~loc =
+    match quoted_attributes with
+    | [] -> e
+    | _ :: _ ->
+      let open Ppxlib_ast.Ast_helper in
+      let loc = { loc with loc_ghost = true } in
+      let mkloc x = Located.mk x ~loc in
+      let var = fresh_name () in
+      let var_expr = Exp.ident (mkloc (Lident var)) in
+      let field_name = mkloc (Lident field_name) in
+      let reified_attrs = self#attributes quoted_attributes in
+      (* append arg1 arg2 = [%expr Stdlib.List.append [%e arg1] [%e arg2]] *)
+      let append arg1 arg2 =
+        Exp.apply
+          (Exp.ident
+             (mkloc (Ldot (Ldot (Lident "Stdlib", "List"), "append"))))
+          [ Nolabel, arg1; Nolabel, arg2 ]
+      in
+      (* [%expr
+         let [%p var] = [%e e] in
+         { [%e var] with field_name =
+         [%e append [%expr [%e var].field_name] reified_attrs]
+         ]
+
+         This comment lies a little bit: field_name is actually some other
+         literal string.
+      *)
+      Exp.let_
+        Nonrecursive
+        [ Vb.mk (Pat.var (mkloc var)) e ]
+        (Exp.record
+           [ field_name, append (Exp.field var_expr field_name) reified_attrs ]
+           (Some var_expr))
+
+  let cast self ext attrs =
     match snd ext with
-    | PStr [ { pstr_desc = Pstr_eval (e, attrs); _ } ] ->
-        assert_no_attributes attrs;
-        e
+    | PStr [ { pstr_desc = Pstr_eval (e, inner_attrs); _ } ] ->
+      assert_no_attributes inner_attrs;
+      (match attrs with
+       | None -> e
+       | Some quoted_attrs ->
+         add_quoted_attributes self e quoted_attrs
+           ~loc:(loc_of_extension ext))
     | _ ->
         Ast_builder.Default.(
           pexp_extension ~loc:(loc_of_extension ext)
@@ -128,7 +224,19 @@ module Patt = Make (struct
 
   let annotate p core_type = ppat_constraint ~loc:core_type.ptyp_loc p core_type
 
-  let cast ext =
+  let cast _ ext attrs =
+    begin
+      match attrs with
+      | None -> ()
+      | Some { quoted_attributes; field_name = _ } ->
+          (* In theory, we could create a pattern where [quoted_attributes]
+             is consed to the front of [p.ppat_attributes]. But this is
+             inconsistent with [Expression.add_quoted_attributes], which appends
+             quoted attributes to the end -- and this wouldn't be a legal
+             pattern.
+          *)
+          assert_no_attributes quoted_attributes
+    end;
     match snd ext with
     | PPat (p, None) -> p
     | PPat (_, Some e) ->

--- a/test/metaquot/test.ml
+++ b/test/metaquot/test.ml
@@ -292,6 +292,243 @@ let _ = [%sig: include S]
     loc_ghost = true}}]
 |}]
 
+(* attributes *)
+
+let _ =
+  let e = [%expr (() [@attr1])] in
+  [%expr [%e e] [@attr2]].pexp_attributes
+[%%expect{|
+- : Ppxlib_ast.Ast.attributes =
+[{Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr1";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}};
+ {Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr2";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}}]
+|}]
+
+let _ =
+  let p = [%pat? (() [@attr1])] in
+  [%pat? [%p p] [@attr2]].ppat_attributes
+[%%expect{|
+- : Ppxlib_ast.Ast.attributes =
+[{Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr1";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}};
+ {Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr2";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}}]
+|}]
+
+let _ =
+  let t = [%type: (unit [@attr1])] in
+  [%type: [%t t] [@attr2]].ptyp_attributes
+[%%expect{|
+- : Ppxlib_ast.Ast.attributes =
+[{Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr1";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}};
+ {Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr2";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}}]
+|}]
+
+let _ =
+  let extract_module_M m =
+    match m with
+    | [%stri module M = [%m? m]] -> m
+    | _ -> assert false
+  in
+  let m = extract_module_M [%stri module M = (struct end [@attr1])] in
+  (extract_module_M [%stri module M = [%m m] [@attr2]]).pmod_attributes
+[%%expect{|
+- : Ppxlib_ast.Ast.attributes =
+[{Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr1";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}};
+ {Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr2";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}}]
+|}]
+
+let _ =
+  let extract_module_ty_S s =
+    match s with
+    | [%stri module type S = [%m? s]] -> s
+    | _ -> assert false
+  in
+  let s = extract_module_ty_S [%stri module type S = (sig end [@attr1])] in
+  (extract_module_ty_S [%stri module type S = [%m s] [@attr2]]).pmty_attributes
+[%%expect{|
+- : Ppxlib_ast.Ast.attributes =
+[{Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr1";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}};
+ {Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr2";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}}]
+|}]
+
 (* mistyped escapes (not producing ASTs at all) *)
 
 let _ = [%expr [%e ()]]
@@ -327,4 +564,10 @@ let _ = [%sigi: [%%i ()]]
 Line _, characters 21-23:
 Error: This expression should not be a unit literal, the expected type is
        Ppxlib_ast.Ast.signature_item
+|}]
+
+let _ = [%expr [%e ()] [@attr]]
+[%%expect{|
+Line _:
+Error: This expression has type unit which is not a record type.
 |}]

--- a/test/metaquot/test.ml
+++ b/test/metaquot/test.ml
@@ -566,8 +566,39 @@ Error: This expression should not be a unit literal, the expected type is
        Ppxlib_ast.Ast.signature_item
 |}]
 
+(* mistyped escapes (not producing ASTs at all) with attributes *)
+
 let _ = [%expr [%e ()] [@attr]]
 [%%expect{|
-Line _:
-Error: This expression has type unit which is not a record type.
+Line _, characters 19-21:
+Error: This expression should not be a unit literal, the expected type is
+       Ppxlib_ast.Ast.expression
+|}]
+
+let _ = [%pat? [%p ()] [@attr]]
+[%%expect{|
+Line _, characters 19-21:
+Error: This expression should not be a unit literal, the expected type is
+       Ppxlib_ast.Ast.pattern
+|}]
+
+let _ = [%type: [%t ()] [@attr]]
+[%%expect{|
+Line _, characters 20-22:
+Error: This expression should not be a unit literal, the expected type is
+       Ppxlib_ast.Ast.core_type
+|}]
+
+let _ = [%stri module M = [%m ()] [@attr]]
+[%%expect{|
+Line _, characters 30-32:
+Error: This expression should not be a unit literal, the expected type is
+       Ppxlib_ast.Ast.module_expr
+|}]
+
+let _ = [%sigi: module type M = [%m ()] [@attr]]
+[%%expect{|
+Line _, characters 36-38:
+Error: This expression should not be a unit literal, the expected type is
+       Ppxlib_ast.Ast.module_type
 |}]

--- a/test/metaquot/test_510.ml
+++ b/test/metaquot/test_510.ml
@@ -570,16 +570,11 @@ Error: This expression should not be a unit literal, the expected type is
        Ppxlib_ast.Ast.signature_item
 |}]
 
-let _ = [%expr [%e ()] [@attr]]
-[%%expect{|
-Line _:
-Error: This expression has type unit which is not a record type.
-|}]
-
 (* mistyped escapes (not producing ASTs at all) with attributes *)
 
 let _ = [%expr [%e ()] [@attr]]
 [%%expect{|
+
 Line _, characters 19-21:
 Error: This expression should not be a unit literal, the expected type is
        Ppxlib_ast.Ast.expression
@@ -587,6 +582,7 @@ Error: This expression should not be a unit literal, the expected type is
 
 let _ = [%pat? [%p ()] [@attr]]
 [%%expect{|
+
 Line _, characters 19-21:
 Error: This expression should not be a unit literal, the expected type is
        Ppxlib_ast.Ast.pattern
@@ -594,6 +590,7 @@ Error: This expression should not be a unit literal, the expected type is
 
 let _ = [%type: [%t ()] [@attr]]
 [%%expect{|
+
 Line _, characters 20-22:
 Error: This expression should not be a unit literal, the expected type is
        Ppxlib_ast.Ast.core_type
@@ -601,6 +598,7 @@ Error: This expression should not be a unit literal, the expected type is
 
 let _ = [%stri module M = [%m ()] [@attr]]
 [%%expect{|
+
 Line _, characters 30-32:
 Error: This expression should not be a unit literal, the expected type is
        Ppxlib_ast.Ast.module_expr
@@ -608,6 +606,7 @@ Error: This expression should not be a unit literal, the expected type is
 
 let _ = [%sigi: module type M = [%m ()] [@attr]]
 [%%expect{|
+
 Line _, characters 36-38:
 Error: This expression should not be a unit literal, the expected type is
        Ppxlib_ast.Ast.module_type

--- a/test/metaquot/test_510.ml
+++ b/test/metaquot/test_510.ml
@@ -575,3 +575,40 @@ let _ = [%expr [%e ()] [@attr]]
 Line _:
 Error: This expression has type unit which is not a record type.
 |}]
+
+(* mistyped escapes (not producing ASTs at all) with attributes *)
+
+let _ = [%expr [%e ()] [@attr]]
+[%%expect{|
+Line _, characters 19-21:
+Error: This expression should not be a unit literal, the expected type is
+       Ppxlib_ast.Ast.expression
+|}]
+
+let _ = [%pat? [%p ()] [@attr]]
+[%%expect{|
+Line _, characters 19-21:
+Error: This expression should not be a unit literal, the expected type is
+       Ppxlib_ast.Ast.pattern
+|}]
+
+let _ = [%type: [%t ()] [@attr]]
+[%%expect{|
+Line _, characters 20-22:
+Error: This expression should not be a unit literal, the expected type is
+       Ppxlib_ast.Ast.core_type
+|}]
+
+let _ = [%stri module M = [%m ()] [@attr]]
+[%%expect{|
+Line _, characters 30-32:
+Error: This expression should not be a unit literal, the expected type is
+       Ppxlib_ast.Ast.module_expr
+|}]
+
+let _ = [%sigi: module type M = [%m ()] [@attr]]
+[%%expect{|
+Line _, characters 36-38:
+Error: This expression should not be a unit literal, the expected type is
+       Ppxlib_ast.Ast.module_type
+|}]

--- a/test/metaquot/test_510.ml
+++ b/test/metaquot/test_510.ml
@@ -292,6 +292,243 @@ let _ = [%sig: include S]
     loc_ghost = true}}]
 |}]
 
+(* attributes *)
+
+let _ =
+  let e = [%expr (() [@attr1])] in
+  [%expr [%e e] [@attr2]].pexp_attributes
+[%%expect{|
+- : Ppxlib_ast.Ast.attributes =
+[{Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr1";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}};
+ {Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr2";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}}]
+|}]
+
+let _ =
+  let p = [%pat? (() [@attr1])] in
+  [%pat? [%p p] [@attr2]].ppat_attributes
+[%%expect{|
+- : Ppxlib_ast.Ast.attributes =
+[{Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr1";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}};
+ {Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr2";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}}]
+|}]
+
+let _ =
+  let t = [%type: (unit [@attr1])] in
+  [%type: [%t t] [@attr2]].ptyp_attributes
+[%%expect{|
+- : Ppxlib_ast.Ast.attributes =
+[{Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr1";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}};
+ {Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr2";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}}]
+|}]
+
+let _ =
+  let extract_module_M m =
+    match m with
+    | [%stri module M = [%m? m]] -> m
+    | _ -> assert false
+  in
+  let m = extract_module_M [%stri module M = (struct end [@attr1])] in
+  (extract_module_M [%stri module M = [%m m] [@attr2]]).pmod_attributes
+[%%expect{|
+- : Ppxlib_ast.Ast.attributes =
+[{Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr1";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}};
+ {Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr2";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}}]
+|}]
+
+let _ =
+  let extract_module_ty_S s =
+    match s with
+    | [%stri module type S = [%m? s]] -> s
+    | _ -> assert false
+  in
+  let s = extract_module_ty_S [%stri module type S = (sig end [@attr1])] in
+  (extract_module_ty_S [%stri module type S = [%m s] [@attr2]]).pmty_attributes
+[%%expect{|
+- : Ppxlib_ast.Ast.attributes =
+[{Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr1";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}};
+ {Ppxlib_ast.Ast.attr_name =
+   {Ppxlib_ast.Ast.txt = "attr2";
+    loc =
+     {Ppxlib_ast.Ast.loc_start =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_end =
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        pos_cnum = -1};
+      loc_ghost = true}};
+  attr_payload = Ppxlib_ast.Ast.PStr [];
+  attr_loc =
+   {Ppxlib_ast.Ast.loc_start =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_end =
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+      pos_cnum = -1};
+    loc_ghost = true}}]
+|}]
+
 (* mistyped escapes (not producing ASTs at all) *)
 
 let _ = [%expr [%e ()]]
@@ -331,4 +568,10 @@ let _ = [%sigi: [%%i ()]]
 Line _, characters 21-23:
 Error: This expression should not be a unit literal, the expected type is
        Ppxlib_ast.Ast.signature_item
+|}]
+
+let _ = [%expr [%e ()] [@attr]]
+[%%expect{|
+Line _:
+Error: This expression has type unit which is not a record type.
 |}]


### PR DESCRIPTION
Fixes #406 by preserving attributes on antiquoted constructs.

Example:
```ocaml
let e = [%expr (() [@attr1])] in
[%expr [%e] [@attr2]]

(* Old output: *)
() [@attr1]

(* New output: *)
() [@attr1] [@attr2]
```

You can see more examples in the tests.

Some non-obvious design decisions/weirdness:
  * `attr2` goes at the end of the attribute list, not the start, because it's an "outer" attribute. This is consistent with other places that ppxlib merges attributes, e.g. `merge_attributes` in `src/extension.ml`.
  * However, this design decision means that we can't support attributes in patterns, e.g. there's no way to put `[@attr1]` at the end of `quoted_expr.pexp_attributes` in the pattern `[%expr [%e? quoted_expr] [@attr1]]`.
  * I merge the attributes by inserting a runtime call to `Stdlib.List.append`. This is susceptible to shadowing, but I couldn't think of a better idea.
  * Some type errors are worse. See the example below.

```ocaml
let _ = [%expr [%e ()] [@attr]]
[%%expect{|
Line _:
Error: This expression has type unit which is not a record type.
|}]
```

That's because this gets expanded to something like:
```ocaml
let v = () in
{ v with pexp_attributes = v.pexp_attributes @ [ attr ] }
```
This error message could be improved if we put a type annotation on `v` earlier on, e.g. `let v : Parsetree.expression = () in ...`, but that's also susceptible to the shadowing issue. Could a maintainer weigh in?