### PR TITLE
Give semantics to reserving attribute namespace with dots

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ unreleased
 
 - Preserve quoted attributes on antiquotes in metaquot (#441, @ncik-roberts)
 
+- Attribute namespaces: Fix semantics of reserving multi-component namespaces (#443, @ncik-roberts)
+
 0.30.0 (20/06/2023)
 -------------------
 

--- a/test/driver/attributes/test.ml
+++ b/test/driver/attributes/test.ml
@@ -92,3 +92,63 @@ type t2 = <  >
 Line _, characters 17-20:
 Error: Attribute `foo' was not used
 |}]
+
+(* Reserved Namespaces *)
+
+(* ppxlib checks that unreserved attributes aren't dropped *)
+
+let x = (42 [@bar])
+[%%expect{|
+Line _, characters 14-17:
+Error: Attribute `bar' was silently dropped
+|}]
+
+let x = (42 [@bar.baz])
+[%%expect{|
+Line _, characters 14-21:
+Error: Attribute `bar.baz' was silently dropped
+|}]
+
+(* But reserving a namespace disables those checks. *)
+
+let () = Reserved_namespaces.reserve "bar"
+
+let x = (42 [@bar])
+let x = (42 [@bar.baz])
+[%%expect{|
+val x : int = 42
+val x : int = 42
+|}]
+
+let x = (42 [@bar_not_proper_sub_namespace])
+[%%expect{|
+Line _, characters 14-42:
+Error: Attribute `bar_not_proper_sub_namespace' was silently dropped
+|}]
+
+(* The namespace reservation process understands dots as namespace
+   separators. *)
+
+let () = Reserved_namespaces.reserve "baz.qux"
+
+let x = (42 [@baz])
+[%%expect{|
+Line _, characters 14-17:
+Error: Attribute `baz' was silently dropped
+|}]
+
+let x = (42 [@baz.qux])
+[%%expect{|
+val x : int = 42
+|}]
+
+let x = (42 [@baz.qux.quux])
+[%%expect{|
+val x : int = 42
+|}]
+
+let x = (42 [@baz.qux_not_proper_sub_namespace])
+[%%expect{|
+Line _, characters 14-46:
+Error: Attribute `baz.qux_not_proper_sub_namespace' was silently dropped
+|}]

--- a/test/driver/attributes/test.ml
+++ b/test/driver/attributes/test.ml
@@ -152,3 +152,20 @@ let x = (42 [@baz.qux_not_proper_sub_namespace])
 Line _, characters 14-46:
 Error: Attribute `baz.qux_not_proper_sub_namespace' was silently dropped
 |}]
+
+(* You can reserve multiple subnamespaces under the same namespace *)
+
+let () = Reserved_namespaces.reserve "baz.qux2"
+
+let x = (42 [@baz.qux])
+let x = (42 [@baz.qux2])
+[%%expect{|
+val x : int = 42
+val x : int = 42
+|}]
+
+let x = (42 [@baz.qux3])
+[%%expect{|
+Line _, characters 14-22:
+Error: Attribute `baz.qux3' was silently dropped
+|}]

--- a/test/driver/attributes/test_510.ml
+++ b/test/driver/attributes/test_510.ml
@@ -103,3 +103,92 @@ type t2 = <  >
 Line _, characters 17-20:
 Error: Attribute `foo' was not used
 |}]
+
+(* Reserved Namespaces *)
+
+(* ppxlib checks that unreserved attributes aren't dropped *)
+
+let x = (42 [@bar])
+[%%expect{|
+
+Line _, characters 14-17:
+Error: Attribute `bar' was silently dropped
+|}]
+
+let x = (42 [@bar.baz])
+[%%expect{|
+
+Line _, characters 14-21:
+Error: Attribute `bar.baz' was silently dropped
+|}]
+
+(* But reserving a namespace disables those checks. *)
+
+let () = Reserved_namespaces.reserve "bar"
+
+let x = (42 [@bar])
+let x = (42 [@bar.baz])
+[%%expect{|
+
+val x : int = 42
+
+val x : int = 42
+|}]
+
+let x = (42 [@bar_not_proper_sub_namespace])
+[%%expect{|
+
+Line _, characters 14-42:
+Error: Attribute `bar_not_proper_sub_namespace' was silently dropped
+|}]
+
+(* The namespace reservation process understands dots as namespace
+   separators. *)
+
+let () = Reserved_namespaces.reserve "baz.qux"
+
+let x = (42 [@baz])
+[%%expect{|
+
+Line _, characters 14-17:
+Error: Attribute `baz' was silently dropped
+|}]
+
+let x = (42 [@baz.qux])
+[%%expect{|
+
+val x : int = 42
+|}]
+
+let x = (42 [@baz.qux.quux])
+[%%expect{|
+
+val x : int = 42
+|}]
+
+let x = (42 [@baz.qux_not_proper_sub_namespace])
+[%%expect{|
+
+Line _, characters 14-46:
+Error: Attribute `baz.qux_not_proper_sub_namespace' was silently dropped
+|}]
+
+(* You can reserve multiple subnamespaces under the same namespace *)
+
+let () = Reserved_namespaces.reserve "baz.qux2"
+
+let x = (42 [@baz.qux])
+let x = (42 [@baz.qux2])
+[%%expect{|
+
+val x : int = 42
+
+val x : int = 42
+|}]
+
+let x = (42 [@baz.qux3])
+[%%expect{|
+
+Line _, characters 14-22:
+Error: Attribute `baz.qux3' was silently dropped
+|}]


### PR DESCRIPTION
Resolves #442.

This PR gives different semantics to reserving attribute namespaces that contain dots, like "foo.bar". The previous semantics: reserving this namespace has no effect. The new semantics: reserving this namespaces causes attributes of the form `[@foo.bar]` or `[@foo.bar.*]` to be treated as reserved.

This is technically a backward-incompatible change, as existing reservations of "foo.bar" will start to have an effect. But it's hard to imagine anyone actually intending these reservations to have no effect, and I claim the new semantics is a more reasonable way to handle this case.