### PR TITLE
`trunk-support` supports trunk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install ppxlib dependencies
         run: |
-          opam install ./ppxlib.opam --deps-only
+          opam install ./ppxlib.opam --deps-only --with-test
 
       - name: Show configuration
         run: |
@@ -42,4 +42,4 @@ jobs:
           opam list
 
       - name: Build the ppxlib
-        run: opam exec -- dune build -p ppxlib
+        run: opam exec -- dune test -p ppxlib

--- a/astlib/ast_502.ml
+++ b/astlib/ast_502.ml
@@ -147,7 +147,7 @@ module Parsetree = struct
               - [T #tconstr]             when [l=[T]],
               - [(T1, ..., Tn) #tconstr] when [l=[T1 ; ... ; Tn]].
            *)
-    | Ptyp_alias of core_type * string  (** [T as 'a]. *)
+    | Ptyp_alias of core_type * string loc  (** [T as 'a]. *)
     | Ptyp_variant of row_field list * closed_flag * label list option
         (** [Ptyp_variant([`A;`B], flag, labels)] represents:
               - [[ `A|`B ]]

--- a/astlib/ast_502.ml
+++ b/astlib/ast_502.ml
@@ -456,7 +456,7 @@ module Parsetree = struct
       pbop_loc : Location.t;
     }
 
-  and function_param (*IF_CURRENT = Parsetree.function_param *) =
+  and function_param_desc (*IF_CURRENT = Parsetree.function_param_desc *) =
     | Pparam_val of arg_label * expression option * pattern
     (** [Pparam_val (lbl, exp0, P)] represents the parameter:
         - [P]
@@ -475,17 +475,18 @@ module Parsetree = struct
         Note: If [E0] is provided, only
         {{!Asttypes.arg_label.Optional}[Optional]} is allowed.
     *)
-    | Pparam_newtype of string loc * Location.t
-    (** [Pparam_newtype (x, loc)] represents the parameter [(type x)].
-        [x] carries the location of the identifier, whereas [loc] is
-        the location of the [(type x)] as a whole.
+    | Pparam_newtype of string loc
+    (** [Pparam_newtype x] represents the parameter [(type x)].
+        [x] carries the location of the identifier, whereas the [pparam_loc]
+        on the enclosing [function_param] node is the location of the [(type x)]
+        as a whole.
 
         Multiple parameters [(type a b c)] are represented as multiple
         [Pparam_newtype] nodes, let's say:
 
-        {[ [ Pparam_newtype (a, loc1);
-             Pparam_newtype (b, loc2);
-             Pparam_newtype (c, loc3);
+        {[ [ { pparam_kind = Pparam_newtype a; pparam_loc = loc1 };
+             { pparam_kind = Pparam_newtype b; pparam_loc = loc2 };
+             { pparam_kind = Pparam_newtype c; pparam_loc = loc3 };
            ]
         ]}
 
@@ -494,6 +495,11 @@ module Parsetree = struct
         ghost locations. The locations on [a], [b], [c], correspond to the
         variables [a], [b], and [c] in the source code.
     *)
+
+  and function_param (*IF_CURRENT = Parsetree.function_param *) =
+    { pparam_loc : Location.t;
+      pparam_desc : function_param_desc;
+    }
 
   and function_body (*IF_CURRENT = Parsetree.function_body *) =
     | Pfunction_body of expression

--- a/astlib/ast_502.ml
+++ b/astlib/ast_502.ml
@@ -192,6 +192,7 @@ module Parsetree = struct
              {!value_description}.
            *)
     | Ptyp_package of package_type  (** [(module S)]. *)
+    | Ptyp_open of Longident.t loc * core_type (** [M.(T)] *)
     | Ptyp_extension of extension  (** [[%id]]. *)
 
   and package_type = Longident.t loc * (Longident.t loc * core_type) list
@@ -322,41 +323,30 @@ module Parsetree = struct
               - [let rec P1 = E1 and ... and Pn = EN in E]
                  when [flag] is {{!Asttypes.rec_flag.Recursive}[Recursive]}.
            *)
-    | Pexp_function of case list  (** [function P1 -> E1 | ... | Pn -> En] *)
-    | Pexp_fun of arg_label * expression option * pattern * expression
-        (** [Pexp_fun(lbl, exp0, P, E1)] represents:
-              - [fun P -> E1]
-                        when [lbl] is {{!Asttypes.arg_label.Nolabel}[Nolabel]}
-                         and [exp0] is [None]
-              - [fun ~l:P -> E1]
-                        when [lbl] is {{!Asttypes.arg_label.Labelled}[Labelled l]}
-                         and [exp0] is [None]
-              - [fun ?l:P -> E1]
-                        when [lbl] is {{!Asttypes.arg_label.Optional}[Optional l]}
-                         and [exp0] is [None]
-              - [fun ?l:(P = E0) -> E1]
-                        when [lbl] is {{!Asttypes.arg_label.Optional}[Optional l]}
-                         and [exp0] is [Some E0]
-
-             Notes:
-             - If [E0] is provided, only
-               {{!Asttypes.arg_label.Optional}[Optional]} is allowed.
-             - [fun P1 P2 .. Pn -> E1] is represented as nested
-               {{!expression_desc.Pexp_fun}[Pexp_fun]}.
-             - [let f P = E] is represented using
-               {{!expression_desc.Pexp_fun}[Pexp_fun]}.
-           *)
+    | Pexp_function of
+        function_param list * type_constraint option * function_body
+    (** [Pexp_function ([P1; ...; Pn], C, body)] represents any construct
+        involving [fun] or [function], including:
+        - [fun P1 ... Pn -> E]
+          when [body = Pfunction_body E]
+        - [fun P1 ... Pn -> function p1 -> e1 | ... | pm -> em]
+          when [body = Pfunction_cases [ p1 -> e1; ...; pm -> em ]]
+        [C] represents a type constraint or coercion placed immediately before the
+        arrow, e.g. [fun P1 ... Pn : ty -> ...] when [C = Some (Pconstraint ty)].
+        A function must have parameters. [Pexp_function (params, _, body)] must
+        have non-empty [params] or a [Pfunction_cases _] body.
+    *)
     | Pexp_apply of expression * (arg_label * expression) list
-        (** [Pexp_apply(E0, [(l1, E1) ; ... ; (ln, En)])]
-              represents [E0 ~l1:E1 ... ~ln:En]
+          (** [Pexp_apply(E0, [(l1, E1) ; ... ; (ln, En)])]
+                represents [E0 ~l1:E1 ... ~ln:En]
 
-              [li] can be
-                {{!Asttypes.arg_label.Nolabel}[Nolabel]}   (non labeled argument),
-                {{!Asttypes.arg_label.Labelled}[Labelled]} (labelled arguments) or
-                {{!Asttypes.arg_label.Optional}[Optional]} (optional argument).
+                [li] can be
+                  {{!Asttypes.arg_label.Nolabel}[Nolabel]}   (non labeled argument),
+                  {{!Asttypes.arg_label.Labelled}[Labelled]} (labelled arguments) or
+                  {{!Asttypes.arg_label.Optional}[Optional]} (optional argument).
 
-             Invariant: [n > 0]
-           *)
+               Invariant: [n > 0]
+             *)
     | Pexp_match of expression * case list
         (** [match E0 with P1 -> E1 | ... | Pn -> En] *)
     | Pexp_try of expression * case list
@@ -465,6 +455,60 @@ module Parsetree = struct
       pbop_exp : expression;
       pbop_loc : Location.t;
     }
+
+  and function_param (*IF_CURRENT = Parsetree.function_param *) =
+    | Pparam_val of arg_label * expression option * pattern
+    (** [Pparam_val (lbl, exp0, P)] represents the parameter:
+        - [P]
+          when [lbl] is {{!Asttypes.arg_label.Nolabel}[Nolabel]}
+          and [exp0] is [None]
+        - [~l:P]
+          when [lbl] is {{!Asttypes.arg_label.Labelled}[Labelled l]}
+          and [exp0] is [None]
+        - [?l:P]
+          when [lbl] is {{!Asttypes.arg_label.Optional}[Optional l]}
+          and [exp0] is [None]
+        - [?l:(P = E0)]
+          when [lbl] is {{!Asttypes.arg_label.Optional}[Optional l]}
+          and [exp0] is [Some E0]
+
+        Note: If [E0] is provided, only
+        {{!Asttypes.arg_label.Optional}[Optional]} is allowed.
+    *)
+    | Pparam_newtype of string loc * Location.t
+    (** [Pparam_newtype (x, loc)] represents the parameter [(type x)].
+        [x] carries the location of the identifier, whereas [loc] is
+        the location of the [(type x)] as a whole.
+
+        Multiple parameters [(type a b c)] are represented as multiple
+        [Pparam_newtype] nodes, let's say:
+
+        {[ [ Pparam_newtype (a, loc1);
+             Pparam_newtype (b, loc2);
+             Pparam_newtype (c, loc3);
+           ]
+        ]}
+
+        Here, the first loc [loc1] is the location of [(type a b c)], and the
+        subsequent locs [loc2] and [loc3] are the same as [loc1], except marked as
+        ghost locations. The locations on [a], [b], [c], correspond to the
+        variables [a], [b], and [c] in the source code.
+    *)
+
+  and function_body (*IF_CURRENT = Parsetree.function_body *) =
+    | Pfunction_body of expression
+    | Pfunction_cases of case list * Location.t * attributes
+    (** In [Pfunction_cases (_, loc, attrs)], the location extends from the
+        start of the [function] keyword to the end of the last case. The compiler
+        will only use typechecking-related attributes from [attrs], e.g. enabling
+        or disabling a warning.
+    *)
+  (** See the comment on {{!expression_desc.Pexp_function}[Pexp_function]}. *)
+
+  and type_constraint (*IF_CURRENT = Parsetree.type_constraint *) =
+    | Pconstraint of core_type
+    | Pcoerce of core_type option * core_type
+  (** See the comment on {{!expression_desc.Pexp_function}[Pexp_function]}. *)
 
   (** {2 Value descriptions} *)
 

--- a/astlib/migrate_501_502.ml
+++ b/astlib/migrate_501_502.ml
@@ -440,7 +440,7 @@ and copy_core_type_desc :
       Ast_502.Parsetree.Ptyp_class
         (copy_loc copy_Longident_t x0, List.map copy_core_type x1)
   | Ast_501.Parsetree.Ptyp_alias (x0, x1) ->
-      Ast_502.Parsetree.Ptyp_alias (copy_core_type x0, x1)
+      Ast_502.Parsetree.Ptyp_alias (copy_core_type x0, { Ast_502.Asttypes.txt = x1; loc = x0.ptyp_loc } )
   | Ast_501.Parsetree.Ptyp_variant (x0, x1, x2) ->
       Ast_502.Parsetree.Ptyp_variant
         ( List.map copy_row_field x0,

--- a/astlib/migrate_501_502.ml
+++ b/astlib/migrate_501_502.ml
@@ -51,14 +51,15 @@ and copy_expression :
        Ast_501.Parsetree.pexp_loc_stack;
        Ast_501.Parsetree.pexp_attributes;
      } ->
+  let pexp_loc = copy_location pexp_loc in
   {
-    Ast_502.Parsetree.pexp_desc = copy_expression_desc pexp_desc;
-    Ast_502.Parsetree.pexp_loc = copy_location pexp_loc;
+    Ast_502.Parsetree.pexp_desc = copy_expression_desc pexp_loc pexp_desc;
+    Ast_502.Parsetree.pexp_loc;
     Ast_502.Parsetree.pexp_loc_stack = copy_location_stack pexp_loc_stack;
     Ast_502.Parsetree.pexp_attributes = copy_attributes pexp_attributes;
   }
 
-and copy_expression_desc :
+and copy_expression_desc loc :
     Ast_501.Parsetree.expression_desc -> Ast_502.Parsetree.expression_desc =
   function
   | Ast_501.Parsetree.Pexp_ident x0 ->
@@ -69,13 +70,25 @@ and copy_expression_desc :
       Ast_502.Parsetree.Pexp_let
         (copy_rec_flag x0, List.map copy_value_binding x1, copy_expression x2)
   | Ast_501.Parsetree.Pexp_function x0 ->
-      Ast_502.Parsetree.Pexp_function (List.map copy_case x0)
-  | Ast_501.Parsetree.Pexp_fun (x0, x1, x2, x3) ->
-      Ast_502.Parsetree.Pexp_fun
-        ( copy_arg_label x0,
-          Option.map copy_expression x1,
-          copy_pattern x2,
-          copy_expression x3 )
+      Ast_502.Parsetree.Pexp_function
+        ( [],
+          None,
+          Ast_502.Parsetree.Pfunction_cases (List.map copy_case x0, loc, []) )
+  | Ast_501.Parsetree.Pexp_fun (arg_label, opt_expr, pat, expr) ->
+      Ast_502.Parsetree.Pexp_function
+        ( [
+            Pparam_val
+              ( copy_arg_label arg_label,
+                Option.map copy_expression opt_expr,
+                copy_pattern pat );
+          ],
+          None,
+          Ast_502.Parsetree.Pfunction_body (copy_expression expr) )
+      (* Ast_502.Parsetree.Pexp_fun *)
+      (*   ( copy_arg_label x0, *)
+      (*     Option.map copy_expression x1, *)
+      (*     copy_pattern x2, *)
+      (*     copy_expression x3 ) *)
   | Ast_501.Parsetree.Pexp_apply (x0, x1) ->
       Ast_502.Parsetree.Pexp_apply
         ( copy_expression x0,

--- a/astlib/migrate_501_502.ml
+++ b/astlib/migrate_501_502.ml
@@ -77,10 +77,14 @@ and copy_expression_desc loc :
   | Ast_501.Parsetree.Pexp_fun (arg_label, opt_expr, pat, expr) ->
       Ast_502.Parsetree.Pexp_function
         ( [
-            Pparam_val
-              ( copy_arg_label arg_label,
-                Option.map copy_expression opt_expr,
-                copy_pattern pat );
+            {
+              pparam_desc =
+                Pparam_val
+                  ( copy_arg_label arg_label,
+                    Option.map copy_expression opt_expr,
+                    copy_pattern pat );
+              pparam_loc = loc;
+            };
           ],
           None,
           Ast_502.Parsetree.Pfunction_body (copy_expression expr) )

--- a/astlib/migrate_502_501.ml
+++ b/astlib/migrate_502_501.ml
@@ -112,7 +112,10 @@ and copy_expression_desc :
         List.fold_right
           (fun param expr ->
             match param with
-            | Ast_502.Parsetree.Pparam_val (lbl, exp0, p) ->
+            | {
+             Ast_502.Parsetree.pparam_desc = Pparam_val (lbl, exp0, p);
+             pparam_loc;
+            } ->
                 let pexp_desc =
                   Ast_501.Parsetree.Pexp_fun
                     ( copy_arg_label lbl,
@@ -122,17 +125,17 @@ and copy_expression_desc :
                 in
                 {
                   Ast_501.Parsetree.pexp_desc;
-                  pexp_loc = expr.pexp_loc;
+                  pexp_loc = pparam_loc;
                   pexp_loc_stack = [];
                   pexp_attributes = [];
                 }
-            | Pparam_newtype (x, loc) ->
+            | { pparam_desc = Pparam_newtype x; pparam_loc } ->
                 let pexp_desc =
                   Ast_501.Parsetree.Pexp_newtype (copy_loc (fun x -> x) x, expr)
                 in
                 {
                   Ast_501.Parsetree.pexp_desc;
-                  pexp_loc = loc;
+                  pexp_loc = pparam_loc;
                   pexp_loc_stack = [];
                   pexp_attributes = [];
                 })

--- a/astlib/migrate_502_501.ml
+++ b/astlib/migrate_502_501.ml
@@ -436,7 +436,7 @@ and copy_core_type_desc loc :
       Ast_501.Parsetree.Ptyp_class
         (copy_loc copy_Longident_t x0, List.map copy_core_type x1)
   | Ast_502.Parsetree.Ptyp_alias (x0, x1) ->
-      Ast_501.Parsetree.Ptyp_alias (copy_core_type x0, x1)
+      Ast_501.Parsetree.Ptyp_alias (copy_core_type x0, x1.txt)
   | Ast_502.Parsetree.Ptyp_variant (x0, x1, x2) ->
       Ast_501.Parsetree.Ptyp_variant
         ( List.map copy_row_field x0,

--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -51,3 +51,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+pin-depends: [
+  [ "ocaml-compiler-libs.v0.11.0" "git+https://github.com/art-w/ocaml-compiler-libs.git#ocaml-5.2-trunk" ]
+]

--- a/ppxlib.opam.template
+++ b/ppxlib.opam.template
@@ -1,0 +1,3 @@
+pin-depends: [
+  [ "ocaml-compiler-libs.v0.11.0" "git+https://github.com/art-w/ocaml-compiler-libs.git#ocaml-5.2-trunk" ]
+]


### PR DESCRIPTION
This PR is unfinished (locations are wrong, migration is untested, migrations don't roundtrip...), but should hopefully allow users to compile ppxlib against `trunk`.
Note that you will need to pin `ocaml-compiler-libs` to `git@github.com:art-w/ocaml-compiler-libs.git#ocaml-5.2-trunk` since the dependency is not compatible with 5.02.

-----

Ocaml pretty recently added two parsetree changes in its parsetree:
- https://github.com/ocaml/ocaml/pull/12044
- https://github.com/ocaml/ocaml/pull/12236

### Local open types

I migrated local open in types as we migrate local open in patterns (4.04 -> 4.03): by raising an error. This means that any code using local open in types anywhere will be unable to use ppxlib, until ppxlib bumps its AST to 5.02. This will require a lot of work, since I suspect many PPXes directly pattern-match/create function nodes.

### Syntactic arities

For syntactic arities, it seems that there are some problems. Let's collect any issue found when implementing the migrations in this thread (I'll update the list and add more information as we make progress).

#### For 5.02 -> 5.01:

- some locations (for "subfunctions") are missing. We can use the "whole location" maybe. Similarly for`pexp_loc_stack`.
- We need to check to which node to attach the attributes to.

#### For 5.01 -> 5.02:

- I have only done the migration "naively", without using the new feature where a function has syntactic arity greater than 1.
- Some location information might also be missing? (Need investigation)
- Doing it properly requires some focus to do it right!