### PR TITLE
Expose migration/copying/etc. functions for all AST types needed by `Pprintast`

### DIFF
--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -18,10 +18,13 @@ astlib/ast_413.ml
 astlib/ast_414.ml
 astlib/ast_501.ml
 
-# Files that use cinaps to generate bode blocks from other code blocks work well,
+# Files that use cinaps to generate code blocks from other code blocks work well,
 # but files that inject freely formatted code via cinaps must be excluded
 ast/versions.ml
 ast/versions.mli
+ast/import.ml
+astlib/migrate_414_500.ml
+astlib/migrate_500_414.ml
 
 # Currently our expect-test lexer is too strict for our expect tests to
 # work well with ocamlformat

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ unreleased
 
 - Restore the "path_arg" functionality in the V3 API (#431, @ELLIOTTCABLE)
 
+- Expose migration/copying/etc. functions for all AST types needed by `Pprintast` (#454, @antalsz)
+
 0.30.0 (20/06/2023)
 -------------------
 

--- a/ast/cinaps/ast_cinaps_helpers.ml
+++ b/ast/cinaps/ast_cinaps_helpers.ml
@@ -3,32 +3,12 @@
 include StdLabels
 include Printf
 
-let nl () = printf "\n"
-
-let qualified_types =
-  [
-    ( "Parsetree",
-      [
-        "structure";
-        "signature";
-        "toplevel_phrase";
-        "core_type";
-        "expression";
-        "pattern";
-        "case";
-        "type_declaration";
-        "type_extension";
-        "extension_constructor";
-      ] );
-  ]
+let nl = Astlib_cinaps_helpers.nl
+let qualified_types = Astlib_cinaps_helpers.qualified_types
+let foreach_module = Astlib_cinaps_helpers.foreach_module
+let foreach_type = Astlib_cinaps_helpers.foreach_type
 
 let all_types = List.concat (List.map ~f:snd qualified_types)
-
-let foreach_module f =
-  nl ();
-  List.iter qualified_types ~f:(fun (m, types) -> f m types)
-
-let foreach_type f = foreach_module (fun m -> List.iter ~f:(f m))
 
 let foreach_version f =
   nl ();

--- a/ast/cinaps/ast_cinaps_helpers.ml
+++ b/ast/cinaps/ast_cinaps_helpers.ml
@@ -3,6 +3,9 @@
 include StdLabels
 include Printf
 
+let capitalize_ascii = Stdppx.String.capitalize_ascii
+
+(* Reexports from [Astlib_cinaps_helpers] *)
 let nl = Astlib_cinaps_helpers.nl
 let qualified_types = Astlib_cinaps_helpers.qualified_types
 let foreach_module = Astlib_cinaps_helpers.foreach_module

--- a/ast/cinaps/ast_cinaps_helpers.ml
+++ b/ast/cinaps/ast_cinaps_helpers.ml
@@ -7,7 +7,6 @@ let nl = Astlib_cinaps_helpers.nl
 let qualified_types = Astlib_cinaps_helpers.qualified_types
 let foreach_module = Astlib_cinaps_helpers.foreach_module
 let foreach_type = Astlib_cinaps_helpers.foreach_type
-
 let all_types = List.concat (List.map ~f:snd qualified_types)
 
 let foreach_version f =

--- a/ast/cinaps/dune
+++ b/ast/cinaps/dune
@@ -1,3 +1,3 @@
 (library
  (name ast_cinaps_helpers)
- (libraries supported_version astlib_cinaps_helpers))
+ (libraries stdppx supported_version astlib_cinaps_helpers))

--- a/ast/cinaps/dune
+++ b/ast/cinaps/dune
@@ -1,3 +1,3 @@
 (library
  (name ast_cinaps_helpers)
- (libraries supported_version))
+ (libraries supported_version astlib_cinaps_helpers))

--- a/ast/import.ml
+++ b/ast/import.ml
@@ -4,6 +4,8 @@
    It must be opened in all modules, especially the ones coming from the compiler.
 *)
 
+(*$ open Ast_cinaps_helpers $*)
+
 module Js = Versions.OCaml_500
 module Ocaml = Versions.OCaml_current
 
@@ -12,18 +14,43 @@ module Select_ast (Ocaml : Versions.OCaml_version) = struct
 
   module Type = struct
     type ('js, 'ocaml) t =
-      | Signature
-          : (Js.Ast.Parsetree.signature, Ocaml.Ast.Parsetree.signature) t
+      (*$ foreach_type (fun _ s ->
+            printf
+              "      | %s\n\
+              \          : ( Js.Ast.Parsetree.%s,\n\
+              \              Ocaml.Ast.Parsetree.%s )\n\
+              \            t\n"
+              (String.capitalize_ascii s) s s
+          )
+      *)
       | Structure
-          : (Js.Ast.Parsetree.structure, Ocaml.Ast.Parsetree.structure) t
+          : ( Js.Ast.Parsetree.structure,
+              Ocaml.Ast.Parsetree.structure )
+            t
+      | Signature
+          : ( Js.Ast.Parsetree.signature,
+              Ocaml.Ast.Parsetree.signature )
+            t
       | Toplevel_phrase
           : ( Js.Ast.Parsetree.toplevel_phrase,
               Ocaml.Ast.Parsetree.toplevel_phrase )
             t
-      | Expression
-          : (Js.Ast.Parsetree.expression, Ocaml.Ast.Parsetree.expression) t
       | Core_type
-          : (Js.Ast.Parsetree.core_type, Ocaml.Ast.Parsetree.core_type) t
+          : ( Js.Ast.Parsetree.core_type,
+              Ocaml.Ast.Parsetree.core_type )
+            t
+      | Expression
+          : ( Js.Ast.Parsetree.expression,
+              Ocaml.Ast.Parsetree.expression )
+            t
+      | Pattern
+          : ( Js.Ast.Parsetree.pattern,
+              Ocaml.Ast.Parsetree.pattern )
+            t
+      | Case
+          : ( Js.Ast.Parsetree.case,
+              Ocaml.Ast.Parsetree.case )
+            t
       | Type_declaration
           : ( Js.Ast.Parsetree.type_declaration,
               Ocaml.Ast.Parsetree.type_declaration )
@@ -36,6 +63,43 @@ module Select_ast (Ocaml : Versions.OCaml_version) = struct
           : ( Js.Ast.Parsetree.extension_constructor,
               Ocaml.Ast.Parsetree.extension_constructor )
             t
+      | Class_expr
+          : ( Js.Ast.Parsetree.class_expr,
+              Ocaml.Ast.Parsetree.class_expr )
+            t
+      | Class_field
+          : ( Js.Ast.Parsetree.class_field,
+              Ocaml.Ast.Parsetree.class_field )
+            t
+      | Class_type
+          : ( Js.Ast.Parsetree.class_type,
+              Ocaml.Ast.Parsetree.class_type )
+            t
+      | Class_signature
+          : ( Js.Ast.Parsetree.class_signature,
+              Ocaml.Ast.Parsetree.class_signature )
+            t
+      | Class_type_field
+          : ( Js.Ast.Parsetree.class_type_field,
+              Ocaml.Ast.Parsetree.class_type_field )
+            t
+      | Module_expr
+          : ( Js.Ast.Parsetree.module_expr,
+              Ocaml.Ast.Parsetree.module_expr )
+            t
+      | Module_type
+          : ( Js.Ast.Parsetree.module_type,
+              Ocaml.Ast.Parsetree.module_type )
+            t
+      | Signature_item
+          : ( Js.Ast.Parsetree.signature_item,
+              Ocaml.Ast.Parsetree.signature_item )
+            t
+      | Structure_item
+          : ( Js.Ast.Parsetree.structure_item,
+              Ocaml.Ast.Parsetree.structure_item )
+            t
+(*$*)
       | List : ('a, 'b) t -> ('a list, 'b list) t
       | Pair : ('a, 'b) t * ('c, 'd) t -> ('a * 'c, 'b * 'd) t
   end
@@ -48,14 +112,32 @@ module Select_ast (Ocaml : Versions.OCaml_version) = struct
     let open Of_ocaml in
     fun node ->
       match node with
-      | Signature -> copy_signature
+      (*$ foreach_type (fun _ s ->
+            printf
+              "      | %s -> copy_%s\n"
+              (String.capitalize_ascii s) s
+          )
+      *)
       | Structure -> copy_structure
+      | Signature -> copy_signature
       | Toplevel_phrase -> copy_toplevel_phrase
-      | Expression -> copy_expression
       | Core_type -> copy_core_type
+      | Expression -> copy_expression
+      | Pattern -> copy_pattern
+      | Case -> copy_case
       | Type_declaration -> copy_type_declaration
       | Type_extension -> copy_type_extension
       | Extension_constructor -> copy_extension_constructor
+      | Class_expr -> copy_class_expr
+      | Class_field -> copy_class_field
+      | Class_type -> copy_class_type
+      | Class_signature -> copy_class_signature
+      | Class_type_field -> copy_class_type_field
+      | Module_expr -> copy_module_expr
+      | Module_type -> copy_module_type
+      | Signature_item -> copy_signature_item
+      | Structure_item -> copy_structure_item
+(*$*)
       | List t -> List.map (of_ocaml t)
       | Pair (a, b) ->
           let f = of_ocaml a in
@@ -66,14 +148,32 @@ module Select_ast (Ocaml : Versions.OCaml_version) = struct
     let open To_ocaml in
     fun node ->
       match node with
-      | Signature -> copy_signature
+      (*$ foreach_type (fun _ s ->
+            printf
+              "      | %s -> copy_%s\n"
+              (String.capitalize_ascii s) s
+          )
+      *)
       | Structure -> copy_structure
+      | Signature -> copy_signature
       | Toplevel_phrase -> copy_toplevel_phrase
-      | Expression -> copy_expression
       | Core_type -> copy_core_type
+      | Expression -> copy_expression
+      | Pattern -> copy_pattern
+      | Case -> copy_case
       | Type_declaration -> copy_type_declaration
       | Type_extension -> copy_type_extension
       | Extension_constructor -> copy_extension_constructor
+      | Class_expr -> copy_class_expr
+      | Class_field -> copy_class_field
+      | Class_type -> copy_class_type
+      | Class_signature -> copy_class_signature
+      | Class_type_field -> copy_class_type_field
+      | Module_expr -> copy_module_expr
+      | Module_type -> copy_module_type
+      | Signature_item -> copy_signature_item
+      | Structure_item -> copy_structure_item
+(*$*)
       | List t -> List.map (to_ocaml t)
       | Pair (a, b) ->
           let f = to_ocaml a in

--- a/ast/import.ml
+++ b/ast/import.ml
@@ -20,7 +20,7 @@ module Select_ast (Ocaml : Versions.OCaml_version) = struct
               \          : ( Js.Ast.Parsetree.%s,\n\
               \              Ocaml.Ast.Parsetree.%s )\n\
               \            t\n"
-              (String.capitalize_ascii s) s s
+              (capitalize_ascii s) s s
           )
       *)
       | Structure
@@ -115,7 +115,7 @@ module Select_ast (Ocaml : Versions.OCaml_version) = struct
       (*$ foreach_type (fun _ s ->
             printf
               "      | %s -> copy_%s\n"
-              (String.capitalize_ascii s) s
+              (capitalize_ascii s) s
           )
       *)
       | Structure -> copy_structure
@@ -151,7 +151,7 @@ module Select_ast (Ocaml : Versions.OCaml_version) = struct
       (*$ foreach_type (fun _ s ->
             printf
               "      | %s -> copy_%s\n"
-              (String.capitalize_ascii s) s
+              (capitalize_ascii s) s
           )
       *)
       | Structure -> copy_structure

--- a/ast/versions.ml
+++ b/ast/versions.ml
@@ -46,6 +46,15 @@ module type Ast = sig
     type type_declaration
     type type_extension
     type extension_constructor
+    type class_expr
+    type class_field
+    type class_type
+    type class_signature
+    type class_type_field
+    type module_expr
+    type module_type
+    type signature_item
+    type structure_item
   end
 (*$*)
   module Config : sig
@@ -69,6 +78,15 @@ type 'a _types = 'a constraint 'a
     type_declaration      : _;
     type_extension        : _;
     extension_constructor : _;
+    class_expr            : _;
+    class_field           : _;
+    class_type            : _;
+    class_signature       : _;
+    class_type_field      : _;
+    module_expr           : _;
+    module_type           : _;
+    signature_item        : _;
+    structure_item        : _;
 (*$*)
   >
 ;;
@@ -97,6 +115,24 @@ type 'a get_type_extension =
   'x constraint 'a _types = < type_extension : 'x; .. >
 type 'a get_extension_constructor =
   'x constraint 'a _types = < extension_constructor : 'x; .. >
+type 'a get_class_expr =
+  'x constraint 'a _types = < class_expr : 'x; .. >
+type 'a get_class_field =
+  'x constraint 'a _types = < class_field : 'x; .. >
+type 'a get_class_type =
+  'x constraint 'a _types = < class_type : 'x; .. >
+type 'a get_class_signature =
+  'x constraint 'a _types = < class_signature : 'x; .. >
+type 'a get_class_type_field =
+  'x constraint 'a _types = < class_type_field : 'x; .. >
+type 'a get_module_expr =
+  'x constraint 'a _types = < module_expr : 'x; .. >
+type 'a get_module_type =
+  'x constraint 'a _types = < module_type : 'x; .. >
+type 'a get_signature_item =
+  'x constraint 'a _types = < signature_item : 'x; .. >
+type 'a get_structure_item =
+  'x constraint 'a _types = < structure_item : 'x; .. >
 (*$*)
 
 module type OCaml_version = sig
@@ -115,6 +151,15 @@ module type OCaml_version = sig
     type_declaration      : Ast.Parsetree.type_declaration;
     type_extension        : Ast.Parsetree.type_extension;
     extension_constructor : Ast.Parsetree.extension_constructor;
+    class_expr            : Ast.Parsetree.class_expr;
+    class_field           : Ast.Parsetree.class_field;
+    class_type            : Ast.Parsetree.class_type;
+    class_signature       : Ast.Parsetree.class_signature;
+    class_type_field      : Ast.Parsetree.class_type_field;
+    module_expr           : Ast.Parsetree.module_expr;
+    module_type           : Ast.Parsetree.module_type;
+    signature_item        : Ast.Parsetree.signature_item;
+    structure_item        : Ast.Parsetree.structure_item;
 (*$*)
   > _types
   type _ witnesses += Version : types witnesses
@@ -135,6 +180,15 @@ struct
     type_declaration      : Ast.Parsetree.type_declaration;
     type_extension        : Ast.Parsetree.type_extension;
     extension_constructor : Ast.Parsetree.extension_constructor;
+    class_expr            : Ast.Parsetree.class_expr;
+    class_field           : Ast.Parsetree.class_field;
+    class_type            : Ast.Parsetree.class_type;
+    class_signature       : Ast.Parsetree.class_signature;
+    class_type_field      : Ast.Parsetree.class_type_field;
+    module_expr           : Ast.Parsetree.module_expr;
+    module_type           : Ast.Parsetree.module_type;
+    signature_item        : Ast.Parsetree.signature_item;
+    structure_item        : Ast.Parsetree.structure_item;
 (*$*)
   > _types
   type _ witnesses += Version : types witnesses
@@ -157,6 +211,15 @@ type 'types ocaml_version =
      and type Ast.Parsetree.type_declaration = 'types get_type_declaration
      and type Ast.Parsetree.type_extension = 'types get_type_extension
      and type Ast.Parsetree.extension_constructor = 'types get_extension_constructor
+     and type Ast.Parsetree.class_expr = 'types get_class_expr
+     and type Ast.Parsetree.class_field = 'types get_class_field
+     and type Ast.Parsetree.class_type = 'types get_class_type
+     and type Ast.Parsetree.class_signature = 'types get_class_signature
+     and type Ast.Parsetree.class_type_field = 'types get_class_type_field
+     and type Ast.Parsetree.module_expr = 'types get_module_expr
+     and type Ast.Parsetree.module_type = 'types get_module_type
+     and type Ast.Parsetree.signature_item = 'types get_signature_item
+     and type Ast.Parsetree.structure_item = 'types get_structure_item
 (*$*)
   )
 
@@ -173,6 +236,15 @@ type ('from, 'to_) migration_functions = {
   copy_type_declaration: 'from get_type_declaration -> 'to_ get_type_declaration;
   copy_type_extension: 'from get_type_extension -> 'to_ get_type_extension;
   copy_extension_constructor: 'from get_extension_constructor -> 'to_ get_extension_constructor;
+  copy_class_expr: 'from get_class_expr -> 'to_ get_class_expr;
+  copy_class_field: 'from get_class_field -> 'to_ get_class_field;
+  copy_class_type: 'from get_class_type -> 'to_ get_class_type;
+  copy_class_signature: 'from get_class_signature -> 'to_ get_class_signature;
+  copy_class_type_field: 'from get_class_type_field -> 'to_ get_class_type_field;
+  copy_module_expr: 'from get_module_expr -> 'to_ get_module_expr;
+  copy_module_type: 'from get_module_type -> 'to_ get_module_type;
+  copy_signature_item: 'from get_signature_item -> 'to_ get_signature_item;
+  copy_structure_item: 'from get_structure_item -> 'to_ get_structure_item;
 (*$*)
 }
 
@@ -189,6 +261,15 @@ let migration_identity : ('a, 'a) migration_functions = {
   copy_type_declaration = id;
   copy_type_extension = id;
   copy_extension_constructor = id;
+  copy_class_expr = id;
+  copy_class_field = id;
+  copy_class_type = id;
+  copy_class_signature = id;
+  copy_class_type_field = id;
+  copy_module_expr = id;
+  copy_module_type = id;
+  copy_signature_item = id;
+  copy_structure_item = id;
 (*$*)
 }
 
@@ -206,6 +287,15 @@ let migration_compose (ab : ('a, 'b) migration_functions) (bc : ('b, 'c) migrati
   copy_type_declaration      = compose bc.copy_type_declaration      ab.copy_type_declaration;
   copy_type_extension        = compose bc.copy_type_extension        ab.copy_type_extension;
   copy_extension_constructor = compose bc.copy_extension_constructor ab.copy_extension_constructor;
+  copy_class_expr            = compose bc.copy_class_expr            ab.copy_class_expr;
+  copy_class_field           = compose bc.copy_class_field           ab.copy_class_field;
+  copy_class_type            = compose bc.copy_class_type            ab.copy_class_type;
+  copy_class_signature       = compose bc.copy_class_signature       ab.copy_class_signature;
+  copy_class_type_field      = compose bc.copy_class_type_field      ab.copy_class_type_field;
+  copy_module_expr           = compose bc.copy_module_expr           ab.copy_module_expr;
+  copy_module_type           = compose bc.copy_module_type           ab.copy_module_type;
+  copy_signature_item        = compose bc.copy_signature_item        ab.copy_signature_item;
+  copy_structure_item        = compose bc.copy_structure_item        ab.copy_structure_item;
 (*$*)
 }
 
@@ -226,6 +316,15 @@ module type Migrate_module = sig
   val copy_type_declaration     : From.Parsetree.type_declaration -> To.Parsetree.type_declaration
   val copy_type_extension       : From.Parsetree.type_extension -> To.Parsetree.type_extension
   val copy_extension_constructor: From.Parsetree.extension_constructor -> To.Parsetree.extension_constructor
+  val copy_class_expr           : From.Parsetree.class_expr -> To.Parsetree.class_expr
+  val copy_class_field          : From.Parsetree.class_field -> To.Parsetree.class_field
+  val copy_class_type           : From.Parsetree.class_type -> To.Parsetree.class_type
+  val copy_class_signature      : From.Parsetree.class_signature -> To.Parsetree.class_signature
+  val copy_class_type_field     : From.Parsetree.class_type_field -> To.Parsetree.class_type_field
+  val copy_module_expr          : From.Parsetree.module_expr -> To.Parsetree.module_expr
+  val copy_module_type          : From.Parsetree.module_type -> To.Parsetree.module_type
+  val copy_signature_item       : From.Parsetree.signature_item -> To.Parsetree.signature_item
+  val copy_structure_item       : From.Parsetree.structure_item -> To.Parsetree.structure_item
 (*$*)
 end
 
@@ -248,6 +347,15 @@ struct
       copy_type_declaration;
       copy_type_extension;
       copy_extension_constructor;
+      copy_class_expr;
+      copy_class_field;
+      copy_class_type;
+      copy_class_signature;
+      copy_class_type_field;
+      copy_module_expr;
+      copy_module_type;
+      copy_signature_item;
+      copy_structure_item;
 (*$*)
     }
 end
@@ -292,6 +400,15 @@ let immediate_migration
     (type type_declaration)
     (type type_extension)
     (type extension_constructor)
+    (type class_expr)
+    (type class_field)
+    (type class_type)
+    (type class_signature)
+    (type class_type_field)
+    (type module_expr)
+    (type module_type)
+    (type signature_item)
+    (type structure_item)
 (*$*)
     ((module A) : <
      (*$ foreach_type (fun _ s -> printf  "     %-21s : %s;\n" s s) *)
@@ -305,6 +422,15 @@ let immediate_migration
      type_declaration      : type_declaration;
      type_extension        : type_extension;
      extension_constructor : extension_constructor;
+     class_expr            : class_expr;
+     class_field           : class_field;
+     class_type            : class_type;
+     class_signature       : class_signature;
+     class_type_field      : class_type_field;
+     module_expr           : module_expr;
+     module_type           : module_type;
+     signature_item        : signature_item;
+     structure_item        : structure_item;
 (*$*)
      > ocaml_version)
     direction
@@ -330,6 +456,15 @@ let migrate
     (type type_declaration1) (type type_declaration2)
     (type type_extension1) (type type_extension2)
     (type extension_constructor1) (type extension_constructor2)
+    (type class_expr1) (type class_expr2)
+    (type class_field1) (type class_field2)
+    (type class_type1) (type class_type2)
+    (type class_signature1) (type class_signature2)
+    (type class_type_field1) (type class_type_field2)
+    (type module_expr1) (type module_expr2)
+    (type module_type1) (type module_type2)
+    (type signature_item1) (type signature_item2)
+    (type structure_item1) (type structure_item2)
 (*$*)
     ((module A) : <
      (*$ foreach_type (fun _ s -> printf "     %-21s : %s1;\n" s s) *)
@@ -343,6 +478,15 @@ let migrate
      type_declaration      : type_declaration1;
      type_extension        : type_extension1;
      extension_constructor : extension_constructor1;
+     class_expr            : class_expr1;
+     class_field           : class_field1;
+     class_type            : class_type1;
+     class_signature       : class_signature1;
+     class_type_field      : class_type_field1;
+     module_expr           : module_expr1;
+     module_type           : module_type1;
+     signature_item        : signature_item1;
+     structure_item        : structure_item1;
 (*$*)
      > ocaml_version)
     ((module B) : <
@@ -357,6 +501,15 @@ let migrate
      type_declaration      : type_declaration2;
      type_extension        : type_extension2;
      extension_constructor : extension_constructor2;
+     class_expr            : class_expr2;
+     class_field           : class_field2;
+     class_type            : class_type2;
+     class_signature       : class_signature2;
+     class_type_field      : class_type_field2;
+     module_expr           : module_expr2;
+     module_type           : module_type2;
+     signature_item        : signature_item2;
+     structure_item        : structure_item2;
 (*$*)
      > ocaml_version)
   : (A.types, B.types) migration_functions
@@ -392,6 +545,15 @@ module Convert (A : OCaml_version) (B : OCaml_version) = struct
     copy_type_declaration;
     copy_type_extension;
     copy_extension_constructor;
+    copy_class_expr;
+    copy_class_field;
+    copy_class_type;
+    copy_class_signature;
+    copy_class_type_field;
+    copy_module_expr;
+    copy_module_type;
+    copy_signature_item;
+    copy_structure_item;
 (*$*)
   } : (A.types, B.types) migration_functions =
     migrate (module A) (module B)

--- a/ast/versions.mli
+++ b/ast/versions.mli
@@ -37,6 +37,15 @@ module type Ast = sig
     type type_declaration
     type type_extension
     type extension_constructor
+    type class_expr
+    type class_field
+    type class_type
+    type class_signature
+    type class_type_field
+    type module_expr
+    type module_type
+    type signature_item
+    type structure_item
   end
 (*$*)
   module Config : sig
@@ -60,6 +69,15 @@ type 'a _types = 'a constraint 'a
     type_declaration      : _;
     type_extension        : _;
     extension_constructor : _;
+    class_expr            : _;
+    class_field           : _;
+    class_type            : _;
+    class_signature       : _;
+    class_type_field      : _;
+    module_expr           : _;
+    module_type           : _;
+    signature_item        : _;
+    structure_item        : _;
 (*$*)
   >
 ;;
@@ -98,6 +116,15 @@ module type OCaml_version = sig
     type_declaration      : Ast.Parsetree.type_declaration;
     type_extension        : Ast.Parsetree.type_extension;
     extension_constructor : Ast.Parsetree.extension_constructor;
+    class_expr            : Ast.Parsetree.class_expr;
+    class_field           : Ast.Parsetree.class_field;
+    class_type            : Ast.Parsetree.class_type;
+    class_signature       : Ast.Parsetree.class_signature;
+    class_type_field      : Ast.Parsetree.class_type_field;
+    module_expr           : Ast.Parsetree.module_expr;
+    module_type           : Ast.Parsetree.module_type;
+    signature_item        : Ast.Parsetree.signature_item;
+    structure_item        : Ast.Parsetree.structure_item;
 (*$*)
   > _types
 
@@ -155,6 +182,15 @@ module Convert (A : OCaml_version) (B : OCaml_version) : sig
   val copy_type_declaration      : A.Ast.Parsetree.type_declaration      -> B.Ast.Parsetree.type_declaration
   val copy_type_extension        : A.Ast.Parsetree.type_extension        -> B.Ast.Parsetree.type_extension
   val copy_extension_constructor : A.Ast.Parsetree.extension_constructor -> B.Ast.Parsetree.extension_constructor
+  val copy_class_expr            : A.Ast.Parsetree.class_expr            -> B.Ast.Parsetree.class_expr
+  val copy_class_field           : A.Ast.Parsetree.class_field           -> B.Ast.Parsetree.class_field
+  val copy_class_type            : A.Ast.Parsetree.class_type            -> B.Ast.Parsetree.class_type
+  val copy_class_signature       : A.Ast.Parsetree.class_signature       -> B.Ast.Parsetree.class_signature
+  val copy_class_type_field      : A.Ast.Parsetree.class_type_field      -> B.Ast.Parsetree.class_type_field
+  val copy_module_expr           : A.Ast.Parsetree.module_expr           -> B.Ast.Parsetree.module_expr
+  val copy_module_type           : A.Ast.Parsetree.module_type           -> B.Ast.Parsetree.module_type
+  val copy_signature_item        : A.Ast.Parsetree.signature_item        -> B.Ast.Parsetree.signature_item
+  val copy_structure_item        : A.Ast.Parsetree.structure_item        -> B.Ast.Parsetree.structure_item
 (*$*)
 end
 

--- a/astlib/cinaps/astlib_cinaps_helpers.ml
+++ b/astlib/cinaps/astlib_cinaps_helpers.ml
@@ -37,3 +37,37 @@ let foreach_version_pair f =
     | [ _ ] | [] -> ()
   in
   aux supported_versions
+
+(* Just for 4.14 <-> 5.00, mostly used by [ast_cinaps_helpers] *)
+
+let qualified_types =
+  [
+    ( "Parsetree",
+      [
+        "structure";
+        "signature";
+        "toplevel_phrase";
+        "core_type";
+        "expression";
+        "pattern";
+        "case";
+        "type_declaration";
+        "type_extension";
+        "extension_constructor";
+        "class_expr";
+        "class_field";
+        "class_type";
+        "class_signature";
+        "class_type_field";
+        "module_expr";
+        "module_type";
+        "signature_item";
+        "structure_item";
+      ] );
+  ]
+
+let foreach_module f =
+  nl ();
+  List.iter qualified_types ~f:(fun (m, types) -> f m types)
+
+let foreach_type f = foreach_module (fun m -> List.iter ~f:(f m))

--- a/astlib/migrate_414_500.ml
+++ b/astlib/migrate_414_500.ml
@@ -1,40 +1,90 @@
 module From = Ast_414
 module To = Ast_500
 
-let copy_structure : Ast_414.Parsetree.structure -> Ast_500.Parsetree.structure
-    =
- fun x -> x
+(*$ open Astlib_cinaps_helpers $*)
 
-let copy_signature : Ast_414.Parsetree.signature -> Ast_500.Parsetree.signature
-    =
- fun x -> x
+(*$ foreach_type (fun _ s ->
+      Printf.printf
+        "let copy_%s\n\
+        \  : Ast_414.Parsetree.%s -> Ast_500.Parsetree.%s\n\
+        \  = fun x -> x\n\n"
+        s s s
+  )
+*)
+let copy_structure
+  : Ast_414.Parsetree.structure -> Ast_500.Parsetree.structure
+  = fun x -> x
 
-let copy_toplevel_phrase :
-    Ast_414.Parsetree.toplevel_phrase -> Ast_500.Parsetree.toplevel_phrase =
- fun x -> x
+let copy_signature
+  : Ast_414.Parsetree.signature -> Ast_500.Parsetree.signature
+  = fun x -> x
 
-let copy_core_type : Ast_414.Parsetree.core_type -> Ast_500.Parsetree.core_type
-    =
- fun x -> x
+let copy_toplevel_phrase
+  : Ast_414.Parsetree.toplevel_phrase -> Ast_500.Parsetree.toplevel_phrase
+  = fun x -> x
 
-let copy_expression :
-    Ast_414.Parsetree.expression -> Ast_500.Parsetree.expression =
- fun x -> x
+let copy_core_type
+  : Ast_414.Parsetree.core_type -> Ast_500.Parsetree.core_type
+  = fun x -> x
 
-let copy_pattern : Ast_414.Parsetree.pattern -> Ast_500.Parsetree.pattern =
- fun x -> x
+let copy_expression
+  : Ast_414.Parsetree.expression -> Ast_500.Parsetree.expression
+  = fun x -> x
 
-let copy_case : Ast_414.Parsetree.case -> Ast_500.Parsetree.case = fun x -> x
+let copy_pattern
+  : Ast_414.Parsetree.pattern -> Ast_500.Parsetree.pattern
+  = fun x -> x
 
-let copy_type_declaration :
-    Ast_414.Parsetree.type_declaration -> Ast_500.Parsetree.type_declaration =
- fun x -> x
+let copy_case
+  : Ast_414.Parsetree.case -> Ast_500.Parsetree.case
+  = fun x -> x
 
-let copy_type_extension :
-    Ast_414.Parsetree.type_extension -> Ast_500.Parsetree.type_extension =
- fun x -> x
+let copy_type_declaration
+  : Ast_414.Parsetree.type_declaration -> Ast_500.Parsetree.type_declaration
+  = fun x -> x
 
-let copy_extension_constructor :
-    Ast_414.Parsetree.extension_constructor ->
-    Ast_500.Parsetree.extension_constructor =
- fun x -> x
+let copy_type_extension
+  : Ast_414.Parsetree.type_extension -> Ast_500.Parsetree.type_extension
+  = fun x -> x
+
+let copy_extension_constructor
+  : Ast_414.Parsetree.extension_constructor -> Ast_500.Parsetree.extension_constructor
+  = fun x -> x
+
+let copy_class_expr
+  : Ast_414.Parsetree.class_expr -> Ast_500.Parsetree.class_expr
+  = fun x -> x
+
+let copy_class_field
+  : Ast_414.Parsetree.class_field -> Ast_500.Parsetree.class_field
+  = fun x -> x
+
+let copy_class_type
+  : Ast_414.Parsetree.class_type -> Ast_500.Parsetree.class_type
+  = fun x -> x
+
+let copy_class_signature
+  : Ast_414.Parsetree.class_signature -> Ast_500.Parsetree.class_signature
+  = fun x -> x
+
+let copy_class_type_field
+  : Ast_414.Parsetree.class_type_field -> Ast_500.Parsetree.class_type_field
+  = fun x -> x
+
+let copy_module_expr
+  : Ast_414.Parsetree.module_expr -> Ast_500.Parsetree.module_expr
+  = fun x -> x
+
+let copy_module_type
+  : Ast_414.Parsetree.module_type -> Ast_500.Parsetree.module_type
+  = fun x -> x
+
+let copy_signature_item
+  : Ast_414.Parsetree.signature_item -> Ast_500.Parsetree.signature_item
+  = fun x -> x
+
+let copy_structure_item
+  : Ast_414.Parsetree.structure_item -> Ast_500.Parsetree.structure_item
+  = fun x -> x
+
+(*$*)

--- a/astlib/migrate_500_414.ml
+++ b/astlib/migrate_500_414.ml
@@ -1,40 +1,90 @@
 module From = Ast_500
 module To = Ast_414
 
-let copy_structure : Ast_500.Parsetree.structure -> Ast_414.Parsetree.structure
-    =
- fun x -> x
+(*$ open Astlib_cinaps_helpers $*)
 
-let copy_signature : Ast_500.Parsetree.signature -> Ast_414.Parsetree.signature
-    =
- fun x -> x
+(*$ foreach_type (fun _ s ->
+      Printf.printf
+        "let copy_%s\n\
+        \  : Ast_500.Parsetree.%s -> Ast_414.Parsetree.%s\n\
+        \  = fun x -> x\n\n"
+        s s s
+  )
+*)
+let copy_structure
+  : Ast_500.Parsetree.structure -> Ast_414.Parsetree.structure
+  = fun x -> x
 
-let copy_toplevel_phrase :
-    Ast_500.Parsetree.toplevel_phrase -> Ast_414.Parsetree.toplevel_phrase =
- fun x -> x
+let copy_signature
+  : Ast_500.Parsetree.signature -> Ast_414.Parsetree.signature
+  = fun x -> x
 
-let copy_core_type : Ast_500.Parsetree.core_type -> Ast_414.Parsetree.core_type
-    =
- fun x -> x
+let copy_toplevel_phrase
+  : Ast_500.Parsetree.toplevel_phrase -> Ast_414.Parsetree.toplevel_phrase
+  = fun x -> x
 
-let copy_expression :
-    Ast_500.Parsetree.expression -> Ast_414.Parsetree.expression =
- fun x -> x
+let copy_core_type
+  : Ast_500.Parsetree.core_type -> Ast_414.Parsetree.core_type
+  = fun x -> x
 
-let copy_pattern : Ast_500.Parsetree.pattern -> Ast_414.Parsetree.pattern =
- fun x -> x
+let copy_expression
+  : Ast_500.Parsetree.expression -> Ast_414.Parsetree.expression
+  = fun x -> x
 
-let copy_case : Ast_500.Parsetree.case -> Ast_414.Parsetree.case = fun x -> x
+let copy_pattern
+  : Ast_500.Parsetree.pattern -> Ast_414.Parsetree.pattern
+  = fun x -> x
 
-let copy_type_declaration :
-    Ast_500.Parsetree.type_declaration -> Ast_414.Parsetree.type_declaration =
- fun x -> x
+let copy_case
+  : Ast_500.Parsetree.case -> Ast_414.Parsetree.case
+  = fun x -> x
 
-let copy_type_extension :
-    Ast_500.Parsetree.type_extension -> Ast_414.Parsetree.type_extension =
- fun x -> x
+let copy_type_declaration
+  : Ast_500.Parsetree.type_declaration -> Ast_414.Parsetree.type_declaration
+  = fun x -> x
 
-let copy_extension_constructor :
-    Ast_500.Parsetree.extension_constructor ->
-    Ast_414.Parsetree.extension_constructor =
- fun x -> x
+let copy_type_extension
+  : Ast_500.Parsetree.type_extension -> Ast_414.Parsetree.type_extension
+  = fun x -> x
+
+let copy_extension_constructor
+  : Ast_500.Parsetree.extension_constructor -> Ast_414.Parsetree.extension_constructor
+  = fun x -> x
+
+let copy_class_expr
+  : Ast_500.Parsetree.class_expr -> Ast_414.Parsetree.class_expr
+  = fun x -> x
+
+let copy_class_field
+  : Ast_500.Parsetree.class_field -> Ast_414.Parsetree.class_field
+  = fun x -> x
+
+let copy_class_type
+  : Ast_500.Parsetree.class_type -> Ast_414.Parsetree.class_type
+  = fun x -> x
+
+let copy_class_signature
+  : Ast_500.Parsetree.class_signature -> Ast_414.Parsetree.class_signature
+  = fun x -> x
+
+let copy_class_type_field
+  : Ast_500.Parsetree.class_type_field -> Ast_414.Parsetree.class_type_field
+  = fun x -> x
+
+let copy_module_expr
+  : Ast_500.Parsetree.module_expr -> Ast_414.Parsetree.module_expr
+  = fun x -> x
+
+let copy_module_type
+  : Ast_500.Parsetree.module_type -> Ast_414.Parsetree.module_type
+  = fun x -> x
+
+let copy_signature_item
+  : Ast_500.Parsetree.signature_item -> Ast_414.Parsetree.signature_item
+  = fun x -> x
+
+let copy_structure_item
+  : Ast_500.Parsetree.structure_item -> Ast_414.Parsetree.structure_item
+  = fun x -> x
+
+(*$*)


### PR DESCRIPTION
This moves some cinaps stuff around, but otherwise is just a widening of the exposed APIs -- no new functionality is defined (except for a few new identity functions for the 4.14 <-> 5.00 nonmigration).

The motivation for this is that we would like to be able to link up `Pprintast` with the [flambda-backend](https://github.com/ocaml-flambda/flambda-backend) pretty-printer, and this requires the broader API surface area this PR exposes; to be clear, though, this PR doesn't do anything flambda-backend specific.