### PR TITLE
Fix minor error in README

### DIFF
--- a/examples/simple-extension-rewriter/README.md
+++ b/examples/simple-extension-rewriter/README.md
@@ -7,7 +7,7 @@ as a string.
 E.g., assuming we set `MY_VAR="foo"`, it will turn:
 
 ```ocaml
-let () = print_string [%get_env "foo"]
+let () = print_string [%get_env "MY_VAR"]
 ```
 
 into:


### PR DESCRIPTION
Currently learning OCaml so I may be missing something. This confused me for a few seconds.
If `MY_VAR="foo"`, it makes sense to `[%get_env "MY_VAR"]`, but not really `[%get_env "foo"]`.