### PR TITLE
Fix hash used by `Attribute.get`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 unreleased
 -------------------
 
+- Update `Attribute.get` to ignore `loc_ghost`. (#460, @ceastlund)
+
 - Add API to manipulate attributes that are used as flags (#408, @dianaoigo)
 
 - Update changelog to use ISO 8061 date format: YYYY-MM-DD. (#445, @ceastlund)

--- a/src/attribute.ml
+++ b/src/attribute.ml
@@ -307,8 +307,9 @@ let declare_flag name context =
 module Attribute_table = Stdlib.Hashtbl.Make (struct
   type t = string loc
 
-  let hash : t -> int = Hashtbl.hash
-  let equal : t -> t -> bool = Poly.equal
+  let normalize t = { t with loc = { t.loc with loc_ghost = true } }
+  let hash t = Hashtbl.hash (normalize t)
+  let equal x y = Poly.equal (normalize x) (normalize y)
 end)
 
 let not_seen = Attribute_table.create 128

--- a/test/driver/attributes/test.ml
+++ b/test/driver/attributes/test.ml
@@ -260,6 +260,5 @@ let () =
 
 let e = [%flag_ghost "bye" [@flag]]
 [%%expect{|
-Line _, characters 29-33:
-Error: Attribute `flag' was silently dropped
+val e : string * string = ("bye", "bye")
 |}]


### PR DESCRIPTION
Updated `Attribute.get` and `Attribute.has_flag` to ignore `loc_ghost` field of attribute locations. This allows flags to be used in code that is manipulated by other ppxes and has `loc_ghost` set to `false` along the way, when the original attribute in the source file had `loc_ghost` set to `true`.

The diff to the tests is probably slightly more readable commit-by-commit.