### PR TITLE
Sort errors by location before appending them to the AST

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 unreleased
 -------------------
 
+- Sort embedded errors that are appended to the AST by location so the compiler
+  reports the one closer to the beginning of the file first. (#463, @NathanReb)
+
 - Update `Attribute.get` to ignore `loc_ghost`. (#460, @ceastlund)
 
 - Add API to manipulate attributes that are used as flags (#408, @dianaoigo)

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -631,6 +631,12 @@ let print_passes () =
     if !perform_checks_on_extensions then
       Printf.printf "<builtin:check-unused-extensions>\n")
 
+let sort_errors_by_loc errors =
+  List.sort errors ~cmp:(fun error error' ->
+      let loc = Location.Error.get_location error in
+      let loc' = Location.Error.get_location error' in
+      Location.compare loc loc')
+
 (*$*)
 
 let map_structure_gen st ~tool_name ~hook ~expect_mismatch_handler ~input_name
@@ -652,7 +658,8 @@ let map_structure_gen st ~tool_name ~hook ~expect_mismatch_handler ~input_name
     st
   in
   let with_errors errors st =
-    List.map errors ~f:(fun error ->
+    let sorted = sort_errors_by_loc errors in
+    List.map sorted ~f:(fun error ->
         Ast_builder.Default.pstr_extension
           ~loc:(Location.Error.get_location error)
           (Location.Error.to_extension error)
@@ -727,7 +734,8 @@ let map_signature_gen sg ~tool_name ~hook ~expect_mismatch_handler ~input_name
     sg
   in
   let with_errors errors sg =
-    List.map errors ~f:(fun error ->
+    let sorted = sort_errors_by_loc errors in
+    List.map sorted ~f:(fun error ->
         Ast_builder.Default.psig_extension
           ~loc:(Location.Error.get_location error)
           (Location.Error.to_extension error)


### PR DESCRIPTION
This may seem like an unnecessary feature since the whole point of embedding errors is to allow reporting them all at once. This works with merlin but not with the compiler which will only report the first one it encounters.

You'll note I kept the `List.rev` that was added in #447 so that errors with the same loc will appear in the preserved transformation order. That shouldn't impact a lot of real life cases though.

This will help fixing #453 's tests as well.

Note that the cookies and checks error will still be appended before the transformation errors so they won't be displayed by the compiler if there is one transformation error, even though they may be located closer to the beginning of the file.
I'm happy to simply collect all such errors together, sort them and then append them to AST as one common batch of errors if you think this is okay and won't break anything.