### PR TITLE
Fix misleading error in man page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ unreleased
   transformations. All such errors are collected and appended as
   extension nodes to the final AST (#447, @burnleydev1)
 
+- Fix a small mistake in the man pages: Embededding errors is done by default with
+  `-as-pp`, not with `-dump-ast` (#464, @pitag-ha)
+
 0.31.0 (2023-09-21)
 -------------------
 

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -1348,7 +1348,7 @@ let standalone_args =
       " Print the parsetree (same as ocamlc -dparsetree)" );
     ( "-embed-errors",
       Arg.Set embed_errors,
-      " Embed errors in the output AST (default: true when -dump-ast, false \
+      " Embed errors in the output AST (default: true when -as-pp, false \
        otherwise)" );
     ( "-null",
       Arg.Unit (fun () -> set_output_mode Null),


### PR DESCRIPTION
I've noticed this small mistake in our man pages when checking how dune calls the PPX driver: It does so with `-dump-ast`, however errors are not embedded.