### PR TITLE
Set appropriate binary mode writing stdout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@ unreleased
 - Fix a small mistake in the man pages: Embededding errors is done by default with
   `-as-pp`, not with `-dump-ast` (#464, @pitag-ha)
 
+- Set appropriate binary mode when writing to `stdout` especially for Windows
+  compatibility. (#466, @jonahbeckford)
+
 0.31.0 (2023-09-21)
 -------------------
 

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -154,7 +154,11 @@ module Ast_io = struct
   let read input_source ~input_kind =
     try
       match input_source with
-      | Stdin -> from_channel stdin ~input_kind
+      | Stdin ->
+          (match input_kind with
+          | Necessarily_binary -> set_binary_mode_in stdin true
+          | _ -> ());
+          from_channel stdin ~input_kind
       | File fn -> In_channel.with_file fn ~f:(from_channel ~input_kind)
     with exn -> (
       match Location.Error.of_exn exn with

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -168,9 +168,7 @@ module Ast_io = struct
     try
       match input_source with
       | Stdin ->
-          (match input_kind with
-          | Necessarily_binary -> set_binary_mode_in stdin true
-          | _ -> ());
+          set_binary_mode_in stdin true;
           from_channel stdin ~input_kind
       | File fn -> In_channel.with_file fn ~f:(from_channel ~input_kind)
     with exn -> (

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -2,7 +2,9 @@ open Import
 
 let with_output fn ~binary ~f =
   match fn with
-  | None | Some "-" -> f stdout
+  | None | Some "-" ->
+      set_binary_mode_out stdout binary;
+      f stdout
   | Some fn -> Out_channel.with_file fn ~binary ~f
 
 module Kind = struct

--- a/test/driver/run_as_ppx_rewriter_preserve_version/print_magic_number.ml
+++ b/test/driver/run_as_ppx_rewriter_preserve_version/print_magic_number.ml
@@ -1,9 +1,5 @@
 let magic_length = String.length Astlib.Config.ast_impl_magic_number
 let buf = Bytes.create magic_length
-
-let len =
-  set_binary_mode_in stdin true;
-  input stdin buf 0 magic_length
-
+let len = input stdin buf 0 magic_length
 let s = Bytes.sub_string buf 0 len
 let () = Printf.printf "Magic number: %s" s

--- a/test/driver/run_as_ppx_rewriter_preserve_version/print_magic_number.ml
+++ b/test/driver/run_as_ppx_rewriter_preserve_version/print_magic_number.ml
@@ -1,5 +1,9 @@
 let magic_length = String.length Astlib.Config.ast_impl_magic_number
 let buf = Bytes.create magic_length
-let len = input stdin buf 0 magic_length
+
+let len =
+  set_binary_mode_in stdin true;
+  input stdin buf 0 magic_length
+
 let s = Bytes.sub_string buf 0 len
 let () = Printf.printf "Magic number: %s" s


### PR DESCRIPTION
TLDR: Windows needs the binary mode set.

Possible fix for https://github.com/ocaml-ppx/ppxlib/issues/466

### Context

I'm using Dune in an unusual way that is exposing this ppxlib bug. Basically, since I want to use PPX-es with Dune from a bytecode-only environment, and because Dune requires a C compiler to build a `(staged_pps)` or `(pps)` driver, I have to resort to:

```scheme
 (preprocess
  (action
   (run %{lib:TheNameOfTheLibrary:ppx.exe} -as-pp %{input-file})))
```

That in turn runs `-as-pp` which writes to `stdout`.

So:

```powershell
# Works
Y:\source\dksdk-type\tests\_std\lib\DkSDKCoder_PPX\ppx.exe -as-pp .\tests\_std\expression.ml -o a.pp.ml

# Fails
Y:\source\dksdk-type\tests\_std\lib\DkSDKCoder_PPX\ppx.exe -as-pp .\tests\_std\expression.ml
Caml1999M031Fatal error: exception Failure("output_value: not a binary channel")
Raised by primitive operation at Stdlib.output_value in file "stdlib.ml", line 386, characters 26-54
Called from Ppxlib__Utils.Ast_io.write.(fun) in file "src/utils.ml", line 187, characters 8-34
Called from Ppxlib__Driver.process_file in file "src/driver.ml", line 1169, characters 6-159
Called from Ppxlib__Driver.standalone in file "src/driver.ml", line 1541, characters 9-27
Re-raised at Location.report_exception.loop in file "parsing/location.ml", line 938, characters 14-25
Called from Ppxlib__Driver.standalone in file "src/driver.ml", line 1544, characters 4-59
Called from Dune__exe___ppx in file ".ppx/6241d9fed22cd957d799b2636a4b50f0/_ppx.ml-gen", line 1, characters 9-36
```
