### PR TITLE
Make `Context_free.map_top_down`'s `embed_errors` arg optional

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 unreleased
 -------------------
 
+- Add an optional `embed_errors` argument to `Context_free.map_top_down` that
+  controls how to deal with exceptions thrown by context-free rules.
+  (#<PR_NUMBER>, @NathanReb)
+
 - Fix `Longident.parse` so it properly handles unparenthesized dotted operators
   such as `+.` or `*.`. (#111, @rgrinberg, @NathanReb)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ unreleased
 
 - Add an optional `embed_errors` argument to `Context_free.map_top_down` that
   controls how to deal with exceptions thrown by context-free rules.
-  (#<PR_NUMBER>, @NathanReb)
+  (#468, @NathanReb)
 
 - Fix `Longident.parse` so it properly handles unparenthesized dotted operators
   such as `+.` or `*.`. (#111, @rgrinberg, @NathanReb)

--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -401,7 +401,8 @@ module Expect_mismatch_handler = struct
 end
 
 class map_top_down ?(expect_mismatch_handler = Expect_mismatch_handler.nop)
-  ?(generated_code_hook = Generated_code_hook.nop) rules ~embed_errors =
+  ?(generated_code_hook = Generated_code_hook.nop) ?(embed_errors = false) rules
+  =
   let hook = generated_code_hook in
 
   let special_functions =

--- a/src/context_free.mli
+++ b/src/context_free.mli
@@ -149,8 +149,8 @@ class map_top_down :
     Expect_mismatch_handler.t (* default: Expect_mismatch_handler.nop *) ->
   ?generated_code_hook:
     Generated_code_hook.t (* default: Generated_code_hook.nop *) ->
+  ?embed_errors:bool ->
   Rule.t list ->
-  embed_errors:bool ->
 object
   inherit Ast_traverse.map_with_expansion_context_and_errors
 end


### PR DESCRIPTION
This extra argument that was added in #453 caused breakage in `ocsigen-i18n` that was using `Context_free.map_top_down`.

Although it's undocumented, this function is still part of the public API. Adding an extra optional argument is not strictly speaking non-breaking but is good enough of an effort considering the status of this function and in particular, the fact that it only has a single public external user at the moment, for which it does prevent breakage.