### PR TITLE
Remove ocaml-compiler-libs pin

### DIFF
--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -51,6 +51,3 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
-pin-depends: [
-  [ "ocaml-compiler-libs.v0.11.0" "git+https://github.com/art-w/ocaml-compiler-libs.git#ocaml-5.2-trunk" ]
-]


### PR DESCRIPTION
This pin isn't required anymore since the release of `ocaml-compiler-libs.v0.17.0`