### PR TITLE
Turn OCaml != 5.1.0~aplha1 contraint to a conflict

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -15,7 +15,7 @@
 (package
  (name ppxlib)
  (depends
-  (ocaml (and (and (>= 4.04.1) (< 5.2.0)) (<> 5.1.0~alpha1)))
+  (ocaml (and (and (>= 4.04.1) (< 5.2.0))))
   (ocaml-compiler-libs (>= v0.11.0))
   (ppx_derivers (>= 1.0))
   (sexplib0 (>= v0.12))
@@ -26,6 +26,7 @@
   (cinaps (and :with-test (>= v0.12.1))))
  (conflicts
   (ocaml-migrate-parsetree (< 2.0.0))
+  (ocaml (= 5.1.0~alpha1))
   base-effects)
  (synopsis "Standard infrastructure for ppx rewriters")
  (description "Ppxlib is the standard infrastructure for ppx rewriters

--- a/dune-project
+++ b/dune-project
@@ -26,7 +26,8 @@
   (cinaps (and :with-test (>= v0.12.1))))
  (conflicts
   (ocaml-migrate-parsetree (< 2.0.0))
-  (ocaml (= 5.1.0~alpha1))
+  (ocaml-base-compiler (= 5.1.0~alpha1))
+  (ocaml-variants (= 5.1.0~alpha1+options))
   base-effects)
  (synopsis "Standard infrastructure for ppx rewriters")
  (description "Ppxlib is the standard infrastructure for ppx rewriters

--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -21,7 +21,7 @@ doc: "https://ocaml-ppx.github.io/ppxlib/"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.04.1" & < "5.2.0" & != "5.1.0~alpha1"}
+  "ocaml" {>= "4.04.1" & < "5.2.0"}
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ppx_derivers" {>= "1.0"}
   "sexplib0" {>= "v0.12"}
@@ -34,6 +34,7 @@ depends: [
 ]
 conflicts: [
   "ocaml-migrate-parsetree" {< "2.0.0"}
+  "ocaml" {= "5.1.0~alpha1"}
   "base-effects"
 ]
 build: [

--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -34,7 +34,8 @@ depends: [
 ]
 conflicts: [
   "ocaml-migrate-parsetree" {< "2.0.0"}
-  "ocaml" {= "5.1.0~alpha1"}
+  "ocaml-base-compiler" {= "5.1.0~alpha1"}
+  "ocaml-variants" {= "5.1.0~alpha1+options"}
   "base-effects"
 ]
 build: [


### PR DESCRIPTION
This will simplify the opam file a bit and make reading the range of supported ocaml versions easier.