### PR TITLE
Fix migration of Pexp_function type_constraints

### DIFF
--- a/astlib/migrate_501_502.ml
+++ b/astlib/migrate_501_502.ml
@@ -141,7 +141,7 @@ and copy_expression_desc loc :
               (* Same as above, might not roundtrip but hopefully OK. *)
               let c1 = Option.map copy_core_type c1
               and c2 = copy_core_type c2 in
-              (acc, Some (Ast_502.Parsetree.Pcoerce (c1, c2)), take_body e)
+              (acc, Some (Ast_502.Parsetree.Pcoerce (c1, c2)), take_body exp)
           | _ -> (acc, None, take_body e)
       and take_arguments_fun acc arg_label opt_default pat expr =
         let acc =


### PR DESCRIPTION
In 5.2 the representation of function expressions has been simplified. Among the simplifications, a `Pexp_function` now has a `type_constraint` argument that captures a type constraint or coercion on the function's return type.

E.g. in 5.01 the following:
```ocaml
let f x : string = x
```
was roughly:
```ocaml
Pexp_fun
  Nolabel
  None
  (Ppat_var "x")
  (Pexp_constraint (Pexp_ident "x") (Ptyp_constr "t")
```

In 5.02 it becomes:
```ocaml
Pexp_function
  [(Pparam_val Nolabel None (Ppat_var "x"))]
  (Some (Pconstraint (Ptyp_constr "t")))
  (Pfunction_body (Pexp_ident "x"))
```

It's worth noting that it's still possible to have the coercion or constraint in the function body. We chose to always extract it from the body and promote it to the `Pexp_function` argument when migrating from 5.1 to 5.2.

There was a bug in the coercion case where we were promoting it AND keeping it in the body which lead to compilation errors as the expression wasn't typing correctly anymore.