### PR TITLE
Fix source quotation in OCaml 5.2

### DIFF
--- a/astlib/location.ml
+++ b/astlib/location.ml
@@ -1,6 +1,7 @@
 include Ocaml_common.Location
 
 let set_input_name name = input_name := name
+let set_input_lexbuf lexbuf_opt = input_lexbuf := lexbuf_opt
 
 module Error = struct
   [@@@warning "-37"]

--- a/astlib/location.mli
+++ b/astlib/location.mli
@@ -46,6 +46,9 @@ with type location := t
 val set_input_name : string -> unit
 (** Set the name of the input source, e.g. the file name. *)
 
+val set_input_lexbuf : Lexing.lexbuf option -> unit
+(** Set the name of the input source, e.g. the file name. *)
+
 val none : t
 (** An arbitrary value of type [t]; describes an empty ghost range. *)
 

--- a/test/driver/source-quotation-in-errors/dune
+++ b/test/driver/source-quotation-in-errors/dune
@@ -1,0 +1,8 @@
+(executable
+ (name raising_driver)
+ (libraries ppxlib))
+
+(cram
+ (enabled_if
+  (>= %{ocaml_version} "4.08.0"))
+ (deps raising_driver.exe))

--- a/test/driver/source-quotation-in-errors/raising_driver.ml
+++ b/test/driver/source-quotation-in-errors/raising_driver.ml
@@ -1,0 +1,14 @@
+open Ppxlib
+
+let rules =
+  [
+    Extension.V3.declare "raise" Extension.Context.expression
+      Ast_pattern.(pstr nil)
+      (fun ~ctxt ->
+        let loc = Expansion_context.Extension.extension_point_loc ctxt in
+        Location.raise_errorf ~loc "An exception, raise be!")
+    |> Context_free.Rule.extension;
+  ]
+
+let () = Driver.V2.register_transformation ~rules "raise"
+let () = Driver.standalone ()

--- a/test/driver/source-quotation-in-errors/run.t
+++ b/test/driver/source-quotation-in-errors/run.t
@@ -1,0 +1,26 @@
+When the ppxlib driver reports an error by itself, source quotation should work
+properly.
+
+We start off by explicitly setting the error reporting style to contextual to
+ensure source quotation is enabled:
+
+  $ export OCAML_ERROR_STYLE=contextual
+
+Here we have a driver compiled with a single rule that will raise a located
+exception for every "[%raise]" extension point.
+
+We need an input file:
+
+  $ cat > file.ml << EOF
+  > let x = [%raise]
+  > EOF
+
+When running the driver on this file, it should report the error and show
+the relevant quoted source:
+
+  $ ./raising_driver.exe -impl file.ml
+  File "file.ml", line 1, characters 8-16:
+  1 | let x = [%raise]
+              ^^^^^^^^
+  Error: An exception, raise be!
+  [1]


### PR DESCRIPTION
The compiler removed some logic that was reopening the source file based on `Location.input_name` and instead only rely on `Location.input_lexbuf` for source quotation.

This PR first adds a test that rely on source quotation. Our test suite failed to catch this bug because all our tests use `OCAML_ERROR_STYLE=short`.
It then changes the way we read source files to stick to what the compiler does in `Pparse` while preserving our features such read from stdin. We now set the input_lexbuf properly.
