### PR TITLE
Add driver flag to force opting in to unused code warnings in derived code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ details.
 
 ### Other changes
 
+- Driver: Add `-unused-code-warnings=force` command-line flag argument. (#490, @mbarbin)
+
 - new functions `Ast_builder.{e,p}list_tail` that take an extra tail
   expression/pattern argument parameter compared to `Ast_builder.{e,p}list`, so
   they can build ASTs like `a :: b :: c` instead of only `[ a; b ]`.

--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -91,8 +91,21 @@ driver.exe [extra_args] [<files>]
   -no-merge                   Do not merge context free transformations (better for debugging rewriters). As a result, the context-free transformations are not all applied before all impl and intf.
   -cookie NAME=EXPR           Set the cookie NAME to EXPR
   --cookie                    Same as -cookie
-  -help                       Display this list of options
-  --help                      Display this list of options
+  -deriving-keep-w32 {impl|intf|both}
+                               Do not try to disable warning 32 for the generated code
+  -deriving-disable-w32-method {code|attribute}
+                               How to disable warning 32 for the generated code
+  -type-conv-keep-w32 {impl|intf|both}
+                               Deprecated, use -deriving-keep-w32
+  -type-conv-w32 {code|attribute}
+                               Deprecated, use -deriving-disable-w32-method
+  -deriving-keep-w60 {impl|intf|both}
+                               Do not try to disable warning 60 for the generated code
+  -unused-code-warnings {true|false|force}
+                               Allow ppx derivers to enable unused code warnings (default: false)
+  -help                        Display this list of options
+  --help                       Display this list of options
+
 v}
 {%html: </details>%}
 

--- a/src/options.ml
+++ b/src/options.ml
@@ -1,4 +1,8 @@
-let default_allow_unused_code_warnings = false
+module Forcable_bool = struct
+  type t = True | False | Force
+end
+
+let default_allow_unused_code_warnings : Forcable_bool.t = False
 let perform_checks = false
 
 (* The checks on extensions are only to get better error messages


### PR DESCRIPTION
To quote the documentation recently added for the disable warning flags:

> Ppxlib driver has a variety of ways to disable warnings that can be triggered when using `[@@deriving ...]`. These are all enabled by default but we added flags to let driver users disable them. To allow smooth transition from always adding them to never do so and let individual ppx-es do what they must to avoid triggering warnings, we also added optional arguments to `Deriving.make` so that the ppx themselves can declare whether they need the driver to disable warnings or not.
>
> One such flag and optional argument pair is the `-unused-code-warnings` flag and `?unused_code_warning` `Deriving.V2.make` argument. Both of those default to `false` and control whether we disable warnings 32 and 60 for generated code.

This PR adds a new value for the flag, in addition to `true|false`, it adds `force` which allows to force enabling unused code warnings even when the deriver arg was set to `false`. See the 2 new lines in the table documenting the combination of `Deriver arg` and `Driver Flag`:

```diff
 | Deriver arg | Driver Flag | Unused Code Warnings
 |-------------|-------------|----------------------
 | true        | true        | Enabled
 | true        | false       | Disabled*
+| true        | force       | Enabled
 | false       | true        | Disabled
 | false       | false       | Disabled
+| false       | force       | Enabled
```

Motivation:

This is a PR that was prompted by the discussion in #473 

In particular, I am interested to see what is the result of enabling unused code warnings locally without requiring the PPX author opt-in part of it.