### PR TITLE
Add an -unused-type-warnings flag to the driver 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 unreleased
 ----------
 
+- Add `-unused-type-warnings` flag to the driver to allow users to disable
+  the generation of warning 34 silencing structure items when using
+  `[@@deriving ...]` on type declarations. (#493, @NathanReb)
+
 - Fix `Longident.parse` so it also handles indexing operators such as
   `.!()`, `.%(;..)<-`, or `Vec.(.%())` (#494, @octachron)
 

--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -91,8 +91,22 @@ driver.exe [extra_args] [<files>]
   -no-merge                   Do not merge context free transformations (better for debugging rewriters). As a result, the context-free transformations are not all applied before all impl and intf.
   -cookie NAME=EXPR           Set the cookie NAME to EXPR
   --cookie                    Same as -cookie
-  -help                       Display this list of options
-  --help                      Display this list of options
+  -deriving-keep-w32 {impl|intf|both}
+                               Do not try to disable warning 32 for the generated code
+  -deriving-disable-w32-method {code|attribute}
+                               How to disable warning 32 for the generated code
+  -type-conv-keep-w32 {impl|intf|both}
+                               Deprecated, use -deriving-keep-w32
+  -type-conv-w32 {code|attribute}
+                               Deprecated, use -deriving-disable-w32-method
+  -deriving-keep-w60 {impl|intf|both}
+                               Do not try to disable warning 60 for the generated code
+  -unused-code-warnings _      Allow ppx derivers to enable unused code warnings
+  -unused-type-warnings {true|false}
+                               Allow unused type warnings for types with [@@deriving ...]
+  -help                        Display this list of options
+  --help                       Display this list of options
+
 v}
 {%html: </details>%}
 

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -67,6 +67,15 @@ let () =
     ~doc:"_ Allow ppx derivers to enable unused code warnings"
 
 let allow_unused_code_warnings () = !allow_unused_code_warnings
+let allow_unused_type_warnings = ref Options.default_allow_unused_type_warnings
+
+let () =
+  Driver.add_arg "-unused-type-warnings"
+    (Bool (( := ) allow_unused_type_warnings))
+    ~doc:
+      "{true|false} Allow unused type warnings for types with [@@deriving ...]"
+
+let allow_unused_type_warnings () = !allow_unused_type_warnings
 
 module Args = struct
   include (
@@ -701,7 +710,7 @@ let wrap_sig ~loc ~hide list =
    +-----------------------------------------------------------------+ *)
 
 let types_used_by_deriving (tds : type_declaration list) : structure_item list =
-  if keep_w32_impl () then []
+  if keep_w32_impl () || allow_unused_type_warnings () then []
   else
     List.map tds ~f:(fun td ->
         let typ = Common.core_type_of_type_declaration td in

--- a/src/options.ml
+++ b/src/options.ml
@@ -1,4 +1,5 @@
 let default_allow_unused_code_warnings = false
+let default_allow_unused_type_warnings = false
 let perform_checks = false
 
 (* The checks on extensions are only to get better error messages


### PR DESCRIPTION
This allows disabling the generation of `let _ = fun (_ : t) -> ()` strucutre items for each type using derivers.

The feature was meant to automatically disable warning 34 when using `[@@deriving ...]`.

This is based on top of #492 to ease testing for the feature, only the last commit is relevant.