### PR TITLE
Context_free: add a special_function' variant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ unreleased
 - Fix `Longident.parse` so it also handles indexing operators such as
   `.!()`, `.%(;..)<-`, or `Vec.(.%())` (#494, @octachron)
 
+- Add a `special_function'` variant which directly takes a `Longident.t`
+  argument to avoid the issue that `Longident.t` cover distinct syntaxic classes
+  which cannot be easily parsed by a common parser (#496, @octachron).
+
 0.32.1 (2024-04-23)
 -------------------
 

--- a/src/context_free.ml
+++ b/src/context_free.ml
@@ -130,6 +130,9 @@ module Rule = struct
   let special_function id f =
     T (Special_function, { name = id; ident = Longident.parse id; expand = f })
 
+  let special_function' ident f =
+    T (Special_function, { name = Longident.name ident; ident; expand = f })
+
   let constant kind suffix expand = T (Constant, { suffix; kind; expand })
 
   let attr_str_type_decl attribute expand =

--- a/src/context_free.mli
+++ b/src/context_free.mli
@@ -19,6 +19,8 @@ module Rule : sig
   (** Rewrite an extension point *)
 
   val special_function : string -> (expression -> expression option) -> t
+
+  val special_function' : Longident.t -> (expression -> expression option) -> t
   (** [special_function id expand] is a rule to rewrite a function call at
       parsing time. [id] is the identifier to match on and [expand] is used to
       expand the full function application (it gets the Pexp_apply node). If the
@@ -26,7 +28,9 @@ module Rule : sig
       the identifier (Pexp_ident node) so you should handle both cases.
 
       If [id] is an operator identifier and contains dots, it should be
-      parenthesized (e.g. ["(+.+)"]).
+      parenthesized (e.g. ["(+.+)"]). Another option is to use the
+      [special_function'] variant which takes directly a {!Longident.t}
+      argument.
 
       [expand] must decide whether the expression it receive can be rewritten or
       not. Especially ppxlib makes the assumption that [expand] is idempotent.


### PR DESCRIPTION
Parsing `Longindent.t`s is quite unpractical because `Longident.t` are used as an IR for different and distinct syntaxic classes. This means that interpreting the string argument of the `Context_free.special_function` is less trivial than it appears.

To circumvent this issue, this commit takes the view that in complex cases the user themself can still easily specify the identifier that they intended to use.

Thus it sounds sensible to provides a `special_function'` variant function which takes directly a `Longident.t` argument for advanced uses.