### PR TITLE
Add a trunk-build github action

### DIFF
--- a/.github/workflows/trunk-build.yml
+++ b/.github/workflows/trunk-build.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Pick up a robust cache prefix
         id: setup

--- a/.github/workflows/trunk-build.yml
+++ b/.github/workflows/trunk-build.yml
@@ -2,6 +2,8 @@ name: Build on `trunk`
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     # Every weekday, at 5:43 UTC

--- a/.github/workflows/trunk-build.yml
+++ b/.github/workflows/trunk-build.yml
@@ -1,0 +1,51 @@
+name: Build on `trunk`
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # Every weekday, at 5:43 UTC
+    - cron: '43 5 * * 1-5'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Pick up a robust cache prefix
+        id: setup
+        run: |
+          # Ensure that cache is flushed when trunk is updated
+          cache_prefix="$(git ls-remote https://github.com/ocaml/ocaml.git refs/heads/trunk | cut -f 1)"
+          echo "cache_prefix=$cache_prefix" >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
+
+      - name: Install OCaml compiler
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 'ocaml-variants.5.3.0+trunk'
+          dune-cache: true
+          cache-prefix: ${{ steps.setup.outputs.cache_prefix }}
+
+      - name: Install ppxlib dependencies
+        run: |
+          opam install ./ppxlib.opam --deps-only
+
+      - name: Show configuration
+        run: |
+          opam exec -- ocamlc -config
+          opam config list
+          opam exec -- dune printenv
+          opam list
+
+      - name: Build the ppxlib
+        run: opam exec -- dune build -p ppxlib @install
+
+      - name: Install test dependencies
+        run: |
+          opam install ./ppxlib.opam --deps-only -t
+          opam exec -- dune build -p ppxlib @runtest
+        continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Ppxlib - Meta-programming for OCaml
 
-[![ocaml-ci status][ocaml-ci-img]][ocaml-ci] [![AppVeyor status][appveyor-img]][appveyor]
+[![ocaml-ci status][ocaml-ci-img]][ocaml-ci] [![trunk-build-status][trunk-build-img]][trunk-build] [![AppVeyor status][appveyor-img]][appveyor]
 
 [ocaml-ci]: https://ci.ocamllabs.io/github/ocaml-ppx/ppxlib
 [ocaml-ci-img]: https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Focaml-ppx%2Fppxlib%2Fmain&logo=ocaml
 [appveyor]:       https://ci.appveyor.com/project/diml/ppxlib/branch/main
 [appveyor-img]:   https://ci.appveyor.com/api/projects/status/bogbsm33uvh083jx?svg=true
+[trunk-build]: https://github.com/ocaml-ppx/ppxlib/actions/workflows/trunk-build.yml
+[trunk-build-img]: https://github.com/ocaml-ppx/ppxlib/actions/workflows/trunk-build.yml/badge.svg?branch=main
 
 [Ppxlib documentation][doc]
 


### PR DESCRIPTION
Adds an action that builds with the latest supported trunk. We'll need this for incremental trunk support and I'd like to see it run on #487.

I heavily reused the work of @shym from #410, thank you for this contribution!