### PR TITLE
Rename and modify e/plist_v2 to e/plist_tail

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,10 @@
 unreleased
 ----------
 
-- new functions `Ast_builder.{e,p}list_v2` that take an extra `?tail:expression`
-  parameter compared to `Ast_builder.{e,p}list`, so they can build ASTs like
-  `a :: b :: c` instead of only `[ a; b ]`.
+- new functions `Ast_builder.{e,p}list_tail` that take an extra tail
+  expression/pattern argument parameter compared to `Ast_builder.{e,p}list`, so
+  they can build ASTs like `a :: b :: c` instead of only `[ a; b ]`.
+  (#498, #<PR_NUMBER>, @v-gb, @NathanReb)
 
 - Fix `Longident.parse` so it also handles indexing operators such as
   `.!()`, `.%(;..)<-`, or `Vec.(.%())` (#494, @octachron)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ unreleased
 - new functions `Ast_builder.{e,p}list_tail` that take an extra tail
   expression/pattern argument parameter compared to `Ast_builder.{e,p}list`, so
   they can build ASTs like `a :: b :: c` instead of only `[ a; b ]`.
-  (#498, #<PR_NUMBER>, @v-gb, @NathanReb)
+  (#498, #502, @v-gb, @NathanReb)
 
 - Fix `Longident.parse` so it also handles indexing operators such as
   `.!()`, `.%(;..)<-`, or `Vec.(.%())` (#494, @octachron)

--- a/src/ast_builder.ml
+++ b/src/ast_builder.ml
@@ -127,33 +127,33 @@ module Default = struct
   let econstruct cd arg =
     pexp_construct ~loc:cd.pcd_loc (Located.map_lident cd.pcd_name) arg
 
-  let rec elist_v2 ~loc ?tail l =
+  let rec elist_tail ~loc l tail =
     match l with
-    | [] -> (
-        match tail with
-        | Some e -> e
-        | None ->
-            pexp_construct ~loc (Located.mk ~loc (Longident.Lident "[]")) None)
+    | [] -> tail
     | x :: l ->
         pexp_construct ~loc
           (Located.mk ~loc (Longident.Lident "::"))
-          (Some (pexp_tuple ~loc [ x; elist_v2 ~loc ?tail l ]))
+          (Some (pexp_tuple ~loc [ x; elist_tail ~loc l tail ]))
 
-  let elist ~loc l = elist_v2 ~loc l
+  let elist ~loc l =
+    let tail =
+      pexp_construct ~loc (Located.mk ~loc (Longident.Lident "[]")) None
+    in
+    elist_tail ~loc l tail
 
-  let rec plist_v2 ~loc ?tail l =
+  let rec plist_tail ~loc l tail =
     match l with
-    | [] -> (
-        match tail with
-        | Some p -> p
-        | None ->
-            ppat_construct ~loc (Located.mk ~loc (Longident.Lident "[]")) None)
+    | [] -> tail
     | x :: l ->
         ppat_construct ~loc
           (Located.mk ~loc (Longident.Lident "::"))
-          (Some (ppat_tuple ~loc [ x; plist_v2 ~loc ?tail l ]))
+          (Some (ppat_tuple ~loc [ x; plist_tail ~loc l tail ]))
 
-  let plist ~loc l = plist_v2 ~loc l
+  let plist ~loc l =
+    let tail =
+      ppat_construct ~loc (Located.mk ~loc (Longident.Lident "[]")) None
+    in
+    plist_tail ~loc l tail
 
   let unapplied_type_constr_conv_without_apply ~loc (ident : Longident.t) ~f =
     match ident with
@@ -398,8 +398,8 @@ end) : S = struct
   let eapply e el = Default.eapply ~loc e el
   let eabstract ps e = Default.eabstract ~loc ps e
   let esequence el = Default.esequence ~loc el
-  let elist_v2 ?tail l = Default.elist_v2 ~loc ?tail l
-  let plist_v2 ?tail l = Default.plist_v2 ~loc ?tail l
+  let elist_tail l tail = Default.elist_tail ~loc l tail
+  let plist_tail l tail = Default.plist_tail ~loc l tail
   let elist l = Default.elist ~loc l
   let plist l = Default.plist ~loc l
 

--- a/src/ast_builder_intf.ml
+++ b/src/ast_builder_intf.ml
@@ -42,10 +42,22 @@ module type Additional_helpers = sig
   val pexp_tuple_opt : (expression list -> expression option) with_loc
   val pconstruct : constructor_declaration -> pattern option -> pattern
   val econstruct : constructor_declaration -> expression option -> expression
-  val elist_v2 : (?tail:expression -> expression list -> expression) with_loc
+
+  val elist_tail : (expression list -> expression -> expression) with_loc
+  (** [elist_tail ~loc [expr1; expr2; expr3] expr_tail] produces the expression
+      [expr1::expr2::expr3::expr_tail]. *)
+
   val elist : (expression list -> expression) with_loc
-  val plist_v2 : (?tail:pattern -> pattern list -> pattern) with_loc
+  (** [elist ~loc [expr1; expr2; expr3]] produces the list litteral expression
+      [[expr1; expr2; expr3]]. *)
+
+  val plist_tail : (pattern list -> pattern -> pattern) with_loc
+  (** [plist_tail ~loc [pat1; pat2; pat3] pat_tail] produces the pattern
+      [pat1::pat2::pat3::pat_tail]. *)
+
   val plist : (pattern list -> pattern) with_loc
+  (** [plist ~loc [pat1; pat2; pat3]] produces the list pattern
+      [[pat1; pat2; pat3]]. *)
 
   val pstr_value_list :
     loc:Location.t ->


### PR DESCRIPTION
This makes the tail argument mandatory, making it an alternative to e/plist rather than a replacement, as suggested by @ceastlund.