### PR TITLE
Fix -locations-check behaviour

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,9 @@ details.
 - Keep location ranges consistent when migrating `Pexp_function` nodes from 5.2+
   to older versions (#504, @jchavarri)
 
+- Fix `-locations-check` behaviour so it is no longer required to pass `-check`
+  as well to enable location checks. (#506, @NathanReb)
+
 
 0.32.1 (2024-04-23)
 -------------------

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -664,7 +664,7 @@ let map_structure_gen st ~tool_name ~hook ~expect_mismatch_handler ~input_name
   let cookies_and_check st =
     Cookies.call_post_handlers T;
     let errors =
-      if !perform_checks then (
+      if !perform_checks then
         (* TODO: these two passes could be merged, we now have more passes for
            checks than for actual rewriting. *)
         let unused_attributes_errors =
@@ -676,15 +676,15 @@ let map_structure_gen st ~tool_name ~hook ~expect_mismatch_handler ~input_name
           else []
         in
         let not_seen_errors = Attribute.collect_unseen_errors () in
-        (if !perform_locations_check then
-           let open Location_check in
-           ignore
-             ((enforce_invariants !loc_fname)#structure st
-                Non_intersecting_ranges.empty
-               : Non_intersecting_ranges.t));
-        unused_attributes_errors @ unused_extension_errors @ not_seen_errors)
+        unused_attributes_errors @ unused_extension_errors @ not_seen_errors
       else []
     in
+    (if !perform_locations_check then
+       let open Location_check in
+       ignore
+         ((enforce_invariants !loc_fname)#structure st
+            Non_intersecting_ranges.empty
+           : Non_intersecting_ranges.t));
     with_errors errors st
   in
   let file_path = get_default_path_str st in
@@ -740,7 +740,7 @@ let map_signature_gen sg ~tool_name ~hook ~expect_mismatch_handler ~input_name
   let cookies_and_check sg =
     Cookies.call_post_handlers T;
     let errors =
-      if !perform_checks then (
+      if !perform_checks then
         (* TODO: these two passes could be merged, we now have more passes for
            checks than for actual rewriting. *)
         let unused_attributes_errors =
@@ -752,15 +752,15 @@ let map_signature_gen sg ~tool_name ~hook ~expect_mismatch_handler ~input_name
           else []
         in
         let not_seen_errors = Attribute.collect_unseen_errors () in
-        (if !perform_locations_check then
-           let open Location_check in
-           ignore
-             ((enforce_invariants !loc_fname)#signature sg
-                Non_intersecting_ranges.empty
-               : Non_intersecting_ranges.t));
-        unused_attributes_errors @ unused_extension_errors @ not_seen_errors)
+        unused_attributes_errors @ unused_extension_errors @ not_seen_errors
       else []
     in
+    (if !perform_locations_check then
+       let open Location_check in
+       ignore
+         ((enforce_invariants !loc_fname)#signature sg
+            Non_intersecting_ranges.empty
+           : Non_intersecting_ranges.t));
     with_errors errors sg
   in
   let file_path = get_default_path_sig sg in


### PR DESCRIPTION
It used to be locked behind the `-check` flag as well, despite what the documentation stated. We might want to do the same for the check-on-extension as well.

It's worth noting that all checks are disabled by default so there's no problem with `-no-check` not disabling the location check anymore.