### PR TITLE
Update ocamlformat

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version=0.26.1
+version=0.26.2
 profile=conventional
 parse-docstrings=true


### PR DESCRIPTION
There are no change in formatting, it simply adds support for ocaml 5.2 and therefore allows working on ppxlib with a 5.2 switch.