### PR TITLE
Make `-unused-code-warnings` also controls warning 34 suppression items

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,10 @@ details.
 
 ### Other changes
 
+- Make `-unused-code-warnings` flag to the driver also controls the generation
+  of warning 34 silencing structure items when using `[@@deriving ...]` on type
+  declarations. (#510, @mbarbin, @NathanReb)
+
 - Driver: Add `-unused-code-warnings=force` command-line flag argument. (#490, @mbarbin)
 
 - new functions `Ast_builder.{e,p}list_tail` that take an extra tail


### PR DESCRIPTION
Instead of only controlling the generation of items to suppress warnings 32 and 60, makes this flag (and the respective Deriving arg) also control the item generated to suppress warning 34 (unused type declaration).

This is based on a recent discussion with @NathanReb in #490 .