### PR TITLE
Add an -unused-type-warnings flag to the driver (bis)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,10 @@ details.
 
 ### Other changes
 
+- Add `-unused-type-warnings` flag to the driver to allow users to disable
+  only the generation of warning 34 silencing structure items when using
+  `[@@deriving ...]` on type declarations. (#511, @mbarbin, @NathanReb)
+
 - Make `-unused-code-warnings` flag to the driver also controls the generation
   of warning 34 silencing structure items when using `[@@deriving ...]` on type
   declarations. (#510, @mbarbin, @NathanReb)

--- a/doc/driver.mld
+++ b/doc/driver.mld
@@ -103,6 +103,8 @@ driver.exe [extra_args] [<files>]
                                Do not try to disable warning 60 for the generated code
   -unused-code-warnings {true|false|force}
                                Allow ppx derivers to enable unused code warnings (default: false)
+  -unused-type-warnings {true|false|force}
+                               Allow unused type warnings for types with [@@deriving ...] (default: false)
   -help                        Display this list of options
   --help                       Display this list of options
 

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -65,15 +65,40 @@ let () =
   Driver.add_arg "-unused-code-warnings"
     (Symbol
        ( [ "true"; "false"; "force" ],
-         function
-         | "true" -> allow_unused_code_warnings := True
-         | "false" -> allow_unused_code_warnings := False
-         | "force" -> allow_unused_code_warnings := Force
-         | _ -> assert false ))
+         fun flag ->
+           allow_unused_code_warnings :=
+             match flag with
+             | "true" -> True
+             | "false" -> False
+             | "force" -> Force
+             | _ -> assert false ))
     ~doc:" Allow ppx derivers to enable unused code warnings (default: false)"
 
 let allow_unused_code_warnings ~ppx_allows_unused_code_warnings =
   match !allow_unused_code_warnings with
+  | Force -> true
+  | False -> false
+  | True -> ppx_allows_unused_code_warnings
+
+let allow_unused_type_warnings = ref Options.default_allow_unused_type_warnings
+
+let () =
+  Driver.add_arg "-unused-type-warnings"
+    (Symbol
+       ( [ "true"; "false"; "force" ],
+         fun flag ->
+           allow_unused_type_warnings :=
+             match flag with
+             | "true" -> True
+             | "false" -> False
+             | "force" -> Force
+             | _ -> assert false ))
+    ~doc:
+      " Allow unused type warnings for types with [@@deriving ...] (default: \
+       false)"
+
+let allow_unused_type_warnings ~ppx_allows_unused_code_warnings =
+  match !allow_unused_type_warnings with
   | Force -> true
   | False -> false
   | True -> ppx_allows_unused_code_warnings
@@ -712,13 +737,16 @@ let wrap_sig ~loc ~hide list =
    | Main expansion                                                  |
    +-----------------------------------------------------------------+ *)
 
-let types_used_by_deriving (tds : type_declaration list) ~unused_code_warnings :
-    structure_item list =
+let types_used_by_deriving (tds : type_declaration list)
+    ~unused_code_warnings:ppx_allows_unused_code_warnings : structure_item list
+    =
   let unused_code_warnings =
-    allow_unused_code_warnings
-      ~ppx_allows_unused_code_warnings:unused_code_warnings
+    allow_unused_code_warnings ~ppx_allows_unused_code_warnings
   in
-  if keep_w32_impl () || unused_code_warnings then []
+  let unused_type_warnings =
+    allow_unused_type_warnings ~ppx_allows_unused_code_warnings
+  in
+  if keep_w32_impl () || unused_code_warnings || unused_type_warnings then []
   else
     List.map tds ~f:(fun td ->
         let typ = Common.core_type_of_type_declaration td in

--- a/src/deriving.ml
+++ b/src/deriving.ml
@@ -63,15 +63,7 @@ let allow_unused_code_warnings = ref Options.default_allow_unused_code_warnings
 
 let () =
   Driver.add_arg "-unused-code-warnings"
-    (Symbol
-       ( [ "true"; "false"; "force" ],
-         fun flag ->
-           allow_unused_code_warnings :=
-             match flag with
-             | "true" -> True
-             | "false" -> False
-             | "force" -> Force
-             | _ -> assert false ))
+    (Options.Forcable_bool.arg allow_unused_code_warnings)
     ~doc:" Allow ppx derivers to enable unused code warnings (default: false)"
 
 let allow_unused_code_warnings ~ppx_allows_unused_code_warnings =
@@ -84,15 +76,7 @@ let allow_unused_type_warnings = ref Options.default_allow_unused_type_warnings
 
 let () =
   Driver.add_arg "-unused-type-warnings"
-    (Symbol
-       ( [ "true"; "false"; "force" ],
-         fun flag ->
-           allow_unused_type_warnings :=
-             match flag with
-             | "true" -> True
-             | "false" -> False
-             | "force" -> Force
-             | _ -> assert false ))
+    (Options.Forcable_bool.arg allow_unused_type_warnings)
     ~doc:
       " Allow unused type warnings for types with [@@deriving ...] (default: \
        false)"

--- a/src/options.ml
+++ b/src/options.ml
@@ -3,6 +3,7 @@ module Forcable_bool = struct
 end
 
 let default_allow_unused_code_warnings : Forcable_bool.t = False
+let default_allow_unused_type_warnings : Forcable_bool.t = False
 let perform_checks = false
 
 (* The checks on extensions are only to get better error messages

--- a/src/options.ml
+++ b/src/options.ml
@@ -1,5 +1,16 @@
 module Forcable_bool = struct
   type t = True | False | Force
+
+  let arg value =
+    Arg.Symbol
+      ( [ "true"; "false"; "force" ],
+        fun flag ->
+          value :=
+            match flag with
+            | "true" -> True
+            | "false" -> False
+            | "force" -> Force
+            | _ -> assert false )
 end
 
 let default_allow_unused_code_warnings : Forcable_bool.t = False

--- a/test/deriving_warning/run.t
+++ b/test/deriving_warning/run.t
@@ -296,7 +296,7 @@ Same goes for .mli:
 --------------------------------------------------------------------------------
 
 Whenever a set of types has a [@@deriving ...] attached, ppxlib's driver always
-generate structure items meant to disable unused type warnings (warning 34) for
+generates structure items meant to disable unused type warnings (warning 34) for
 any of those types.
 
 Let's consider the following piece of OCaml code:
@@ -328,8 +328,8 @@ We can see that the driver generated two `let _ = fun (_ : ...`, one for each ty
 in the set.
 
 As we mentioned before, the driver flag (`-unused-code-warnings`) allows the
-user to disable all warnings . In addition to this more general flag, we have a
-flag that disable only this part, and allows unused type warnings to be reported
+user to disable all warnings. In addition to this more general flag, we have a
+flag that disables only this part, and allows unused type warnings to be reported
 properly. Passing that flag to the driver should remove the two previously
 mentioned items, without affecting the rest of the generated anti-warning items:
 


### PR DESCRIPTION
Add -unused-type-warnings flag to the driver
    
This allows disabling the generation of `let _ = fun (_ : t) -> ()` strucutre items for each type using derivers.
    
The feature was meant to automatically disable warning 34 when using `[@@deriving ...]`
    
The changes are inspired by #493 but adapted for #510.

Prompted by a discussion with @NathanReb in #490 