### PR TITLE
Fix extension removal bug in `Code_path.main_module_name`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ details.
 
 - Fix a bug where `Code_path.main_module_name` would not properly remove
   extensions from the filename and therefore return an invalid module name.
-  (#<PR_NUMBER>, @NathanReb)
+  (#512, @NathanReb)
 
 - Add `-unused-type-warnings` flag to the driver to allow users to disable
   only the generation of warning 34 silencing structure items when using

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,10 @@ details.
 
 ### Other changes
 
+- Fix a bug where `Code_path.main_module_name` would not properly remove
+  extensions from the filename and therefore return an invalid module name.
+  (#<PR_NUMBER>, @NathanReb)
+
 - Add `-unused-type-warnings` flag to the driver to allow users to disable
   only the generation of warning 34 silencing structure items when using
   `[@@deriving ...]` on type declarations. (#511, @mbarbin, @NathanReb)

--- a/src/code_path.ml
+++ b/src/code_path.ml
@@ -10,9 +10,14 @@ type t = {
   in_expr : bool;
 }
 
+let remove_all_extensions basename =
+  match String.split_on_char ~sep:'.' basename with
+  | [] -> assert false
+  | name :: _ -> name
+
 let top_level ~file_path =
   let main_module_name =
-    file_path |> Stdlib.Filename.basename |> Stdlib.Filename.remove_extension
+    file_path |> Stdlib.Filename.basename |> remove_all_extensions
     |> String.capitalize_ascii
   in
   {

--- a/src/code_path.ml
+++ b/src/code_path.ml
@@ -12,7 +12,7 @@ type t = {
 
 let remove_all_extensions basename =
   match String.split_on_char ~sep:'.' basename with
-  | [] -> assert false
+  | [] -> assert false (* split_on_char never returns the empty list *)
   | name :: _ -> name
 
 let top_level ~file_path =

--- a/test/code_path/test.ml
+++ b/test/code_path/test.ml
@@ -142,3 +142,14 @@ let _ =
 - : string =
 "(code_path(main_module_name Test)(submodule_path())(enclosing_module Test)(enclosing_value())(value())(fully_qualified_path Test))"
 |}]
+
+
+let _ =
+  (* The main module name should properly remove all extensions *)
+  let code_path =
+    Code_path.top_level ~file_path:"some_dir/module_name.cppo.ml"
+  in
+  Code_path.main_module_name code_path
+[%%expect{|
+- : string = "Module_name"
+|}]


### PR DESCRIPTION
Fixes #403.

I'm not sure whether `Code_path` should ignore line directives or not but I do believe it should properly strip extensions. We can always make a different decision about line directive later if do causes trouble beyond this.