### PR TITLE
Ast_builder documentation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,9 +14,6 @@ details.
 
 ### Other changes
 
-- Support class type declarations in derivers with the new, optional arguments
-  `{str,sig}_class_type_decl` in `Deriving.add` (#538, @patricoferris)
-
 - Fix `deriving_inline` round-trip check so that it works with 5.01 <-> 5.02
   migrations (#519, @NathanReb)
 
@@ -27,6 +24,11 @@ details.
 - Change `-dparsetree` from a sexp output to a pretty printed AST, closer
   to what the compiler's `-dparsetree` is.
   (#530, @NathanReb)
+
+- Add Parsetree documentation comments to `Ast_builder` functions (#518, @patricoferris)
+
+- Support class type declarations in derivers with the new, optional arguments
+  `{str,sig}_class_type_decl` in `Deriving.add` (#538, @patricoferris)
 
 0.33.0 (2024-07-22)
 -------------------

--- a/src/ast_builder_intf.ml
+++ b/src/ast_builder_intf.ml
@@ -142,10 +142,6 @@ type 'a with_location = loc:Location.t -> 'a
 
 module type S = sig
   module Located : Located with type 'a with_loc := 'a without_location
-
-  include module type of Ast_builder_generated.Make (struct
-    let loc = Location.none
-  end)
-
+  include Ast_builder_generated.Intf_located
   include Additional_helpers with type 'a with_loc := 'a without_location
 end

--- a/src/gen/gen_ast_builder.ml
+++ b/src/gen/gen_ast_builder.ml
@@ -60,11 +60,9 @@ struct
     | [] -> M.ctyp "%s" typ_name
     | params ->
         let params =
-          List.fold_left params ~init:"" ~f:(fun acc (ctyp, _) ->
-              Format.asprintf "%a" A.ctyp ctyp ^ ", " ^ acc)
+          List.map params ~f:(fun (ctyp, _) -> Format.asprintf "%a" A.ctyp ctyp)
         in
-        let params = String.sub params ~pos:0 ~len:(String.length params - 2) in
-        M.ctyp "(%s) %s" params typ_name
+        M.ctyp "(%s) %s" (String.concat ~sep:", " params) typ_name
 
   let gen_combinator_for_constructor
       ~wrapper:(wpath, wprefix, has_attrs, has_loc_stack) path ~prefix

--- a/src/gen/gen_ast_builder.ml
+++ b/src/gen/gen_ast_builder.ml
@@ -248,6 +248,26 @@ let dump fn ~ext printer x =
   Format.fprintf ppf "%a@." printer x;
   close_out oc
 
+let floating_comment s =
+  let doc =
+    PStr
+      [
+        {
+          pstr_desc =
+            Pstr_eval
+              ( {
+                  pexp_desc = Pexp_constant (Pconst_string (s, loc, None));
+                  pexp_loc = loc;
+                  pexp_loc_stack = [];
+                  pexp_attributes = [];
+                },
+                [] );
+          pstr_loc = loc;
+        };
+      ]
+  in
+  Sig.attribute (Attr.mk { txt = "ocaml.text"; loc } doc)
+
 let generate filename =
   (*  let fn = Misc.find_in_path_uncap !Config.load_path (unit ^ ".cmi") in*)
   let types = get_types ~filename in
@@ -320,7 +340,7 @@ let generate filename =
                 Bytes.set bs 0 (Char.uppercase_ascii @@ Bytes.get bs 0);
                 String.concat ~sep:" " (Bytes.to_string bs :: rest)
           in
-          (M.sigi "(** {2 %s} *)" label :: items) @ acc)
+          (floating_comment (Format.asprintf "{2 %s}" label) :: items) @ acc)
         (mod_sig_items located) []
     in
     let items =

--- a/src/gen/gen_ast_builder.ml
+++ b/src/gen/gen_ast_builder.ml
@@ -144,7 +144,7 @@ struct
         in
         (str, (Format.asprintf "%a" A.ctyp return_type, sign))
 
-  let gen_combinator_for_record path ~prefix return_type attrs lds =
+  let gen_combinator_for_record path ~prefix return_type lds =
     let fields =
       List.map lds ~f:(fun ld -> fqn_longident path ld.pld_name.txt)
     in
@@ -180,15 +180,15 @@ struct
         M.expr "fun ~loc -> %a" A.expr body
       else body
     in
-    let return_type = core_type_of_return_type return_type in
+    let return_ctyp = core_type_of_return_type return_type in
     let typ =
       let l =
         List.filter funcs ~f:(fun (_, f) -> f <> "loc" && f <> "attributes")
       in
       match l with
-      | [ (c, _) ] -> M.ctyp "%a -> %a" A.ctyp c A.ctyp return_type
+      | [ (c, _) ] -> M.ctyp "%a -> %a" A.ctyp c A.ctyp return_ctyp
       | _ ->
-          List.fold_right l ~init:return_type ~f:(fun (typ, func) acc ->
+          List.fold_right l ~init:return_ctyp ~f:(fun (typ, func) acc ->
               M.ctyp "%s:%a -> %a" func A.ctyp typ A.ctyp acc)
     in
     let typ =
@@ -207,10 +207,10 @@ struct
         A.ctyp typ
         (doc_comment
            ~function_name:(function_name_of_path path)
-           ~node_name:(Format.asprintf "%a" A.ctyp return_type)
-           attrs)
+           ~node_name:(Format.asprintf "%a" A.ctyp return_ctyp)
+           return_type.ptype_attributes)
     in
-    (str, (Format.asprintf "%a" A.ctyp return_type, sign))
+    (str, (Format.asprintf "%a" A.ctyp return_ctyp, sign))
 
   let gen_td ?wrapper path td =
     if is_loc path then []
@@ -227,7 +227,7 @@ struct
                 ~f:(gen_combinator_for_constructor ~wrapper path ~prefix td))
       | Ptype_record lds ->
           let prefix = prefix_of_record lds in
-          [ gen_combinator_for_record path ~prefix td td.ptype_attributes lds ]
+          [ gen_combinator_for_record path ~prefix td lds ]
       | Ptype_abstract | Ptype_open -> []
 end
 

--- a/src/gen/import.ml
+++ b/src/gen/import.ml
@@ -135,7 +135,7 @@ module M = struct
       (fun s ->
         match Parse.interface (Lexing.from_string s) with
         | [ x ] -> x
-        | _ -> assert false)
+        | _ -> failwith ("Failed to parse: " ^ s))
       fmt
 end
 

--- a/src/gen/import.ml
+++ b/src/gen/import.ml
@@ -120,11 +120,20 @@ module M = struct
   let patt fmt = parse Parse.pattern fmt
   let ctyp fmt = parse Parse.core_type fmt
   let str fmt = parse Parse.implementation fmt
+  let sign fmt = parse Parse.interface fmt
 
   let stri fmt =
     Format.kasprintf
       (fun s ->
         match Parse.implementation (Lexing.from_string s) with
+        | [ x ] -> x
+        | _ -> assert false)
+      fmt
+
+  let sigi fmt =
+    Format.kasprintf
+      (fun s ->
+        match Parse.interface (Lexing.from_string s) with
         | [ x ] -> x
         | _ -> assert false)
       fmt


### PR DESCRIPTION
Related to: https://github.com/ocaml-ppx/ppxlib/issues/324, https://github.com/ocaml-ppx/ppxlib/issues/435

Much of `Ast_builder` is undocumented. The names of functions are derived from the things they construct from `Ast.ml` (mostly AST nodes from `Parsetree`). The parsetree is well-documented. This PR pulls through that documentation directly to `Ast_builder`.

In order for this to work well, the `gen_ast_builder` script now produces module types for the interface to `Ast_builder` (one for functions with `~loc` arguments called `S_located` and one without, corresponding to the original `S`).

Before:

<img width="1341" alt="Screenshot 2024-08-30 at 14 53 03" src="https://github.com/user-attachments/assets/e6b32390-06da-47e8-b26c-a371e7b6b29f">


After:

<img width="1344" alt="Screenshot 2024-08-30 at 14 49 12" src="https://github.com/user-attachments/assets/27061cca-0a38-47a9-be2e-db30d703ccd8">

_Known problems_:

Some of the doc attributes pulled from the parsetree contain odoc references which clash with the function names defined in the generated code e.g. `type label_declaration` and `val label_declaration` clash for the documentation comment attached to `ptyp_poly`.

---

If there is agreement to add this we could do the same for `Ast_pattern` I'm sure.