### PR TITLE
Fix roundtrip check to support 5.1 <-> 5.2 migrations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@ details.
 
 ### Other changes
 
+- Fix `deriving_inline` round-trip check so that it works with 5.01 <-> 5.02
+  migrations (#519, @NathanReb)
+
 0.33.0 (2024-07-22)
 -------------------
 

--- a/astlib/astlib.ml
+++ b/astlib/astlib.ml
@@ -89,6 +89,12 @@ module Location = Location
 module Longident = Longident
 module Parse = Parse
 module Pprintast = Pprintast
+module Compiler_pprintast = struct
+  include Ocaml_common.Pprintast
+
+  let structure_item fmt t = structure fmt [t]
+  let signature_item fmt t = signature fmt [t]
+end
 
 let init_error_reporting_style_using_env_vars () =
   (*IF_AT_LEAST 408 Ocaml_common.Compmisc.read_clflags_from_env () *)


### PR DESCRIPTION
Printing to source code and parsing with the compiler before running the upward migration is expected to fail because
`fun x y -> z` and `fun x -> fun y -> z` parse to the same AST on 5.01- but have different representations on OCaml 5.02+.

We therefore need to first migrate it to the compiler version before printing it so that it is properly annotated with attributes by the downward migration, allowing the upward one to preserve the original AST.