### PR TITLE
Simple pp output

### DIFF
--- a/src/driver.ml
+++ b/src/driver.ml
@@ -913,6 +913,7 @@ let load_source_file fn =
 
 type output_mode =
   | Pretty_print
+  | Pp_simple
   | Dump_ast
   | Dparsetree
   | Reconcile of Reconcile.mode
@@ -1149,6 +1150,14 @@ let process_file (kind : Kind.t) fn ~input_name ~relocate ~output_mode
           Ast_io.write oc
             { input_name; input_version; ast }
             ~add_ppx_context:true)
+  | Pp_simple ->
+      with_output output ~binary:false ~f:(fun oc ->
+          let ppf = Stdlib.Format.formatter_of_out_channel oc in
+          let ast = add_cookies ast in
+          (match ast with
+          | Intf ast -> Pp_ast.signature ppf ast
+          | Impl ast -> Pp_ast.structure ppf ast);
+          Stdlib.Format.pp_print_newline ppf ())
   | Dparsetree ->
       with_output output ~binary:false ~f:(fun oc ->
           let ppf = Stdlib.Format.formatter_of_out_channel oc in
@@ -1191,11 +1200,12 @@ let set_output_mode mode =
   match (!output_mode, mode) with
   | Pretty_print, _ -> output_mode := mode
   | _, Pretty_print -> assert false
-  | Dump_ast, Dump_ast | Dparsetree, Dparsetree -> ()
+  | Dump_ast, Dump_ast | Pp_simple, Pp_simple | Dparsetree, Dparsetree -> ()
   | Reconcile a, Reconcile b when Poly.equal a b -> ()
   | x, y ->
       let arg_of_output_mode = function
         | Pretty_print -> assert false
+        | Pp_simple -> "-pp-simple"
         | Dump_ast -> "-dump-ast"
         | Dparsetree -> "-dparsetree"
         | Reconcile Using_line_directives -> "-reconcile"
@@ -1343,6 +1353,14 @@ let standalone_args =
       Arg.Unit (fun () -> set_output_mode Dump_ast),
       " Dump the marshaled ast to the output file instead of pretty-printing it"
     );
+    ( "-pp-simple",
+      Arg.Unit (fun () -> set_output_mode Pp_simple),
+      " Pretty-print a simple version of the AST using the internal Pp_ast \
+       module. This is useful for comparing ASTs. For more configuration see \
+       the ppxlib-tools package." );
+    ( "--pp-simple",
+      Arg.Unit (fun () -> set_output_mode Pp_simple),
+      " Same as -pp-simple" );
     ( "--dump-ast",
       Arg.Unit (fun () -> set_output_mode Dump_ast),
       " Same as -dump-ast" );

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -913,7 +913,7 @@ let load_source_file fn =
 
 type output_mode =
   | Pretty_print
-  | Pp_simple
+  | Pp_ast
   | Dump_ast
   | Dparsetree
   | Reconcile of Reconcile.mode
@@ -1150,7 +1150,7 @@ let process_file (kind : Kind.t) fn ~input_name ~relocate ~output_mode
           Ast_io.write oc
             { input_name; input_version; ast }
             ~add_ppx_context:true)
-  | Pp_simple ->
+  | Pp_ast ->
       with_output output ~binary:false ~f:(fun oc ->
           let ppf = Stdlib.Format.formatter_of_out_channel oc in
           let ast = add_cookies ast in
@@ -1200,12 +1200,12 @@ let set_output_mode mode =
   match (!output_mode, mode) with
   | Pretty_print, _ -> output_mode := mode
   | _, Pretty_print -> assert false
-  | Dump_ast, Dump_ast | Pp_simple, Pp_simple | Dparsetree, Dparsetree -> ()
+  | Dump_ast, Dump_ast | Pp_ast, Pp_ast | Dparsetree, Dparsetree -> ()
   | Reconcile a, Reconcile b when Poly.equal a b -> ()
   | x, y ->
       let arg_of_output_mode = function
         | Pretty_print -> assert false
-        | Pp_simple -> "-pp-simple"
+        | Pp_ast -> "-pp-ast"
         | Dump_ast -> "-dump-ast"
         | Dparsetree -> "-dparsetree"
         | Reconcile Using_line_directives -> "-reconcile"
@@ -1353,13 +1353,13 @@ let standalone_args =
       Arg.Unit (fun () -> set_output_mode Dump_ast),
       " Dump the marshaled ast to the output file instead of pretty-printing it"
     );
-    ( "-pp-simple",
-      Arg.Unit (fun () -> set_output_mode Pp_simple),
+    ( "-pp-ast",
+      Arg.Unit (fun () -> set_output_mode Pp_ast),
       " Pretty-print a simple version of the AST using the internal Pp_ast \
        module. This is useful for comparing ASTs. For more configuration see \
        the ppxlib-tools package." );
-    ( "--pp-simple",
-      Arg.Unit (fun () -> set_output_mode Pp_simple),
+    ( "--pp-ast",
+      Arg.Unit (fun () -> set_output_mode Pp_ast),
       " Same as -pp-simple" );
     ( "--dump-ast",
       Arg.Unit (fun () -> set_output_mode Dump_ast),

--- a/test/501_migrations/one_migration.t
+++ b/test/501_migrations/one_migration.t
@@ -4,1127 +4,159 @@ test checks whether parsing on 5.0.0 (result of test running on 5.0.0) is the sa
 parsing on 5.1.0 and then migrating down to 5.0.0 (result of test running on 5.1.0).
 
 The test is mostly useful for debuggung problems in a full round-trip. Since Ppxlib's
-`dparsetree` option doesn't compactify or strip locations, its output is very long.
+`pp-simple` option doesn't compactify or strip locations, its output is very long.
 So let's only keep one example.
 
   $ echo "let x : int = 5" > file.ml
-  $ ./identity_driver.exe -dparsetree file.ml
-  (((pstr_desc
-     (Pstr_attribute
-      ((attr_name
-        ((txt ocaml.ppx.context)
-         (loc
-          ((loc_start
-            ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-           (loc_end
-            ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-           (loc_ghost true)))))
-       (attr_payload
-        (PStr
-         (((pstr_desc
-            (Pstr_eval
-             ((pexp_desc
-               (Pexp_record
-                ((((txt (Lident tool_name))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_constant
-                     (Pconst_string ppxlib_driver
-                      ((loc_start
-                        ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                         (pos_cnum -1)))
-                       (loc_end
-                        ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                         (pos_cnum -1)))
-                       (loc_ghost true))
-                      ())))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident include_dirs))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident []))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident load_path))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident []))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident open_modules))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident []))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident for_package))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident None))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident debug))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident use_threads))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident use_vmthreads))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident recursive_types))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident principal))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident transparent_modules))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident unboxed_types))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident unsafe_string))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident cookies))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident []))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ()))))
-                ()))
-              (pexp_loc
-               ((loc_start
-                 ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-                (loc_end
-                 ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-                (loc_ghost true)))
-              (pexp_loc_stack ()) (pexp_attributes ()))
-             ()))
-           (pstr_loc
-            ((loc_start
-              ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-             (loc_end
-              ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-             (loc_ghost true)))))))
-       (attr_loc
-        ((loc_start
-          ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-         (loc_end ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-         (loc_ghost true))))))
-    (pstr_loc
-     ((loc_start ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-      (loc_end ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-      (loc_ghost true))))
-   ((pstr_desc
-     (Pstr_value Nonrecursive
-      (((pvb_pat
-         ((ppat_desc
-           (Ppat_constraint
-            ((ppat_desc
-              (Ppat_var
-               ((txt x)
-                (loc
-                 ((loc_start
-                   ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 4)))
-                  (loc_end
-                   ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 5)))
-                  (loc_ghost false))))))
-             (ppat_loc
-              ((loc_start
-                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 4)))
-               (loc_end
-                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 5)))
-               (loc_ghost false)))
-             (ppat_loc_stack ()) (ppat_attributes ()))
-            ((ptyp_desc
-              (Ptyp_poly ()
-               ((ptyp_desc
-                 (Ptyp_constr
-                  ((txt (Lident int))
-                   (loc
-                    ((loc_start
-                      ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0)
-                       (pos_cnum 8)))
-                     (loc_end
-                      ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0)
-                       (pos_cnum 11)))
-                     (loc_ghost false))))
-                  ()))
-                (ptyp_loc
-                 ((loc_start
-                   ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 8)))
-                  (loc_end
-                   ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 11)))
-                  (loc_ghost false)))
-                (ptyp_loc_stack ()) (ptyp_attributes ()))))
-             (ptyp_loc
-              ((loc_start
-                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 8)))
-               (loc_end
-                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 11)))
-               (loc_ghost true)))
-             (ptyp_loc_stack ()) (ptyp_attributes ()))))
-          (ppat_loc
-           ((loc_start
-             ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 4)))
-            (loc_end
-             ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 11)))
-            (loc_ghost true)))
-          (ppat_loc_stack ()) (ppat_attributes ())))
-        (pvb_expr
-         ((pexp_desc
-           (Pexp_constraint
-            ((pexp_desc (Pexp_constant (Pconst_integer 5 ())))
-             (pexp_loc
-              ((loc_start
-                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 14)))
-               (loc_end
-                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 15)))
-               (loc_ghost false)))
-             (pexp_loc_stack ()) (pexp_attributes ()))
-            ((ptyp_desc
-              (Ptyp_constr
-               ((txt (Lident int))
-                (loc
-                 ((loc_start
-                   ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 8)))
-                  (loc_end
-                   ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 11)))
-                  (loc_ghost false))))
-               ()))
-             (ptyp_loc
-              ((loc_start
-                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 8)))
-               (loc_end
-                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 11)))
-               (loc_ghost false)))
-             (ptyp_loc_stack ()) (ptyp_attributes ()))))
-          (pexp_loc
-           ((loc_start
-             ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 4)))
-            (loc_end
-             ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 15)))
-            (loc_ghost false)))
-          (pexp_loc_stack ()) (pexp_attributes ())))
-        (pvb_attributes ())
-        (pvb_loc
-         ((loc_start
-           ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 0)))
-          (loc_end
-           ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 15)))
-          (loc_ghost false)))))))
-    (pstr_loc
-     ((loc_start ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 0)))
-      (loc_end ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 15)))
-      (loc_ghost false)))))
+  $ ./identity_driver.exe -pp-simple file.ml
+  [ Pstr_attribute
+      { attr_name = "ocaml.ppx.context"
+      ; attr_payload =
+          PStr
+            [ Pstr_eval
+                ( Pexp_record
+                    ( [ ( Lident "tool_name"
+                        , Pexp_constant
+                            (Pconst_string ( "ppxlib_driver", __loc, None))
+                        )
+                      ; ( Lident "include_dirs"
+                        , Pexp_construct ( Lident "[]", None)
+                        )
+                      ; ( Lident "load_path"
+                        , Pexp_construct ( Lident "[]", None)
+                        )
+                      ; ( Lident "open_modules"
+                        , Pexp_construct ( Lident "[]", None)
+                        )
+                      ; ( Lident "for_package"
+                        , Pexp_construct ( Lident "None", None)
+                        )
+                      ; ( Lident "debug"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "use_threads"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "use_vmthreads"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "recursive_types"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "principal"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "transparent_modules"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "unboxed_types"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "unsafe_string"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "cookies"
+                        , Pexp_construct ( Lident "[]", None)
+                        )
+                      ]
+                    , None
+                    )
+                , __attrs
+                )
+            ]
+      ; attr_loc = __loc
+      }
+  ; Pstr_value
+      ( Nonrecursive
+      , [ { pvb_pat =
+              Ppat_constraint
+                ( Ppat_var "x"
+                , Ptyp_poly ( [], Ptyp_constr ( Lident "int", []))
+                )
+          ; pvb_expr =
+              Pexp_constraint
+                ( Pexp_constant (Pconst_integer ( "5", None))
+                , Ptyp_constr ( Lident "int", [])
+                )
+          ; pvb_attributes = __attrs
+          ; pvb_loc = __loc
+          }
+        ]
+      )
+  ]
 
   $ cat > file.ml << EOF
   > module F () = struct end
   > module M = F ()
   > EOF
-  $ ./identity_driver.exe -dparsetree file.ml
-  (((pstr_desc
-     (Pstr_attribute
-      ((attr_name
-        ((txt ocaml.ppx.context)
-         (loc
-          ((loc_start
-            ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-           (loc_end
-            ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-           (loc_ghost true)))))
-       (attr_payload
-        (PStr
-         (((pstr_desc
-            (Pstr_eval
-             ((pexp_desc
-               (Pexp_record
-                ((((txt (Lident tool_name))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_constant
-                     (Pconst_string ppxlib_driver
-                      ((loc_start
-                        ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                         (pos_cnum -1)))
-                       (loc_end
-                        ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                         (pos_cnum -1)))
-                       (loc_ghost true))
-                      ())))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident include_dirs))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident []))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident load_path))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident []))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident open_modules))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident []))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident for_package))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident None))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident debug))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident use_threads))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident use_vmthreads))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident recursive_types))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident principal))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident transparent_modules))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident unboxed_types))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident unsafe_string))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident cookies))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident []))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ()))))
-                ()))
-              (pexp_loc
-               ((loc_start
-                 ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-                (loc_end
-                 ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-                (loc_ghost true)))
-              (pexp_loc_stack ()) (pexp_attributes ()))
-             ()))
-           (pstr_loc
-            ((loc_start
-              ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-             (loc_end
-              ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-             (loc_ghost true)))))))
-       (attr_loc
-        ((loc_start
-          ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-         (loc_end ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-         (loc_ghost true))))))
-    (pstr_loc
-     ((loc_start ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-      (loc_end ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-      (loc_ghost true))))
-   ((pstr_desc
-     (Pstr_module
-      ((pmb_name
-        ((txt (F))
-         (loc
-          ((loc_start
-            ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 7)))
-           (loc_end
-            ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 8)))
-           (loc_ghost false)))))
-       (pmb_expr
-        ((pmod_desc
-          (Pmod_functor Unit
-           ((pmod_desc (Pmod_structure ()))
-            (pmod_loc
-             ((loc_start
-               ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 14)))
-              (loc_end
-               ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 24)))
-              (loc_ghost false)))
-            (pmod_attributes ()))))
-         (pmod_loc
-          ((loc_start
-            ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 9)))
-           (loc_end
-            ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 24)))
-           (loc_ghost false)))
-         (pmod_attributes ())))
-       (pmb_attributes ())
-       (pmb_loc
-        ((loc_start
-          ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 0)))
-         (loc_end ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 24)))
-         (loc_ghost false))))))
-    (pstr_loc
-     ((loc_start ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 0)))
-      (loc_end ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 24)))
-      (loc_ghost false))))
-   ((pstr_desc
-     (Pstr_module
-      ((pmb_name
-        ((txt (M))
-         (loc
-          ((loc_start
-            ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 32)))
-           (loc_end
-            ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 33)))
-           (loc_ghost false)))))
-       (pmb_expr
-        ((pmod_desc
-          (Pmod_apply
-           ((pmod_desc
-             (Pmod_ident
-              ((txt (Lident F))
-               (loc
-                ((loc_start
-                  ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 36)))
-                 (loc_end
-                  ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 37)))
-                 (loc_ghost false))))))
-            (pmod_loc
-             ((loc_start
-               ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 36)))
-              (loc_end
-               ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 37)))
-              (loc_ghost false)))
-            (pmod_attributes ()))
-           ((pmod_desc (Pmod_structure ()))
-            (pmod_loc
-             ((loc_start
-               ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 36)))
-              (loc_end
-               ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 40)))
-              (loc_ghost false)))
-            (pmod_attributes ()))))
-         (pmod_loc
-          ((loc_start
-            ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 36)))
-           (loc_end
-            ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 40)))
-           (loc_ghost false)))
-         (pmod_attributes ())))
-       (pmb_attributes ())
-       (pmb_loc
-        ((loc_start
-          ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 25)))
-         (loc_end
-          ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 40)))
-         (loc_ghost false))))))
-    (pstr_loc
-     ((loc_start ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 25)))
-      (loc_end ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 40)))
-      (loc_ghost false)))))
+  $ ./identity_driver.exe -pp-simple file.ml
+  [ Pstr_attribute
+      { attr_name = "ocaml.ppx.context"
+      ; attr_payload =
+          PStr
+            [ Pstr_eval
+                ( Pexp_record
+                    ( [ ( Lident "tool_name"
+                        , Pexp_constant
+                            (Pconst_string ( "ppxlib_driver", __loc, None))
+                        )
+                      ; ( Lident "include_dirs"
+                        , Pexp_construct ( Lident "[]", None)
+                        )
+                      ; ( Lident "load_path"
+                        , Pexp_construct ( Lident "[]", None)
+                        )
+                      ; ( Lident "open_modules"
+                        , Pexp_construct ( Lident "[]", None)
+                        )
+                      ; ( Lident "for_package"
+                        , Pexp_construct ( Lident "None", None)
+                        )
+                      ; ( Lident "debug"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "use_threads"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "use_vmthreads"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "recursive_types"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "principal"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "transparent_modules"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "unboxed_types"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "unsafe_string"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "cookies"
+                        , Pexp_construct ( Lident "[]", None)
+                        )
+                      ]
+                    , None
+                    )
+                , __attrs
+                )
+            ]
+      ; attr_loc = __loc
+      }
+  ; Pstr_module
+      { pmb_name = Some "F"
+      ; pmb_expr = Pmod_functor ( Unit, Pmod_structure [])
+      ; pmb_attributes = __attrs
+      ; pmb_loc = __loc
+      }
+  ; Pstr_module
+      { pmb_name = Some "M"
+      ; pmb_expr = Pmod_apply ( Pmod_ident (Lident "F"), Pmod_structure [])
+      ; pmb_attributes = __attrs
+      ; pmb_loc = __loc
+      }
+  ]

--- a/test/501_migrations/one_migration.t
+++ b/test/501_migrations/one_migration.t
@@ -3,70 +3,11 @@ as the ppxlib AST is either 5.0.0 or 5.1.0. While the ppxlib AST is on 5.0.0, th
 test checks whether parsing on 5.0.0 (result of test running on 5.0.0) is the same as
 parsing on 5.1.0 and then migrating down to 5.0.0 (result of test running on 5.1.0).
 
-The test is mostly useful for debuggung problems in a full round-trip. Since Ppxlib's
-`pp-simple` option doesn't compactify or strip locations, its output is very long.
-So let's only keep one example.
+The test is mostly useful for debuggung problems in a full round-trip.
 
   $ echo "let x : int = 5" > file.ml
-  $ ./identity_driver.exe -pp-simple file.ml
-  [ Pstr_attribute
-      { attr_name = "ocaml.ppx.context"
-      ; attr_payload =
-          PStr
-            [ Pstr_eval
-                ( Pexp_record
-                    ( [ ( Lident "tool_name"
-                        , Pexp_constant
-                            (Pconst_string ( "ppxlib_driver", __loc, None))
-                        )
-                      ; ( Lident "include_dirs"
-                        , Pexp_construct ( Lident "[]", None)
-                        )
-                      ; ( Lident "load_path"
-                        , Pexp_construct ( Lident "[]", None)
-                        )
-                      ; ( Lident "open_modules"
-                        , Pexp_construct ( Lident "[]", None)
-                        )
-                      ; ( Lident "for_package"
-                        , Pexp_construct ( Lident "None", None)
-                        )
-                      ; ( Lident "debug"
-                        , Pexp_construct ( Lident "false", None)
-                        )
-                      ; ( Lident "use_threads"
-                        , Pexp_construct ( Lident "false", None)
-                        )
-                      ; ( Lident "use_vmthreads"
-                        , Pexp_construct ( Lident "false", None)
-                        )
-                      ; ( Lident "recursive_types"
-                        , Pexp_construct ( Lident "false", None)
-                        )
-                      ; ( Lident "principal"
-                        , Pexp_construct ( Lident "false", None)
-                        )
-                      ; ( Lident "transparent_modules"
-                        , Pexp_construct ( Lident "false", None)
-                        )
-                      ; ( Lident "unboxed_types"
-                        , Pexp_construct ( Lident "false", None)
-                        )
-                      ; ( Lident "unsafe_string"
-                        , Pexp_construct ( Lident "false", None)
-                        )
-                      ; ( Lident "cookies"
-                        , Pexp_construct ( Lident "[]", None)
-                        )
-                      ]
-                    , None
-                    )
-                , __attrs
-                )
-            ]
-      ; attr_loc = __loc
-      }
-  ; Pstr_value
+  $ ./identity_driver.exe -pp-ast file.ml
+  [ Pstr_value
       ( Nonrecursive
       , [ { pvb_pat =
               Ppat_constraint
@@ -89,65 +30,8 @@ So let's only keep one example.
   > module F () = struct end
   > module M = F ()
   > EOF
-  $ ./identity_driver.exe -pp-simple file.ml
-  [ Pstr_attribute
-      { attr_name = "ocaml.ppx.context"
-      ; attr_payload =
-          PStr
-            [ Pstr_eval
-                ( Pexp_record
-                    ( [ ( Lident "tool_name"
-                        , Pexp_constant
-                            (Pconst_string ( "ppxlib_driver", __loc, None))
-                        )
-                      ; ( Lident "include_dirs"
-                        , Pexp_construct ( Lident "[]", None)
-                        )
-                      ; ( Lident "load_path"
-                        , Pexp_construct ( Lident "[]", None)
-                        )
-                      ; ( Lident "open_modules"
-                        , Pexp_construct ( Lident "[]", None)
-                        )
-                      ; ( Lident "for_package"
-                        , Pexp_construct ( Lident "None", None)
-                        )
-                      ; ( Lident "debug"
-                        , Pexp_construct ( Lident "false", None)
-                        )
-                      ; ( Lident "use_threads"
-                        , Pexp_construct ( Lident "false", None)
-                        )
-                      ; ( Lident "use_vmthreads"
-                        , Pexp_construct ( Lident "false", None)
-                        )
-                      ; ( Lident "recursive_types"
-                        , Pexp_construct ( Lident "false", None)
-                        )
-                      ; ( Lident "principal"
-                        , Pexp_construct ( Lident "false", None)
-                        )
-                      ; ( Lident "transparent_modules"
-                        , Pexp_construct ( Lident "false", None)
-                        )
-                      ; ( Lident "unboxed_types"
-                        , Pexp_construct ( Lident "false", None)
-                        )
-                      ; ( Lident "unsafe_string"
-                        , Pexp_construct ( Lident "false", None)
-                        )
-                      ; ( Lident "cookies"
-                        , Pexp_construct ( Lident "[]", None)
-                        )
-                      ]
-                    , None
-                    )
-                , __attrs
-                )
-            ]
-      ; attr_loc = __loc
-      }
-  ; Pstr_module
+  $ ./identity_driver.exe -pp-ast file.ml
+  [ Pstr_module
       { pmb_name = Some "F"
       ; pmb_expr = Pmod_functor ( Unit, Pmod_structure [])
       ; pmb_attributes = __attrs


### PR DESCRIPTION
This is just an idea to share based on #517 -- changing the migrations `run.t` to use this was very useful for debugging _more_ issues with the 5.2 AST bump cc @NathanReb. 

We discussed (offline) the possibility of changing `-dparsetree` to output the `Pp_ast` output. We would need to understand the downstream use-cases of `-dparsetree` before doing that.