### PR TITLE
Feat/pp ast pprintast

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -25,7 +25,8 @@
   (ocamlfind :with-test)
   (re (and :with-test (>= 1.9.0)))
   (cinaps (and :with-test (>= v0.12.1)))
-  (ocamlformat (and :with-dev-setup (= 0.26.2))))
+  (ocamlformat (and :with-dev-setup (= 0.26.2)))
+  (alcotest :with-test))
  (conflicts
   (ocaml-migrate-parsetree (< 2.0.0))
   (ocaml-base-compiler (= 5.1.0~alpha1))

--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -31,6 +31,7 @@ depends: [
   "re" {with-test & >= "1.9.0"}
   "cinaps" {with-test & >= "v0.12.1"}
   "ocamlformat" {with-dev-setup & = "0.26.2"}
+  "alcotest" {with-test}
   "odoc" {with-doc}
 ]
 conflicts: [

--- a/src/pp_ast.mli
+++ b/src/pp_ast.mli
@@ -69,3 +69,27 @@ val signature_item : signature_item pp
 val expression : expression pp
 val pattern : pattern pp
 val core_type : core_type pp
+
+module Kind : sig
+  type t = Signature | Structure | Expression | Pattern | Core_type
+end
+
+module Ast : sig
+  type t =
+    | Str of structure
+    | Sig of signature
+    | Exp of expression
+    | Pat of pattern
+    | Typ of core_type
+end
+
+val parse_node : kind:Kind.t -> Lexing.lexbuf -> Ast.t
+val pp_ast : config:Config.t -> Ast.t -> Format.formatter -> unit
+
+val sprint :
+  ?show_attrs:bool ->
+  ?show_locs:bool ->
+  ?loc_mode:[ `Full | `Short ] ->
+  ?kind:Kind.t ->
+  string ->
+  string

--- a/src/ppxlib.ml
+++ b/src/ppxlib.ml
@@ -62,7 +62,14 @@ module Ast_helper = Ppxlib_ast.Ast_helper
 module Asttypes = Ppxlib_ast.Asttypes
 module Parse = Ppxlib_ast.Parse
 module Parsetree = Ppxlib_ast.Parsetree
-module Pprintast = Ppxlib_ast.Pprintast
+
+module Pprintast = struct
+  include Ppxlib_ast.Pprintast
+  module Kind = Pp_ast.Kind
+
+  let sprint = Pp_ast.sprint
+end
+
 module Selected_ast = Ppxlib_ast.Selected_ast
 module Location = Location
 module Longident = Longident

--- a/test/pp_ast/dune
+++ b/test/pp_ast/dune
@@ -1,0 +1,9 @@
+(test
+ (name test)
+ (libraries ppxlib alcotest))
+
+(rule
+ (alias runtest)
+ (deps test.exe)
+ (action
+  (run %{deps})))

--- a/test/pp_ast/test.ml
+++ b/test/pp_ast/test.ml
@@ -1,0 +1,62 @@
+open Ppxlib
+
+let test title fn = Alcotest.test_case title `Quick fn
+
+let assert_string left right =
+  Alcotest.check Alcotest.string "should be equal" right left
+
+let sprint_ast_expr =
+  let ast = Pp_ast.sprint "42" in
+  test "sprint AST expression" @@ fun () ->
+  assert_string ast "Pexp_constant (Pconst_integer ( \"42\", None))"
+
+let sprint_ast_pat =
+  let ast = Pp_ast.sprint ~kind:Pp_ast.Kind.Pattern "42" in
+  test "sprint AST pattern" @@ fun () ->
+  assert_string ast "Ppat_constant (Pconst_integer ( \"42\", None))"
+
+let sprint_ast_core_type =
+  let ast = Pp_ast.sprint ~kind:Pp_ast.Kind.Core_type "string" in
+  test "sprint AST core type" @@ fun () ->
+  assert_string ast "Ptyp_constr ( Lident \"string\", [])"
+
+let sprint_ast_sig =
+  let ast = Pp_ast.sprint ~kind:Pp_ast.Kind.Signature "val x: int" in
+  test "sprint AST signature" @@ fun () ->
+  assert_string ast
+    "[ Psig_value\n\
+    \    { pval_name = \"x\"\n\
+    \    ; pval_type = Ptyp_constr ( Lident \"int\", [])\n\
+    \    ; pval_prim = []\n\
+    \    ; pval_attributes = __attrs\n\
+    \    ; pval_loc = __loc\n\
+    \    }\n\
+     ]"
+
+let sprint_ast_str =
+  let ast = Pp_ast.sprint ~kind:Pp_ast.Kind.Structure "let x = 42" in
+  test "sprint AST structure" @@ fun () ->
+  assert_string ast
+    "[ Pstr_value\n\
+    \    ( Nonrecursive\n\
+    \    , [ { pvb_pat = Ppat_var \"x\"\n\
+    \        ; pvb_expr = Pexp_constant (Pconst_integer ( \"42\", None))\n\
+    \        ; pvb_attributes = __attrs\n\
+    \        ; pvb_loc = __loc\n\
+    \        }\n\
+    \      ]\n\
+    \    )\n\
+     ]"
+
+let () =
+  Alcotest.run ~show_errors:true ~compact:true ~tail_errors:`Unlimited "ppxlib"
+    [
+      ( "Pprintast",
+        [
+          sprint_ast_expr;
+          sprint_ast_pat;
+          sprint_ast_str;
+          sprint_ast_sig;
+          sprint_ast_core_type;
+        ] );
+    ]


### PR DESCRIPTION
## Description

@NathanReb after read your feature and PR I thought about do this, what do you think?

Add the sprint function to the pp_ast. The idea is to provide an easy way to debug and improve dx on tests and documentation.

Before, the only way to get a string from it was by creating an AST, like `[%expr 40 + 2]` and applying `Pp_ast.expression (Format.formatter_of_buffer buffer) [%expr 40 + 2]` and then collect the value from the buffer, for a simple print it was necessary `Pp_ast.expression (Format.std_formatter) [%expr 40 + 2]`
Now, `pp_ast` has a sprint function that delivers the ast structure from a string. 


## Usage

```ocaml
let () = Pp_ast.sprint "42" |> print_endline
(* Pexp_constant (Pconst_integer ( \"42\", None)) *)
```

It was also added to Ppxlib.Pprintast

```ocaml
let () = Pprintast.sprint "42" |> print_endline
(* Pexp_constant (Pconst_integer ( \"42\", None)) *)
```
