### PR TITLE
Replace -dparsetree sexp output with a pretty-printed AST

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,10 @@ details.
   a `ppxlib-pp-ast` executable in a new separate `ppxlib-tools` package
   (#517, @NathanReb)
 
+- Change `-dparsetree` from a sexp output to a pretty printed AST, closer
+  to what the compiler's `-dparsetree` is.
+  (#530, @NathanReb)
+
 0.33.0 (2024-07-22)
 -------------------
 

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -1154,8 +1154,8 @@ let process_file (kind : Kind.t) fn ~input_name ~relocate ~output_mode
           let ppf = Stdlib.Format.formatter_of_out_channel oc in
           let ast = add_cookies ast in
           (match ast with
-          | Intf ast -> Sexp.pp_hum ppf (Ast_traverse.sexp_of#signature ast)
-          | Impl ast -> Sexp.pp_hum ppf (Ast_traverse.sexp_of#structure ast));
+          | Intf ast -> Pp_ast.signature ppf ast
+          | Impl ast -> Pp_ast.structure ppf ast);
           Stdlib.Format.pp_print_newline ppf ())
   | Reconcile mode ->
       Reconcile.reconcile !replacements

--- a/test/501_migrations/one_migration.t
+++ b/test/501_migrations/one_migration.t
@@ -9,1122 +9,154 @@ So let's only keep one example.
 
   $ echo "let x : int = 5" > file.ml
   $ ./identity_driver.exe -dparsetree file.ml
-  (((pstr_desc
-     (Pstr_attribute
-      ((attr_name
-        ((txt ocaml.ppx.context)
-         (loc
-          ((loc_start
-            ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-           (loc_end
-            ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-           (loc_ghost true)))))
-       (attr_payload
-        (PStr
-         (((pstr_desc
-            (Pstr_eval
-             ((pexp_desc
-               (Pexp_record
-                ((((txt (Lident tool_name))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_constant
-                     (Pconst_string ppxlib_driver
-                      ((loc_start
-                        ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                         (pos_cnum -1)))
-                       (loc_end
-                        ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                         (pos_cnum -1)))
-                       (loc_ghost true))
-                      ())))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident include_dirs))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident []))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident load_path))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident []))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident open_modules))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident []))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident for_package))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident None))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident debug))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident use_threads))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident use_vmthreads))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident recursive_types))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident principal))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident transparent_modules))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident unboxed_types))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident unsafe_string))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident cookies))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident []))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ()))))
-                ()))
-              (pexp_loc
-               ((loc_start
-                 ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-                (loc_end
-                 ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-                (loc_ghost true)))
-              (pexp_loc_stack ()) (pexp_attributes ()))
-             ()))
-           (pstr_loc
-            ((loc_start
-              ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-             (loc_end
-              ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-             (loc_ghost true)))))))
-       (attr_loc
-        ((loc_start
-          ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-         (loc_end ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-         (loc_ghost true))))))
-    (pstr_loc
-     ((loc_start ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-      (loc_end ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-      (loc_ghost true))))
-   ((pstr_desc
-     (Pstr_value Nonrecursive
-      (((pvb_pat
-         ((ppat_desc
-           (Ppat_constraint
-            ((ppat_desc
-              (Ppat_var
-               ((txt x)
-                (loc
-                 ((loc_start
-                   ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 4)))
-                  (loc_end
-                   ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 5)))
-                  (loc_ghost false))))))
-             (ppat_loc
-              ((loc_start
-                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 4)))
-               (loc_end
-                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 5)))
-               (loc_ghost false)))
-             (ppat_loc_stack ()) (ppat_attributes ()))
-            ((ptyp_desc
-              (Ptyp_poly ()
-               ((ptyp_desc
-                 (Ptyp_constr
-                  ((txt (Lident int))
-                   (loc
-                    ((loc_start
-                      ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0)
-                       (pos_cnum 8)))
-                     (loc_end
-                      ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0)
-                       (pos_cnum 11)))
-                     (loc_ghost false))))
-                  ()))
-                (ptyp_loc
-                 ((loc_start
-                   ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 8)))
-                  (loc_end
-                   ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 11)))
-                  (loc_ghost false)))
-                (ptyp_loc_stack ()) (ptyp_attributes ()))))
-             (ptyp_loc
-              ((loc_start
-                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 8)))
-               (loc_end
-                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 11)))
-               (loc_ghost true)))
-             (ptyp_loc_stack ()) (ptyp_attributes ()))))
-          (ppat_loc
-           ((loc_start
-             ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 4)))
-            (loc_end
-             ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 11)))
-            (loc_ghost true)))
-          (ppat_loc_stack ()) (ppat_attributes ())))
-        (pvb_expr
-         ((pexp_desc
-           (Pexp_constraint
-            ((pexp_desc (Pexp_constant (Pconst_integer 5 ())))
-             (pexp_loc
-              ((loc_start
-                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 14)))
-               (loc_end
-                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 15)))
-               (loc_ghost false)))
-             (pexp_loc_stack ()) (pexp_attributes ()))
-            ((ptyp_desc
-              (Ptyp_constr
-               ((txt (Lident int))
-                (loc
-                 ((loc_start
-                   ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 8)))
-                  (loc_end
-                   ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 11)))
-                  (loc_ghost false))))
-               ()))
-             (ptyp_loc
-              ((loc_start
-                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 8)))
-               (loc_end
-                ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 11)))
-               (loc_ghost false)))
-             (ptyp_loc_stack ()) (ptyp_attributes ()))))
-          (pexp_loc
-           ((loc_start
-             ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 4)))
-            (loc_end
-             ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 15)))
-            (loc_ghost false)))
-          (pexp_loc_stack ()) (pexp_attributes ())))
-        (pvb_attributes ())
-        (pvb_loc
-         ((loc_start
-           ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 0)))
-          (loc_end
-           ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 15)))
-          (loc_ghost false)))))))
-    (pstr_loc
-     ((loc_start ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 0)))
-      (loc_end ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 15)))
-      (loc_ghost false)))))
+  [ Pstr_attribute
+      { attr_name = "ocaml.ppx.context"
+      ; attr_payload =
+          PStr
+            [ Pstr_eval
+                ( Pexp_record
+                    ( [ ( Lident "tool_name"
+                        , Pexp_constant
+                            (Pconst_string ( "ppxlib_driver", __loc, None))
+                        )
+                      ; ( Lident "include_dirs"
+                        , Pexp_construct ( Lident "[]", None)
+                        )
+                      ; ( Lident "load_path"
+                        , Pexp_construct ( Lident "[]", None)
+                        )
+                      ; ( Lident "open_modules"
+                        , Pexp_construct ( Lident "[]", None)
+                        )
+                      ; ( Lident "for_package"
+                        , Pexp_construct ( Lident "None", None)
+                        )
+                      ; ( Lident "debug"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "use_threads"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "use_vmthreads"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "recursive_types"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "principal"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "transparent_modules"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "unboxed_types"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "unsafe_string"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "cookies"
+                        , Pexp_construct ( Lident "[]", None)
+                        )
+                      ]
+                    , None
+                    )
+                , __attrs
+                )
+            ]
+      ; attr_loc = __loc
+      }
+  ; Pstr_value
+      ( Nonrecursive
+      , [ { pvb_pat =
+              Ppat_constraint
+                ( Ppat_var "x"
+                , Ptyp_poly ( [], Ptyp_constr ( Lident "int", []))
+                )
+          ; pvb_expr =
+              Pexp_constraint
+                ( Pexp_constant (Pconst_integer ( "5", None))
+                , Ptyp_constr ( Lident "int", [])
+                )
+          ; pvb_attributes = __attrs
+          ; pvb_loc = __loc
+          }
+        ]
+      )
+  ]
 
   $ cat > file.ml << EOF
   > module F () = struct end
   > module M = F ()
   > EOF
   $ ./identity_driver.exe -dparsetree file.ml
-  (((pstr_desc
-     (Pstr_attribute
-      ((attr_name
-        ((txt ocaml.ppx.context)
-         (loc
-          ((loc_start
-            ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-           (loc_end
-            ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-           (loc_ghost true)))))
-       (attr_payload
-        (PStr
-         (((pstr_desc
-            (Pstr_eval
-             ((pexp_desc
-               (Pexp_record
-                ((((txt (Lident tool_name))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_constant
-                     (Pconst_string ppxlib_driver
-                      ((loc_start
-                        ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                         (pos_cnum -1)))
-                       (loc_end
-                        ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                         (pos_cnum -1)))
-                       (loc_ghost true))
-                      ())))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident include_dirs))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident []))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident load_path))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident []))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident open_modules))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident []))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident for_package))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident None))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident debug))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident use_threads))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident use_vmthreads))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident recursive_types))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident principal))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident transparent_modules))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident unboxed_types))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident unsafe_string))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident false))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ())))
-                 (((txt (Lident cookies))
-                   (loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true))))
-                  ((pexp_desc
-                    (Pexp_construct
-                     ((txt (Lident []))
-                      (loc
-                       ((loc_start
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_end
-                         ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                          (pos_cnum -1)))
-                        (loc_ghost true))))
-                     ()))
-                   (pexp_loc
-                    ((loc_start
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_end
-                      ((pos_fname _none_) (pos_lnum 0) (pos_bol 0)
-                       (pos_cnum -1)))
-                     (loc_ghost true)))
-                   (pexp_loc_stack ()) (pexp_attributes ()))))
-                ()))
-              (pexp_loc
-               ((loc_start
-                 ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-                (loc_end
-                 ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-                (loc_ghost true)))
-              (pexp_loc_stack ()) (pexp_attributes ()))
-             ()))
-           (pstr_loc
-            ((loc_start
-              ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-             (loc_end
-              ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-             (loc_ghost true)))))))
-       (attr_loc
-        ((loc_start
-          ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-         (loc_end ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-         (loc_ghost true))))))
-    (pstr_loc
-     ((loc_start ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-      (loc_end ((pos_fname _none_) (pos_lnum 0) (pos_bol 0) (pos_cnum -1)))
-      (loc_ghost true))))
-   ((pstr_desc
-     (Pstr_module
-      ((pmb_name
-        ((txt (F))
-         (loc
-          ((loc_start
-            ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 7)))
-           (loc_end
-            ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 8)))
-           (loc_ghost false)))))
-       (pmb_expr
-        ((pmod_desc
-          (Pmod_functor Unit
-           ((pmod_desc (Pmod_structure ()))
-            (pmod_loc
-             ((loc_start
-               ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 14)))
-              (loc_end
-               ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 24)))
-              (loc_ghost false)))
-            (pmod_attributes ()))))
-         (pmod_loc
-          ((loc_start
-            ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 9)))
-           (loc_end
-            ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 24)))
-           (loc_ghost false)))
-         (pmod_attributes ())))
-       (pmb_attributes ())
-       (pmb_loc
-        ((loc_start
-          ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 0)))
-         (loc_end ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 24)))
-         (loc_ghost false))))))
-    (pstr_loc
-     ((loc_start ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 0)))
-      (loc_end ((pos_fname file.ml) (pos_lnum 1) (pos_bol 0) (pos_cnum 24)))
-      (loc_ghost false))))
-   ((pstr_desc
-     (Pstr_module
-      ((pmb_name
-        ((txt (M))
-         (loc
-          ((loc_start
-            ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 32)))
-           (loc_end
-            ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 33)))
-           (loc_ghost false)))))
-       (pmb_expr
-        ((pmod_desc
-          (Pmod_apply
-           ((pmod_desc
-             (Pmod_ident
-              ((txt (Lident F))
-               (loc
-                ((loc_start
-                  ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 36)))
-                 (loc_end
-                  ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 37)))
-                 (loc_ghost false))))))
-            (pmod_loc
-             ((loc_start
-               ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 36)))
-              (loc_end
-               ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 37)))
-              (loc_ghost false)))
-            (pmod_attributes ()))
-           ((pmod_desc (Pmod_structure ()))
-            (pmod_loc
-             ((loc_start
-               ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 36)))
-              (loc_end
-               ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 40)))
-              (loc_ghost false)))
-            (pmod_attributes ()))))
-         (pmod_loc
-          ((loc_start
-            ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 36)))
-           (loc_end
-            ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 40)))
-           (loc_ghost false)))
-         (pmod_attributes ())))
-       (pmb_attributes ())
-       (pmb_loc
-        ((loc_start
-          ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 25)))
-         (loc_end
-          ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 40)))
-         (loc_ghost false))))))
-    (pstr_loc
-     ((loc_start ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 25)))
-      (loc_end ((pos_fname file.ml) (pos_lnum 2) (pos_bol 25) (pos_cnum 40)))
-      (loc_ghost false)))))
+  [ Pstr_attribute
+      { attr_name = "ocaml.ppx.context"
+      ; attr_payload =
+          PStr
+            [ Pstr_eval
+                ( Pexp_record
+                    ( [ ( Lident "tool_name"
+                        , Pexp_constant
+                            (Pconst_string ( "ppxlib_driver", __loc, None))
+                        )
+                      ; ( Lident "include_dirs"
+                        , Pexp_construct ( Lident "[]", None)
+                        )
+                      ; ( Lident "load_path"
+                        , Pexp_construct ( Lident "[]", None)
+                        )
+                      ; ( Lident "open_modules"
+                        , Pexp_construct ( Lident "[]", None)
+                        )
+                      ; ( Lident "for_package"
+                        , Pexp_construct ( Lident "None", None)
+                        )
+                      ; ( Lident "debug"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "use_threads"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "use_vmthreads"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "recursive_types"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "principal"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "transparent_modules"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "unboxed_types"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "unsafe_string"
+                        , Pexp_construct ( Lident "false", None)
+                        )
+                      ; ( Lident "cookies"
+                        , Pexp_construct ( Lident "[]", None)
+                        )
+                      ]
+                    , None
+                    )
+                , __attrs
+                )
+            ]
+      ; attr_loc = __loc
+      }
+  ; Pstr_module
+      { pmb_name = Some "F"
+      ; pmb_expr = Pmod_functor ( Unit, Pmod_structure [])
+      ; pmb_attributes = __attrs
+      ; pmb_loc = __loc
+      }
+  ; Pstr_module
+      { pmb_name = Some "M"
+      ; pmb_expr = Pmod_apply ( Pmod_ident (Lident "F"), Pmod_structure [])
+      ; pmb_attributes = __attrs
+      ; pmb_loc = __loc
+      }
+  ]


### PR DESCRIPTION
This is an attempt to replace `-dparsetree` output format to something more readable.

I'll trigger a rev-deps build on opam to see if that would break anything.