### PR TITLE
PoC: support OCaml 5.3's `keywords` entry in `OCAMLPARAM`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,9 +12,10 @@ details.
 
 - Add initial OCaml 5.3 support (#487, @NathanReb, @hhugo, @nojb)
 
-- Initialise OCaml 5.3's lexer with the `keywords` setting from `OCAMLPARAM` to
-  allow the standalone ppx driver to process old packages using `effect` as an
-  identifier (#535, @dra27)
+- Initialise OCaml 5.3's lexer with the `keywords` setting from `OCAMLPARAM` or
+  the new `-keywords` driver's CLI option to allow the standalone ppx driver to
+  process old packages using `effect` as an identifier
+  (#535, @dra27, @NathanReb)
 
 ### Other changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,10 @@ details.
 
 - Add initial OCaml 5.3 support (#487, @NathanReb, @hhugo, @nojb)
 
+- Initialise OCaml 5.3's lexer with the `keywords` setting from `OCAMLPARAM` to
+  allow the standalone ppx driver to process old packages using `effect` as an
+  identifier (#535, @dra27)
+
 ### Other changes
 
 - Fix `deriving_inline` round-trip check so that it works with 5.01 <-> 5.02

--- a/astlib/keyword.ml
+++ b/astlib/keyword.ml
@@ -57,3 +57,27 @@ let is_keyword = function
   | "lsr" -> true
   | "asr" -> true
   | _ -> false
+
+let apply_keyword_edition () =
+  match Sys.getenv "OCAMLPARAM" with
+  | s ->
+      let items =
+        if String.equal s "" then []
+        else
+          (* cf. Compenv.parse_args *)
+          match s.[0] with
+          | (':' | '|' | ';' | ' ' | ',') as c ->
+              List.tl (String.split_on_char c s)
+          | _ -> String.split_on_char ',' s
+      in
+      let fold_settings acc item =
+        let len = String.length item in
+        if len >= 9 && String.sub item 0 9 = "keywords=" then
+          Some (String.sub item 9 (len - 9))
+        else acc
+      in
+      let keyword_edition = List.fold_left fold_settings None items in
+      (*IF_AT_LEAST 503 let () = if Option.is_some keyword_edition then Clflags.keyword_edition := keyword_edition in*)
+      (*IF_NOT_AT_LEAST 503 let () = ignore keyword_edition in*)
+      ()
+  | exception Not_found -> ()

--- a/astlib/keyword.ml
+++ b/astlib/keyword.ml
@@ -58,26 +58,42 @@ let is_keyword = function
   | "asr" -> true
   | _ -> false
 
-let apply_keyword_edition () =
-  match Sys.getenv "OCAMLPARAM" with
-  | s ->
-      let items =
-        if String.equal s "" then []
-        else
-          (* cf. Compenv.parse_args *)
-          match s.[0] with
-          | (':' | '|' | ';' | ' ' | ',') as c ->
-              List.tl (String.split_on_char c s)
-          | _ -> String.split_on_char ',' s
-      in
-      let fold_settings acc item =
-        let len = String.length item in
-        if len >= 9 && String.sub item 0 9 = "keywords=" then
-          Some (String.sub item 9 (len - 9))
-        else acc
-      in
-      let keyword_edition = List.fold_left fold_settings None items in
-      (*IF_AT_LEAST 503 let () = if Option.is_some keyword_edition then Clflags.keyword_edition := keyword_edition in*)
-      (*IF_NOT_AT_LEAST 503 let () = ignore keyword_edition in*)
-      ()
-  | exception Not_found -> ()
+let apply_keyword_edition ~cli () =
+  let from_ocaml_param =
+    match Sys.getenv "OCAMLPARAM" with
+    | s -> (
+        let items =
+          if String.equal s "" then []
+          else
+            (* cf. Compenv.parse_args *)
+            match s.[0] with
+            | (':' | '|' | ';' | ' ' | ',') as c ->
+                List.tl (String.split_on_char c s)
+            | _ -> String.split_on_char ',' s
+        in
+        let fold_settings (acc, after_cli) item =
+          match (item, acc) with
+          | "_", None -> (acc, true)
+          | _ ->
+              let len = String.length item in
+              if len >= 9 && String.sub item 0 9 = "keywords=" then
+                (Some (String.sub item 9 (len - 9)), after_cli)
+              else (acc, after_cli)
+        in
+        let from_ocaml_param, after_cli =
+          List.fold_left fold_settings (None, false) items
+        in
+        match from_ocaml_param with
+        | None -> None
+        | Some s -> Some (s, after_cli))
+    | exception Not_found -> None
+  in
+  let keyword_edition =
+    match (cli, from_ocaml_param) with
+    | None, None -> None
+    | None, Some (s, _) | Some _, Some (s, true) -> Some s
+    | _ -> cli
+  in
+  (*IF_AT_LEAST 503 let () = if Option.is_some keyword_edition then Clflags.keyword_edition := keyword_edition in*)
+  (*IF_NOT_AT_LEAST 503 let () = ignore keyword_edition in*)
+  ()

--- a/astlib/keyword.mli
+++ b/astlib/keyword.mli
@@ -1,6 +1,7 @@
 val is_keyword : string -> bool
 (** Check if a string is an OCaml keyword. *)
 
-val apply_keyword_edition : unit -> unit
+val apply_keyword_edition : cli:string option -> unit -> unit
 (** Processes any keywords= sections from the OCAMLPARAM environment variable
-    and initialises the compiler's lexer with the correct keyword set. *)
+    and CLI option and initialises the compiler's lexer with the correct keyword
+    set. *)

--- a/astlib/keyword.mli
+++ b/astlib/keyword.mli
@@ -1,2 +1,6 @@
 val is_keyword : string -> bool
 (** Check if a string is an OCaml keyword. *)
+
+val apply_keyword_edition : unit -> unit
+(** Processes any keywords= sections from the OCAMLPARAM environment variable
+    and initialises the compiler's lexer with the correct keyword set. *)

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -1414,7 +1414,7 @@ let standalone_args =
       Arg.String (fun s -> keywords := Some s),
       "<version+list> Set keywords according to the version+list \
        specification. Allows using a set of keywords different from the one of \
-       the current compiler for backword compatibility." );
+       the current compiler for backward compatibility." );
     ( "--keywords",
       Arg.String (fun s -> keywords := Some s),
       "<version+list> Same as -keywords" );

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -24,6 +24,7 @@ let pretty = ref false
 let styler = ref None
 let output_metadata_filename = ref None
 let corrected_suffix = ref ".ppx-corrected"
+let keywords = ref None
 
 let ghost =
   object
@@ -1409,6 +1410,14 @@ let standalone_args =
     ( "-corrected-suffix",
       Arg.Set_string corrected_suffix,
       "SUFFIX Suffix to append to corrected files" );
+    ( "-keywords",
+      Arg.String (fun s -> keywords := Some s),
+      "<version+list> Set keywords according to the version+list \
+       specification. Allows using a set of keywords different from the one of \
+       the current compiler for backword compatibility." );
+    ( "--keywords",
+      Arg.String (fun s -> keywords := Some s),
+      "<version+list> Same as -keywords" );
   ]
 
 let get_args ?(standalone_args = standalone_args) () =
@@ -1417,8 +1426,8 @@ let get_args ?(standalone_args = standalone_args) () =
 let standalone_main () =
   let usage = Printf.sprintf "%s [extra_args] [<files>]" exe_name in
   let args = get_args () in
-  Astlib.Keyword.apply_keyword_edition ();
   Arg.parse (Arg.align args) set_input usage;
+  Astlib.Keyword.apply_keyword_edition ~cli:!keywords ();
   interpret_mask ();
   if !request_print_transformations then (
     print_transformations ();

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -1417,6 +1417,7 @@ let get_args ?(standalone_args = standalone_args) () =
 let standalone_main () =
   let usage = Printf.sprintf "%s [extra_args] [<files>]" exe_name in
   let args = get_args () in
+  Astlib.Keyword.apply_keyword_edition ();
   Arg.parse (Arg.align args) set_input usage;
   interpret_mask ();
   if !request_print_transformations then (

--- a/test/driver/keywords-option/driver.ml
+++ b/test/driver/keywords-option/driver.ml
@@ -1,0 +1,1 @@
+let () = Ppxlib.Driver.standalone ()

--- a/test/driver/keywords-option/dune
+++ b/test/driver/keywords-option/dune
@@ -1,0 +1,10 @@
+(executable
+ (name driver)
+ (enabled_if
+  (>= %{ocaml_version} "5.3"))
+ (libraries ppxlib))
+
+(cram
+ (enabled_if
+  (>= %{ocaml_version} "5.3"))
+ (deps driver.exe))

--- a/test/driver/keywords-option/run.t
+++ b/test/driver/keywords-option/run.t
@@ -1,0 +1,38 @@
+This test can only work with OCaml 5.3 or higher.
+
+OCaml 5.3 introduced the new `effect` keyword. To allow old code to compile
+under 5.3 it also introduced a `-keyword=version+list` CLI option, allowing one to
+override the set of keywords.
+
+The ppxlib driver also has such an option now to properly configure the lexer before
+attempting to parse source code.
+
+Let's consider the following source file:
+
+  $ cat > test.ml << EOF
+  > let effect = 1
+  > EOF
+
+If passed to the driver as is, it will trigger a parse error:
+
+  $ ./driver.exe --impl test.ml -o ignore.ml
+  File "test.ml", line 1, characters 4-10:
+  1 | let effect = 1
+          ^^^^^^
+  Error: Syntax error
+  [1]
+
+Now, if we use the 5.2 set of keywords, it should happily handle the file:
+
+  $ ./driver.exe --keywords 5.2 --impl test.ml -o ignore.ml
+
+It can also be set using OCAMLPARAM:
+
+  $ OCAMLPARAM=_,keywords=5.2 ./driver.exe --impl test.ml -o ignore.ml
+
+The priority between the CLI option and OCAMLPARAM must be respected, therefore
+both of the following invocation should parse:
+
+  $ OCAMLPARAM=_,keywords=5.2 ./driver.exe --keywords 5.3 --impl test.ml -o ignore.ml
+
+  $ OCAMLPARAM=keywords=5.3,_ ./driver.exe --keywords 5.2 --impl test.ml -o ignore.ml


### PR DESCRIPTION
This is a little proof-of-concept and request for feedback following a check in https://github.com/ocaml/opam-repository/pull/26831 that the mechanism added in 5.3.0~beta1 in https://github.com/ocaml/ocaml/pull/13471 is working. The effect (pun intended) is mildly limited for 5.3, but it seems worth checking these packages now because keywords changes in future may potentially have more impact, so it feels to me to be better to be ready with a "simpler" release.

The mechanism added allows old code (i.e. old releases of packages) to be compiled even if that code uses identifiers which have become keywords since it was written. This is done either by explicitly passing `-keywords 5.2` to the compiler invocations or by setting `OCAMLPARAM` to `_,keywords=5.2`. Certainly for the `effect` keyword, it's generally expected that repositories will choose to switch the identifier (e.g. to `effect_`) rather than use the `-keywords` flag, but the mechanism means that opam packages can be made to work without requiring a release, which obviously reduces adoption friction for new versions of the compiler.

This works well for the small number of packages in 5.3 which use `effect` as an identfier, but it doesn't work for Irmin (cf. https://github.com/mirage/irmin/issues/2346). The `OCAMLPARAM` trick doesn't work because the ppx standalone driver doesn't inspect `OCAMLPARAM`, so it's creating the "wrong" AST. This PR is a possible idea to allow the standalone driver (which is invoking the compiler driver, albeit via compiler-libs) to parse the `keywords` part of `OCAMLPARAM`.

This `Dockerfile` fails with OCaml 5.3:
```Dockerfile
FROM ocaml/opam:debian-12-ocaml-5.3
RUN git clone https://github.com/mirage/irmin.git
WORKDIR irmin
RUN git checkout 3.9.0
RUN sudo ln -f /usr/bin/opam-2.2 /usr/bin/opam
RUN opam install ./irmin.opam --deps-only
RUN opam install repr ppx_irmin mtime bheap
ENV OCAMLPARAM=_,keywords=5.2
RUN opam exec -- dune build -p irmin
```

giving:

```
(cd _build/default && .ppx/851ddbf37b8928057d14b915d5ceebb6/ppx.exe --lib Type --cookie 'library-name="irmin"' -o src/irmin/node_intf.pp.ml --impl src/irmin/node_intf.ml -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
File "src/irmin/node_intf.ml", line 127, characters 7-13:
127 |   type effect := expected_depth:int -> node_key -> t option
             ^^^^^^
Error: Syntax error
```

but if this branch is instead pinned then it builds. I'm not necessarily advocating this being the exact mechanism - the only aim is that it should be possible to "patch" an existing compiler simply by setting an environment variable (this is the general intention of `OCAMLPARAM` and the very obscure `$(ocamlc -where)/ocaml_compiler_internal_params` file)

 - [x] Incompatibly added at the moment, making ppxlib 5.3+ only!
 - [ ] Probably worth including a `-keywords` option equivalent to the compiler's (In which case, the `_` part of `OCAMLPARAM` should arguably be parsed)?
 - [ ] The splitting logic duplicates internal code from `Compenv` which, if wanted, should probably be exposed in compiler-libs instead
 - [x] I've probably violated the way `Clflags` should actually be accessed, but I was being a bit lazy trying to work out all the ocaml-compiler-libs stuff...!