### PR TITLE
Support class type declarations in derivers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@ details.
 
 ### Other changes
 
+- Support class type declarations in derivers with the new, optional arguments
+  `{str,sig}_class_type_decl` in `Deriving.add` (#538, @patricoferris)
+
 - Fix `deriving_inline` round-trip check so that it works with 5.01 <-> 5.02
   migrations (#519, @NathanReb)
 

--- a/src/attribute.ml
+++ b/src/attribute.ml
@@ -23,6 +23,7 @@ module Context = struct
     | Class_infos : _ class_infos t
     | Class_expr : class_expr t
     | Class_field : class_field t
+    | Class_type_decl : class_type_declaration t
     | Module_type : module_type t
     | Module_declaration : module_declaration t
     | Module_type_declaration : module_type_declaration t
@@ -54,6 +55,7 @@ module Context = struct
   let class_infos = Class_infos
   let class_expr = Class_expr
   let class_field = Class_field
+  let class_type_decl = Class_type_decl
   let module_type = Module_type
   let module_declaration = Module_declaration
   let module_type_declaration = Module_type_declaration
@@ -101,6 +103,7 @@ module Context = struct
     | Class_infos -> x.pci_attributes
     | Class_expr -> x.pcl_attributes
     | Class_field -> x.pcf_attributes
+    | Class_type_decl -> x.pci_attributes
     | Module_type -> x.pmty_attributes
     | Module_declaration -> x.pmd_attributes
     | Module_type_declaration -> x.pmtd_attributes
@@ -135,6 +138,7 @@ module Context = struct
     | Class_infos -> { x with pci_attributes = attrs }
     | Class_expr -> { x with pcl_attributes = attrs }
     | Class_field -> { x with pcf_attributes = attrs }
+    | Class_type_decl -> { x with pci_attributes = attrs }
     | Module_type -> { x with pmty_attributes = attrs }
     | Module_declaration -> { x with pmd_attributes = attrs }
     | Module_type_declaration -> { x with pmtd_attributes = attrs }
@@ -176,6 +180,7 @@ module Context = struct
     | Class_infos -> "class declaration"
     | Class_expr -> "class expression"
     | Class_field -> "class field"
+    | Class_type_decl -> "class type declaration"
     | Module_type -> "module type"
     | Module_declaration -> "module declaration"
     | Module_type_declaration -> "module type declaration"

--- a/src/attribute.mli
+++ b/src/attribute.mli
@@ -29,6 +29,7 @@ module Context : sig
     | Class_infos : _ class_infos t
     | Class_expr : class_expr t
     | Class_field : class_field t
+    | Class_type_decl : class_type_declaration t
     | Module_type : module_type t
     | Module_declaration : module_declaration t
     | Module_type_declaration : module_type_declaration t
@@ -60,6 +61,7 @@ module Context : sig
   val class_infos : _ class_infos t
   val class_expr : class_expr t
   val class_field : class_field t
+  val class_type_decl : class_type_declaration t
   val module_type : module_type t
   val module_declaration : module_declaration t
   val module_type_declaration : module_type_declaration t

--- a/src/context_free.mli
+++ b/src/context_free.mli
@@ -117,6 +117,18 @@ module Rule : sig
 
   val attr_sig_exception_expect :
     (signature_item, type_exception, _) attr_inline
+
+  val attr_str_class_type_decl :
+    (structure_item, class_type_declaration, _) attr_group_inline
+
+  val attr_sig_class_type_decl :
+    (signature_item, class_type_declaration, _) attr_group_inline
+
+  val attr_str_class_type_decl_expect :
+    (structure_item, class_type_declaration, _) attr_group_inline
+
+  val attr_sig_class_type_decl_expect :
+    (signature_item, class_type_declaration, _) attr_group_inline
 end
 
 (**/**)

--- a/src/deriving.mli
+++ b/src/deriving.mli
@@ -105,10 +105,12 @@ with type deriver := t
 
 val add :
   ?str_type_decl:(structure, rec_flag * type_declaration list) Generator.t ->
+  ?str_class_type_decl:(structure, class_type_declaration list) Generator.t ->
   ?str_type_ext:(structure, type_extension) Generator.t ->
   ?str_exception:(structure, type_exception) Generator.t ->
   ?str_module_type_decl:(structure, module_type_declaration) Generator.t ->
   ?sig_type_decl:(signature, rec_flag * type_declaration list) Generator.t ->
+  ?sig_class_type_decl:(signature, class_type_declaration list) Generator.t ->
   ?sig_type_ext:(signature, type_extension) Generator.t ->
   ?sig_exception:(signature, type_exception) Generator.t ->
   ?sig_module_type_decl:(signature, module_type_declaration) Generator.t ->
@@ -131,10 +133,12 @@ val add :
 val add_alias :
   string ->
   ?str_type_decl:t list ->
+  ?str_class_type_decl:t list ->
   ?str_type_ext:t list ->
   ?str_exception:t list ->
   ?str_module_type_decl:t list ->
   ?sig_type_decl:t list ->
+  ?sig_class_type_decl:t list ->
   ?sig_type_ext:t list ->
   ?sig_exception:t list ->
   ?sig_module_type_decl:t list ->

--- a/test/deriving/test.ml
+++ b/test/deriving/test.ml
@@ -32,10 +32,12 @@ let mtd =
 val mtd : Deriving.t = <abstr>
 |}]
 
-type t = int [@@deriving bar]
+let cd =
+  Deriving.add "cd"
+    ~sig_class_type_decl:(Deriving.Generator.make_noarg (fun ~loc ~path:_ _ -> [%sig: val y : int]))
+    ~str_class_type_decl:(Deriving.Generator.make_noarg (fun ~loc ~path:_ _ -> [%str let y = 42]))
 [%%expect{|
-Line _, characters 25-28:
-Error: Deriver foo is needed for bar, you need to add it before in the list
+val cd : Deriving.t = <abstr>
 |}]
 
 type t = int [@@deriving bar, foo]
@@ -72,4 +74,10 @@ end = struct
 end
 [%%expect{|
 module Y : sig module type X = sig end val y : int end
+|}]
+
+class type x = object end[@@deriving cd]
+[%%expect{|
+class type x = object  end
+val y : int = 42
 |}]


### PR DESCRIPTION
This PR adds support for class _type_ declarations, which I mistook #509 for. All the same, seems like a good feature to add given ppxlib didn't support it.

It reuses some code from type declarations as they are pretty similar but there is Recursive flag for class types (are the just always recurive?). This bit could perhaps use some more work.