### PR TITLE
Match compilers dummy loc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 unreleased
 ----------
  
+- Change `Location.none` to match the compiler's `Location.none` as of OCaml
+  4.08. This fixes a bug in `loc_of_attribute` (#540, @ncik-roberts, @patricoferris)
+
 - Bump ppxlib's AST to 5.2.0 (#514, @patricoferris)
 
 - Add a `-raise-embedded-errors` flag to the driver. Setting this flag raises the first

--- a/src/common.ml
+++ b/src/common.ml
@@ -149,7 +149,7 @@ let loc_of_attribute { attr_name; attr_payload; attr_loc = _ } =
      from older asts. *)
   (* "ocaml.doc" attributes are generated with [Location.none], which is not helpful for
      error messages. *)
-  if Poly.( = ) attr_name.loc Location.none then
+  if Location.is_none attr_name.loc then
     loc_of_name_and_payload attr_name attr_payload
   else
     {
@@ -158,7 +158,7 @@ let loc_of_attribute { attr_name; attr_payload; attr_loc = _ } =
     }
 
 let loc_of_extension (name, payload) =
-  if Poly.( = ) name.loc Location.none then loc_of_name_and_payload name payload
+  if Location.is_none name.loc then loc_of_name_and_payload name payload
   else
     { name.loc with loc_end = (loc_of_name_and_payload name payload).loc_end }
 

--- a/src/location.ml
+++ b/src/location.ml
@@ -8,7 +8,7 @@ type t = location = {
 }
 
 let in_file name =
-  let loc = { pos_fname = name; pos_lnum = 1; pos_bol = 0; pos_cnum = -1 } in
+  let loc = { pos_fname = name; pos_lnum = 0; pos_bol = 0; pos_cnum = -1 } in
   { loc_start = loc; loc_end = loc; loc_ghost = true }
 
 let set_filename loc fn =
@@ -17,6 +17,7 @@ let set_filename loc fn =
   { loc with loc_start; loc_end }
 
 let none = in_file "_none_"
+let is_none v = Poly.( = ) v none
 
 let init lexbuf fname =
   let open Lexing in

--- a/src/location.mli
+++ b/src/location.mli
@@ -24,6 +24,9 @@ val set_filename : t -> string -> t
 val none : t
 (** An arbitrary value of type [t]; describes an empty ghost range. *)
 
+val is_none : t -> bool
+(** Checks whether a given location is equal to [none] *)
+
 val init : Lexing.lexbuf -> string -> unit
 (** Set the file name and line number of the [lexbuf] to be the start of the
     named file. *)

--- a/test/location/attributes/dune
+++ b/test/location/attributes/dune
@@ -1,0 +1,7 @@
+(executable
+ (name pp)
+ (libraries ppxlib))
+
+(cram
+ (applies_to print_attr_loc)
+ (deps pp.exe))

--- a/test/location/attributes/pp.ml
+++ b/test/location/attributes/pp.ml
@@ -1,0 +1,18 @@
+open Ppxlib
+
+let pp_attr str =
+  let iter =
+    object
+      inherit Ast_traverse.iter as super
+
+      method! attribute v =
+        let loc = loc_of_attribute v in
+        Format.printf "%a %s" Location.print loc v.attr_name.txt;
+        super#attribute v
+    end
+  in
+  iter#structure str;
+  str
+
+let () = Driver.register_transformation ~impl:pp_attr "print-attributes"
+let () = Ppxlib.Driver.standalone ()

--- a/test/location/attributes/print_attr_loc.t
+++ b/test/location/attributes/print_attr_loc.t
@@ -1,0 +1,15 @@
+The compiler inserts documentation comments with their location set to
+`Location.none`. The value for `Location.none` has changed in the compiler (at
+4.08.0). We provide a function, `loc_of_attribute` to handle deriving better location
+errors for attributes with a none location.
+
+  $ cat > test.ml << EOF
+  > let v = 1
+  > (** A documentation comment! *)
+  > EOF
+
+We run an identity driver that prints the locations of attributes.
+
+  $ ./pp.exe --impl test.ml -o ignore.ml
+  File "test.ml", line 2, characters 0-31: ocaml.doc
+

--- a/test/metaquot/test.ml
+++ b/test/metaquot/test.ml
@@ -2,9 +2,9 @@ let loc = Ppxlib.Location.none
 [%%expect{|
 val loc : Warnings.loc =
   {Ppxlib.Location.loc_start =
-    {Lexing.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0; pos_cnum = -1};
+    {Lexing.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1};
    loc_end =
-    {Lexing.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0; pos_cnum = -1};
+    {Lexing.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1};
    loc_ghost = true}
 |}]
 
@@ -18,19 +18,19 @@ let _ = [%expr ()]
    ({Ppxlib_ast.Ast.txt = Ppxlib_ast.Ast.Lident "()";
      loc =
       {Ppxlib_ast.Ast.loc_start =
-        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
          pos_cnum = -1};
        loc_end =
-        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
          pos_cnum = -1};
        loc_ghost = true}},
    None);
  pexp_loc =
   {Ppxlib_ast.Ast.loc_start =
-    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
      pos_cnum = -1};
    loc_end =
-    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
      pos_cnum = -1};
    loc_ghost = true};
  pexp_loc_stack = []; pexp_attributes = []}
@@ -44,19 +44,19 @@ let _ = [%pat? ()]
    ({Ppxlib_ast.Ast.txt = Ppxlib_ast.Ast.Lident "()";
      loc =
       {Ppxlib_ast.Ast.loc_start =
-        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
          pos_cnum = -1};
        loc_end =
-        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
          pos_cnum = -1};
        loc_ghost = true}},
    None);
  ppat_loc =
   {Ppxlib_ast.Ast.loc_start =
-    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
      pos_cnum = -1};
    loc_end =
-    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
      pos_cnum = -1};
    loc_ghost = true};
  ppat_loc_stack = []; ppat_attributes = []}
@@ -70,19 +70,19 @@ let _ = [%type: unit]
    ({Ppxlib_ast.Ast.txt = Ppxlib_ast.Ast.Lident "unit";
      loc =
       {Ppxlib_ast.Ast.loc_start =
-        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
          pos_cnum = -1};
        loc_end =
-        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
          pos_cnum = -1};
        loc_ghost = true}},
    []);
  ptyp_loc =
   {Ppxlib_ast.Ast.loc_start =
-    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
      pos_cnum = -1};
    loc_end =
-    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
      pos_cnum = -1};
    loc_ghost = true};
  ptyp_loc_stack = []; ptyp_attributes = []}
@@ -97,10 +97,10 @@ let _ = [%stri let _ = ()]
       {Ppxlib_ast.Ast.ppat_desc = Ppxlib_ast.Ast.Ppat_any;
        ppat_loc =
         {Ppxlib_ast.Ast.loc_start =
-          {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+          {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
            pos_cnum = -1};
          loc_end =
-          {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+          {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
            pos_cnum = -1};
          loc_ghost = true};
        ppat_loc_stack = []; ppat_attributes = []};
@@ -110,37 +110,37 @@ let _ = [%stri let _ = ()]
          ({Ppxlib_ast.Ast.txt = Ppxlib_ast.Ast.Lident "()";
            loc =
             {Ppxlib_ast.Ast.loc_start =
-              {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1;
+              {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0;
                pos_bol = 0; pos_cnum = -1};
              loc_end =
-              {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1;
+              {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0;
                pos_bol = 0; pos_cnum = -1};
              loc_ghost = true}},
          None);
        pexp_loc =
         {Ppxlib_ast.Ast.loc_start =
-          {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+          {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
            pos_cnum = -1};
          loc_end =
-          {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+          {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
            pos_cnum = -1};
          loc_ghost = true};
        pexp_loc_stack = []; pexp_attributes = []};
      pvb_constraint = None; pvb_attributes = [];
      pvb_loc =
       {Ppxlib_ast.Ast.loc_start =
-        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
          pos_cnum = -1};
        loc_end =
-        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
          pos_cnum = -1};
        loc_ghost = true}}]);
  pstr_loc =
   {Ppxlib_ast.Ast.loc_start =
-    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
      pos_cnum = -1};
    loc_end =
-    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
      pos_cnum = -1};
    loc_ghost = true}}
 |}]
@@ -156,36 +156,36 @@ let _ = [%sigi: include S]
         {Ppxlib_ast.Ast.txt = Ppxlib_ast.Ast.Lident "S";
          loc =
           {Ppxlib_ast.Ast.loc_start =
-            {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+            {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
              pos_cnum = -1};
            loc_end =
-            {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+            {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
              pos_cnum = -1};
            loc_ghost = true}};
       pmty_loc =
        {Ppxlib_ast.Ast.loc_start =
-         {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+         {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
           pos_cnum = -1};
         loc_end =
-         {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+         {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
           pos_cnum = -1};
         loc_ghost = true};
       pmty_attributes = []};
     pincl_loc =
      {Ppxlib_ast.Ast.loc_start =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_end =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_ghost = true};
     pincl_attributes = []};
  psig_loc =
   {Ppxlib_ast.Ast.loc_start =
-    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
      pos_cnum = -1};
    loc_end =
-    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+    {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
      pos_cnum = -1};
    loc_ghost = true}}
 |}]
@@ -199,10 +199,10 @@ let _ = [%str let _ = ()]
        {Ppxlib_ast.Ast.ppat_desc = Ppxlib_ast.Ast.Ppat_any;
         ppat_loc =
          {Ppxlib_ast.Ast.loc_start =
-           {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+           {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
             pos_cnum = -1};
           loc_end =
-           {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+           {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
             pos_cnum = -1};
           loc_ghost = true};
         ppat_loc_stack = []; ppat_attributes = []};
@@ -212,37 +212,37 @@ let _ = [%str let _ = ()]
           ({Ppxlib_ast.Ast.txt = Ppxlib_ast.Ast.Lident "()";
             loc =
              {Ppxlib_ast.Ast.loc_start =
-               {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1;
+               {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0;
                 pos_bol = 0; pos_cnum = -1};
               loc_end =
-               {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1;
+               {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0;
                 pos_bol = 0; pos_cnum = -1};
               loc_ghost = true}},
           None);
         pexp_loc =
          {Ppxlib_ast.Ast.loc_start =
-           {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+           {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
             pos_cnum = -1};
           loc_end =
-           {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+           {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
             pos_cnum = -1};
           loc_ghost = true};
         pexp_loc_stack = []; pexp_attributes = []};
       pvb_constraint = None; pvb_attributes = [];
       pvb_loc =
        {Ppxlib_ast.Ast.loc_start =
-         {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+         {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
           pos_cnum = -1};
         loc_end =
-         {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+         {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
           pos_cnum = -1};
         loc_ghost = true}}]);
   pstr_loc =
    {Ppxlib_ast.Ast.loc_start =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_end =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_ghost = true}}]
 |}]
@@ -258,36 +258,36 @@ let _ = [%sig: include S]
          {Ppxlib_ast.Ast.txt = Ppxlib_ast.Ast.Lident "S";
           loc =
            {Ppxlib_ast.Ast.loc_start =
-             {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+             {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
               pos_cnum = -1};
             loc_end =
-             {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+             {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
               pos_cnum = -1};
             loc_ghost = true}};
        pmty_loc =
         {Ppxlib_ast.Ast.loc_start =
-          {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+          {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
            pos_cnum = -1};
          loc_end =
-          {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+          {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
            pos_cnum = -1};
          loc_ghost = true};
        pmty_attributes = []};
      pincl_loc =
       {Ppxlib_ast.Ast.loc_start =
-        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
          pos_cnum = -1};
        loc_end =
-        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+        {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
          pos_cnum = -1};
        loc_ghost = true};
      pincl_attributes = []};
   psig_loc =
    {Ppxlib_ast.Ast.loc_start =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_end =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_ghost = true}}]
 |}]
@@ -303,38 +303,38 @@ let _ =
    {Ppxlib_ast.Ast.txt = "attr1";
     loc =
      {Ppxlib_ast.Ast.loc_start =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_end =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_ghost = true}};
   attr_payload = Ppxlib_ast.Ast.PStr [];
   attr_loc =
    {Ppxlib_ast.Ast.loc_start =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_end =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_ghost = true}};
  {Ppxlib_ast.Ast.attr_name =
    {Ppxlib_ast.Ast.txt = "attr2";
     loc =
      {Ppxlib_ast.Ast.loc_start =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_end =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_ghost = true}};
   attr_payload = Ppxlib_ast.Ast.PStr [];
   attr_loc =
    {Ppxlib_ast.Ast.loc_start =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_end =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_ghost = true}}]
 |}]
@@ -348,38 +348,38 @@ let _ =
    {Ppxlib_ast.Ast.txt = "attr1";
     loc =
      {Ppxlib_ast.Ast.loc_start =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_end =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_ghost = true}};
   attr_payload = Ppxlib_ast.Ast.PStr [];
   attr_loc =
    {Ppxlib_ast.Ast.loc_start =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_end =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_ghost = true}};
  {Ppxlib_ast.Ast.attr_name =
    {Ppxlib_ast.Ast.txt = "attr2";
     loc =
      {Ppxlib_ast.Ast.loc_start =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_end =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_ghost = true}};
   attr_payload = Ppxlib_ast.Ast.PStr [];
   attr_loc =
    {Ppxlib_ast.Ast.loc_start =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_end =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_ghost = true}}]
 |}]
@@ -393,38 +393,38 @@ let _ =
    {Ppxlib_ast.Ast.txt = "attr1";
     loc =
      {Ppxlib_ast.Ast.loc_start =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_end =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_ghost = true}};
   attr_payload = Ppxlib_ast.Ast.PStr [];
   attr_loc =
    {Ppxlib_ast.Ast.loc_start =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_end =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_ghost = true}};
  {Ppxlib_ast.Ast.attr_name =
    {Ppxlib_ast.Ast.txt = "attr2";
     loc =
      {Ppxlib_ast.Ast.loc_start =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_end =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_ghost = true}};
   attr_payload = Ppxlib_ast.Ast.PStr [];
   attr_loc =
    {Ppxlib_ast.Ast.loc_start =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_end =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_ghost = true}}]
 |}]
@@ -443,38 +443,38 @@ let _ =
    {Ppxlib_ast.Ast.txt = "attr1";
     loc =
      {Ppxlib_ast.Ast.loc_start =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_end =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_ghost = true}};
   attr_payload = Ppxlib_ast.Ast.PStr [];
   attr_loc =
    {Ppxlib_ast.Ast.loc_start =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_end =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_ghost = true}};
  {Ppxlib_ast.Ast.attr_name =
    {Ppxlib_ast.Ast.txt = "attr2";
     loc =
      {Ppxlib_ast.Ast.loc_start =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_end =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_ghost = true}};
   attr_payload = Ppxlib_ast.Ast.PStr [];
   attr_loc =
    {Ppxlib_ast.Ast.loc_start =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_end =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_ghost = true}}]
 |}]
@@ -493,38 +493,38 @@ let _ =
    {Ppxlib_ast.Ast.txt = "attr1";
     loc =
      {Ppxlib_ast.Ast.loc_start =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_end =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_ghost = true}};
   attr_payload = Ppxlib_ast.Ast.PStr [];
   attr_loc =
    {Ppxlib_ast.Ast.loc_start =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_end =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_ghost = true}};
  {Ppxlib_ast.Ast.attr_name =
    {Ppxlib_ast.Ast.txt = "attr2";
     loc =
      {Ppxlib_ast.Ast.loc_start =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_end =
-       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+       {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
         pos_cnum = -1};
       loc_ghost = true}};
   attr_payload = Ppxlib_ast.Ast.PStr [];
   attr_loc =
    {Ppxlib_ast.Ast.loc_start =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_end =
-     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0;
+     {Ppxlib_ast.Ast.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
       pos_cnum = -1};
     loc_ghost = true}}]
 |}]

--- a/test/type_is_recursive/test.ml
+++ b/test/type_is_recursive/test.ml
@@ -14,9 +14,9 @@ let loc = Location.none
 [%%expect{|
 val loc : location =
   {Ppxlib.Location.loc_start =
-    {Lexing.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0; pos_cnum = -1};
+    {Lexing.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1};
    loc_end =
-    {Lexing.pos_fname = "_none_"; pos_lnum = 1; pos_bol = 0; pos_cnum = -1};
+    {Lexing.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1};
    loc_ghost = true}
 |}]
 


### PR DESCRIPTION
A fix as per #532.

I tested reverse dependencies (I think most of them, for their latest version) and they mostly installed `--with-test`. Any that didn't seemed unrelated.