### PR TITLE
Re-enable CI builds for 4.07-4.09

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -64,7 +64,7 @@ format.")
 than ppxlib itself. Also the benchmark runner has dependencies that ppxlib doesn't
 have.")
  (depends
-  (ocaml (>= 4.04.1))
+  (ocaml (>= 4.10.0))
   (ppxlib (= :version))
   base
   yojson))

--- a/ppxlib-bench.opam
+++ b/ppxlib-bench.opam
@@ -13,7 +13,7 @@ doc: "https://ocaml-ppx.github.io/ppxlib/"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.10.0"}
   "ppxlib" {= version}
   "base"
   "yojson"


### PR DESCRIPTION
This is an attempt at re-enabling the CI builds for OCaml 4.07 to 4.09. Thanks to ocaml-ci maintainers we now know that this was caused by ppxlib-bench not being co-installable with the other packages on those versions.

I'll try different solutions here.