### PR TITLE
Add flag `-raise-embedded-errors` to `Driver`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 unreleased
 ----------
 
+- Add a `-raise-embedded-errors` flag to the driver. Setting this flag raises the first
+  `ocaml.error` embedded in the final AST.
+
 - Export `Ast_pattern.fail`. (#563, @ceastlund)
 
 - Make `Ast_traverse.sexp_of` more concise, and add a test. (#561, @ceastlund)

--- a/ast/location_error.ml
+++ b/ast/location_error.ml
@@ -40,3 +40,33 @@ let get_location error =
 
 let of_exn = Astlib.Location.Error.of_exn
 let raise error = raise (Astlib.Location.Error error)
+
+let of_extension (extension : Ast.extension) =
+  let open Parsetree in
+  let parse_msg = function
+    | {
+        pstr_desc =
+          Pstr_eval
+            ({ pexp_desc = Pexp_constant (Pconst_string (msg, _, _)); _ }, []);
+        _;
+      } ->
+        msg
+    | _ -> "ppxlib: failed to extract message in ocaml.error"
+  in
+  let parse_sub_msg = function
+    | {
+        pstr_desc =
+          Pstr_extension
+            (({ txt = "error" | "ocaml.error"; loc }, PStr [ msg ]), []);
+        _;
+      } ->
+        (loc, parse_msg msg)
+    | { pstr_loc = loc; _ } ->
+        (loc, "ppxlib: failed to parse ocaml.error sub messages")
+  in
+  match extension with
+  | { txt = "error" | "ocaml.error"; loc }, PStr (main :: sub) ->
+      let main = parse_msg main in
+      let sub = List.map parse_sub_msg sub in
+      Some (make ~loc main ~sub)
+  | _ -> None

--- a/ast/location_error.mli
+++ b/ast/location_error.mli
@@ -11,3 +11,4 @@ val to_extension : t -> Import.Parsetree.extension
 val raise : t -> 'a
 val update_loc : t -> Location.t -> t
 val get_location : t -> Location.t
+val of_extension : Import.Parsetree.extension -> t option

--- a/src/location.mli
+++ b/src/location.mli
@@ -87,6 +87,10 @@ module Error : sig
 
   val get_location : t -> location
   (** Find out where the error is located. *)
+
+  val of_extension : extension -> t option
+  (** Convert an extension point to an error. Extension points must have the
+      exact form as created by [to_extension]. *)
 end
 with type location := t
 

--- a/test/driver/run_as_ppx_rewriter/run.t
+++ b/test/driver/run_as_ppx_rewriter/run.t
@@ -63,6 +63,7 @@ The only possible usage is [extra_args] <infile> <outfile>...
     -no-merge                   Do not merge context free transformations (better for debugging rewriters). As a result, the context-free transformations are not all applied before all impl and intf.
     -cookie NAME=EXPR           Set the cookie NAME to EXPR
     --cookie                    Same as -cookie
+    -raise-embedded-errors      Raise the first embedded error found in the processed AST
     -help                       Display this list of options
     --help                      Display this list of options
   [2]
@@ -84,5 +85,6 @@ The only exception is consulting help
     -no-merge                   Do not merge context free transformations (better for debugging rewriters). As a result, the context-free transformations are not all applied before all impl and intf.
     -cookie NAME=EXPR           Set the cookie NAME to EXPR
     --cookie                    Same as -cookie
+    -raise-embedded-errors      Raise the first embedded error found in the processed AST
     -help                       Display this list of options
     --help                      Display this list of options

--- a/test/error_embedding/run.t
+++ b/test/error_embedding/run.t
@@ -79,11 +79,11 @@ Error nodes are generated when dependent derivers are not applied.
 Flag `-raise-embedded-errors` raises the first embedded error in the AST.
 
   $ echo "let () = ()" > embedded_error.ml
-  $ echo "module _ = struct [%%ocaml.error \"error 1\"] end" >> embedded_error.ml
+  $ echo "module T = struct [%%ocaml.error \"error 1\"] end" >> embedded_error.ml
   $ echo "[%%ocaml.error \"error 2\"]" >> embedded_error.ml
   $ ./extender.exe embedded_error.ml -raise-embedded-errors
   File "embedded_error.ml", line 2, characters 21-32:
-  2 | module _ = struct [%%ocaml.error "error 1"] end
+  2 | module T = struct [%%ocaml.error "error 1"] end
                            ^^^^^^^^^^^
   Error: error 1
   [1]

--- a/test/error_embedding/run.t
+++ b/test/error_embedding/run.t
@@ -75,3 +75,15 @@ Error nodes are generated when dependent derivers are not applied.
       let _ = "derived_string"
       let _ = "derived_string"
     end[@@ocaml.doc "@inline"][@@merlin.hide ]
+
+Flag `-raise-embedded-errors` raises the first embedded error in the AST.
+
+  $ echo "let () = ()" > embedded_error.ml
+  $ echo "module _ = struct [%%ocaml.error \"error 1\"] end" >> embedded_error.ml
+  $ echo "[%%ocaml.error \"error 2\"]" >> embedded_error.ml
+  $ ./extender.exe embedded_error.ml -raise-embedded-errors
+  File "embedded_error.ml", line 2, characters 21-32:
+  2 | module _ = struct [%%ocaml.error "error 1"] end
+                           ^^^^^^^^^^^
+  Error: error 1
+  [1]


### PR DESCRIPTION
Adds a flag `-raise-embedded-errors` to the shared args in `Driver`, which will raise the first `ocaml.error` node found in the processed AST.

### Motivation
It's useful to be able to run a standalone ppx driver for it's side affects (e.g. registering correction files), without actually making use of it's output directly.

For example, given the program `program.ml`:

```ocaml
type t = int [@@deriving_inline my_deriver]
```

One might run:

```bash
$ my_ppx.exe program.ml -null
```
With the objective of registering a correction file while ignoring any output. However, since errors are embedded into the AST, the error `[%%ocaml.error "ppxlib: [@@@deriving.end] attribute missing"]` never gets surfaced to the users. Now it can be, with `-raise-embedded-errors`.