### PR TITLE
Export Ast_pattern.fail.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 unreleased
 ----------
 
+- Export `Ast_pattern.fail`. (#563, @ceastlund)
+
 - Make `Ast_traverse.sexp_of` more concise, and add a test. (#561, @ceastlund)
 
 0.35.0 (2025-02-03)

--- a/src/ast_pattern.mli
+++ b/src/ast_pattern.mli
@@ -210,3 +210,6 @@ type context
 
 val of_func : (context -> Location.t -> 'a -> 'b -> 'c) -> ('a, 'b, 'c) t
 val to_func : ('a, 'b, 'c) t -> context -> Location.t -> 'a -> 'b -> 'c
+
+val fail : Location.t -> string -> _
+(** Call from [of_func]'s argument when the pattern does not match. *)

--- a/src/ast_pattern.mli
+++ b/src/ast_pattern.mli
@@ -212,4 +212,5 @@ val of_func : (context -> Location.t -> 'a -> 'b -> 'c) -> ('a, 'b, 'c) t
 val to_func : ('a, 'b, 'c) t -> context -> Location.t -> 'a -> 'b -> 'c
 
 val fail : Location.t -> string -> _
-(** Call from [of_func]'s argument when the pattern does not match. *)
+(** Call from [of_func]'s argument when the pattern does not match. The string
+    should describe the expected shape of the AST where the match failed. *)


### PR DESCRIPTION
Without this function it was hard to write new pattern matchers using `of_func`.