### PR TITLE
Use setup-ocaml@v3 for trunk build

### DIFF
--- a/.github/workflows/trunk-build.yml
+++ b/.github/workflows/trunk-build.yml
@@ -26,9 +26,9 @@ jobs:
           cat "$GITHUB_OUTPUT"
 
       - name: Install OCaml compiler
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 'ocaml-variants.5.3.0+trunk'
+          ocaml-compiler: 'ocaml-variants.5.3.1+trunk'
           dune-cache: true
           cache-prefix: ${{ steps.setup.outputs.cache_prefix }}
 


### PR DESCRIPTION
The darcs issue seemed related to https://github.com/ocaml/setup-ocaml/issues/923

I also bumped the version of the trunk compiler we are building against.