### PR TITLE
Add a dune package management GHA workflow

### DIFF
--- a/.github/workflows/dune-build.yml
+++ b/.github/workflows/dune-build.yml
@@ -1,0 +1,18 @@
+name: Build on Dune PM
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        runs-on: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Use dune
+        uses: ocaml-dune/setup-dune@v0.0.1
+        with:
+          automagic: true


### PR DESCRIPTION
This patch introduces a new GitHub Actions workflow with dune package management. It'd help us ensure ppxlib builds with dune PM.