### PR TITLE
Update ubuntu version used for changelog related actions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,4 +10,4 @@ jobs:
     name: Check Changelog Action
     runs-on: ubuntu-latest
     steps:
-      - uses: tarides/changelog-check-action@v1
+      - uses: tarides/changelog-check-action@v3

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,6 +8,6 @@ on:
 jobs:
   Changelog-Entry-Check:
     name: Check Changelog Action
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: tarides/changelog-check-action@v1

--- a/.github/workflows/pr-number.yml
+++ b/.github/workflows/pr-number.yml
@@ -7,4 +7,4 @@ jobs:
     name: Update PR number
     runs-on: ubuntu-latest
     steps:
-      - uses: tarides/pr-number-action@v1.1
+      - uses: tarides/pr-number-action@v2

--- a/.github/workflows/pr-number.yml
+++ b/.github/workflows/pr-number.yml
@@ -5,6 +5,6 @@ on: [pull_request_target]
 jobs:
   PR-Number-Update:
     name: Update PR number
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: tarides/pr-number-action@v1.1


### PR DESCRIPTION
The actions weren't run anymore because we were using an old, fixed version of ubuntu.