### PR TITLE
Add module bindings and module declarations to deriving

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@ unreleased
 - Add a new context-free rule type that replaces AST nodes that have the registered
   attributes attached to them. (#574, @Skepfyr)
 
+- Allow users to derive code from module bindings and module declarations
+  (#576, @patricoferris)
+
 0.36.1 (2025-07-10)
 -------------------
 

--- a/src/context_free.mli
+++ b/src/context_free.mli
@@ -148,6 +148,17 @@ module Rule : sig
   val attr_sig_module_type_decl_expect :
     (signature_item, module_type_declaration, _) attr_inline
 
+  val attr_str_module_binding : (structure_item, module_binding, _) attr_inline
+
+  val attr_sig_module_declaration :
+    (signature_item, module_declaration, _) attr_inline
+
+  val attr_str_module_binding_expect :
+    (structure_item, module_binding, _) attr_inline
+
+  val attr_sig_module_declaration_expect :
+    (signature_item, module_declaration, _) attr_inline
+
   val attr_str_type_ext : (structure_item, type_extension, _) attr_inline
   val attr_sig_type_ext : (signature_item, type_extension, _) attr_inline
   val attr_str_type_ext_expect : (structure_item, type_extension, _) attr_inline

--- a/src/deriving.mli
+++ b/src/deriving.mli
@@ -109,11 +109,13 @@ val add :
   ?str_type_ext:(structure, type_extension) Generator.t ->
   ?str_exception:(structure, type_exception) Generator.t ->
   ?str_module_type_decl:(structure, module_type_declaration) Generator.t ->
+  ?str_module_binding:(structure, module_binding) Generator.t ->
   ?sig_type_decl:(signature, rec_flag * type_declaration list) Generator.t ->
   ?sig_class_type_decl:(signature, class_type_declaration list) Generator.t ->
   ?sig_type_ext:(signature, type_extension) Generator.t ->
   ?sig_exception:(signature, type_exception) Generator.t ->
   ?sig_module_type_decl:(signature, module_type_declaration) Generator.t ->
+  ?sig_module_decl:(signature, module_declaration) Generator.t ->
   ?extension:(loc:Location.t -> path:string -> core_type -> expression) ->
   string ->
   t
@@ -137,11 +139,13 @@ val add_alias :
   ?str_type_ext:t list ->
   ?str_exception:t list ->
   ?str_module_type_decl:t list ->
+  ?str_module_binding:t list ->
   ?sig_type_decl:t list ->
   ?sig_class_type_decl:t list ->
   ?sig_type_ext:t list ->
   ?sig_exception:t list ->
   ?sig_module_type_decl:t list ->
+  ?sig_module_decl:t list ->
   t list ->
   t
 (** [add_alias name set] add an alias. When the user write the alias, all the

--- a/test/deriving/test.ml
+++ b/test/deriving/test.ml
@@ -81,3 +81,21 @@ class type x = object end[@@deriving cd]
 class type x = object  end
 val y : int = 42
 |}]
+
+
+let mbmd =
+  Deriving.add "mbmd"
+    ~sig_module_decl:(Deriving.Generator.make_noarg (fun ~loc ~path:_ _ -> [%sig: val y : int]))
+    ~str_module_binding:(Deriving.Generator.make_noarg (fun ~loc ~path:_ _ -> [%str let y = 42]))
+
+[%%expect{|
+val mbmd : Deriving.t = <abstr>
+|}]
+
+module X = struct
+  type t
+end[@@deriving mbmd]
+[%%expect{|
+module X : sig type t end
+val y : int = 42
+|}]


### PR DESCRIPTION
In https://github.com/ocaml-ppx/ppxlib/issues/546 a feature request was made for `[@@deriving ...]` to work on module bindings (and perhaps their signature counterpart declarations). 

Some notes:
 - I had to disable the cinaps str_to_sig stuff as module bindings and declarations are not as nicely symmetric as other types.
 - Like other `[@@deriving]` features, derived code is placed after the node, therefore using this with module bindings will not place the code _inside_ the module definition but after it. I think some amount of `include`ing can work around this maybe (on the end user's side)?