### PR TITLE
Remove unused code from Code_path

### DIFF
--- a/src/code_path.ml
+++ b/src/code_path.ml
@@ -70,8 +70,3 @@ let enter_value ~loc value_name t =
 
 let to_string_path t = String.concat ~sep:"." (t.file_path :: submodule_path t)
 let with_string_path f ~loc ~path = f ~loc ~path:(to_string_path path);;
-
-let module M = struct
-  let a = "lol"
-end in
-M.a


### PR DESCRIPTION
I belive got added by accident here: https://github.com/ocaml-ppx/ppxlib/commit/3e0f8018f867bcc35357928e0383a8fd380f4943 as there's some inline expected tests in the same commit