### PR TITLE
Update pprintast

### DIFF
--- a/astlib/pprintast.ml
+++ b/astlib/pprintast.ml
@@ -21,73 +21,19 @@
 (* Extensive Rewrite: Hongbo Zhang: University of Pennsylvania *)
 (* TODO more fine-grained precedence pretty-printing *)
 
+(* This file was copied from OCaml 5.3's pprintast.ml and modified in the
+   following ways:
+   - Added [open Ast_503] before other global opens
+   - Replaced [Lexer.is_keyword] with [Keyword.is_keyword] for compat with
+     Ocaml < 5.2.
+   - Added [class_signature] and [type_declaration] entry points at the end. *)
+
 open Ast_503
 open Asttypes
 open Format
 open Location
 open Longident
 open Parsetree
-
-module Option = struct
-  let value t ~default = match t with None -> default | Some x -> x
-end
-
-let varify_type_constructors var_names t =
-  let check_variable vl loc v =
-    if List.mem v vl then
-      Location.raise_errorf ~loc "variable in scope syntax error: %s" v
-  in
-  let var_names = List.map (fun v -> v.txt) var_names in
-  let rec loop t =
-    let desc =
-      match t.ptyp_desc with
-      | Ptyp_any -> Ptyp_any
-      | Ptyp_var x ->
-          check_variable var_names t.ptyp_loc x;
-          Ptyp_var x
-      | Ptyp_arrow (label, core_type, core_type') ->
-          Ptyp_arrow (label, loop core_type, loop core_type')
-      | Ptyp_tuple lst -> Ptyp_tuple (List.map loop lst)
-      | Ptyp_constr ({ txt = Longident.Lident s }, []) when List.mem s var_names
-        ->
-          Ptyp_var s
-      | Ptyp_constr (longident, lst) ->
-          Ptyp_constr (longident, List.map loop lst)
-      | Ptyp_object (lst, o) -> Ptyp_object (List.map loop_object_field lst, o)
-      | Ptyp_class (longident, lst) -> Ptyp_class (longident, List.map loop lst)
-      | Ptyp_alias (core_type, string) ->
-          check_variable var_names t.ptyp_loc string.txt;
-          Ptyp_alias (loop core_type, string)
-      | Ptyp_variant (row_field_list, flag, lbl_lst_option) ->
-          Ptyp_variant
-            (List.map loop_row_field row_field_list, flag, lbl_lst_option)
-      | Ptyp_poly (string_lst, core_type) ->
-          List.iter
-            (fun v -> check_variable var_names t.ptyp_loc v.txt)
-            string_lst;
-          Ptyp_poly (string_lst, loop core_type)
-      | Ptyp_package (longident, lst) ->
-          Ptyp_package (longident, List.map (fun (n, typ) -> (n, loop typ)) lst)
-      | Ptyp_extension (s, arg) -> Ptyp_extension (s, arg)
-      | Ptyp_open (s, ct) -> Ptyp_open (s, loop ct)
-    in
-    { t with ptyp_desc = desc }
-  and loop_row_field field =
-    let prf_desc =
-      match field.prf_desc with
-      | Rtag (label, flag, lst) -> Rtag (label, flag, List.map loop lst)
-      | Rinherit t -> Rinherit (loop t)
-    in
-    { field with prf_desc }
-  and loop_object_field field =
-    let pof_desc =
-      match field.pof_desc with
-      | Otag (label, t) -> Otag (label, loop t)
-      | Oinherit t -> Oinherit (loop t)
-    in
-    { field with pof_desc }
-  in
-  loop t
 
 let prefix_symbols = [ '!'; '?'; '~' ]
 
@@ -139,33 +85,145 @@ let first_is c str = str <> "" && str.[0] = c
 let last_is c str = str <> "" && str.[String.length str - 1] = c
 let first_is_in cs str = str <> "" && List.mem str.[0] cs
 
+(** The OCaml grammar generates [longident]s from five different rules:
+    - module longident (a sequence of uppercase identifiers [A.B.C])
+    - constructor longident, either
+    - a module [longident]
+    - [[]], [()], [true], [false]
+    - an optional module [longident] followed by [(::)] ([A.B.(::)])
+    - class longident, an optional module [longident] followed by a lowercase
+      identifier.
+    - value longident, an optional module [longident] followed by either:
+    - a lowercase identifier ([A.x])
+    - an operator (and in particular the [mod] keyword), ([A.(+), B.(mod)])
+    - type [longident]: a tree of applications and projections of uppercase
+      identifiers followed by a projection ending with a lowercase identifier
+      (for ordinary types), or any identifier (for module types) (e.g
+      [A.B(C.D(E.F).K)(G).X.Y.t]) All these [longident]s share a common core and
+      optionally add some extensions. Unfortunately, these extensions intersect
+      while having different escaping and parentheses rules depending on the
+      kind of [longident]:
+    - [true] or [false] can be either constructor [longident]s, or value, type
+      or class [longident]s using the raw identifier syntax.
+    - [mod] can be either an operator value [longident], or a class or type
+      [longident] using the raw identifier syntax. Thus in order to print
+      correctly [longident]s, we need to keep track of their kind using the
+      context in which they appear. *)
+type longindent_kind =
+  | Constr  (** variant constructors *)
+  | Type  (** core types, module types, class types, and classes *)
+  | Other  (** values and modules *)
+
 (* which identifiers are in fact operators needing parentheses *)
-let needs_parens txt =
-  let fix = fixity_of_string txt in
-  is_infix fix || is_mixfix fix || is_kwdop fix
-  || first_is_in prefix_symbols txt
+let needs_parens ~kind txt =
+  match kind with
+  | Type -> false
+  | Constr | Other ->
+      let fix = fixity_of_string txt in
+      is_infix fix || is_mixfix fix || is_kwdop fix
+      || first_is_in prefix_symbols txt
 
 (* some infixes need spaces around parens to avoid clashes with comment
    syntax *)
 let needs_spaces txt = first_is '*' txt || last_is '*' txt
-let string_loc ppf x = fprintf ppf "%s" x.txt
 
-(* add parentheses to binders when they are in fact infix or prefix operators *)
-let protect_ident ppf txt =
-  let format : (_, _, _) format =
-    if not (needs_parens txt) then "%s"
-    else if needs_spaces txt then "(@;%s@;)"
-    else "(%s)"
-  in
-  fprintf ppf format txt
+let tyvar_of_name s =
+  if String.length s >= 2 && s.[1] = '\'' then
+    (* without the space, this would be parsed as
+       a character literal *)
+    "' " ^ s
+  else if Keyword.is_keyword s then "'\\#" ^ s
+  else if String.equal s "_" then s
+  else "'" ^ s
 
-let protect_longident ppf print_longident longprefix txt =
-  let format : (_, _, _) format =
-    if not (needs_parens txt) then "%a.%s"
-    else if needs_spaces txt then "%a.(@;%s@;)"
-    else "%a.(%s)"
-  in
-  fprintf ppf format print_longident longprefix txt
+module Doc = struct
+  (* Turn an arbitrary variable name into a valid OCaml identifier by adding \#
+   in case it is a keyword, or parenthesis when it is an infix or prefix
+   operator. *)
+  let ident_of_name ~kind ppf txt =
+    let format : (_, _, _) format =
+      if Keyword.is_keyword txt then
+        match (kind, txt) with
+        | Constr, ("true" | "false") -> "%s"
+        | _ -> "\\#%s"
+      else if not (needs_parens ~kind txt) then "%s"
+      else if needs_spaces txt then "(@;%s@;)"
+      else "(%s)"
+    in
+    Format_doc.fprintf ppf format txt
+
+  let protect_longident ~kind ppf print_longident longprefix txt =
+    if not (needs_parens ~kind txt) then
+      Format_doc.fprintf ppf "%a.%a" print_longident longprefix
+        (ident_of_name ~kind) txt
+    else if needs_spaces txt then
+      Format_doc.fprintf ppf "%a.(@;%s@;)" print_longident longprefix txt
+    else Format_doc.fprintf ppf "%a.(%s)" print_longident longprefix txt
+
+  let rec any_longident ~kind f = function
+    | Lident s -> ident_of_name ~kind f s
+    | Ldot (y, s) -> protect_longident ~kind f (any_longident ~kind:Other) y s
+    | Lapply (y, s) ->
+        Format_doc.fprintf f "%a(%a)"
+          (any_longident ~kind:Other)
+          y
+          (any_longident ~kind:Other)
+          s
+
+  let value_longident ppf l = any_longident ~kind:Other ppf l
+  let longident = value_longident
+  let constr ppf l = any_longident ~kind:Constr ppf l
+  let type_longident ppf l = any_longident ~kind:Type ppf l
+  let tyvar ppf s = Format_doc.fprintf ppf "%s" (tyvar_of_name s)
+
+  (* Expressions are considered nominal if they can be used as the subject of a
+     sentence or action. In practice, we consider that an expression is nominal
+     if they satisfy one of:
+     - Similar to an identifier: words separated by '.' or '#'.
+     - Do not contain spaces when printed.
+     - Is a constant that is short enough.
+  *)
+  let nominal_exp t =
+    let open Format_doc.Doc in
+    let longident ?(is_constr = false) l =
+      let kind = if is_constr then Constr else Other in
+      Format_doc.doc_printer (any_longident ~kind) l.Location.txt
+    in
+    let rec nominal_exp doc exp =
+      match exp.pexp_desc with
+      | _ when exp.pexp_attributes <> [] -> None
+      | Pexp_ident l -> Some (longident l doc)
+      | Pexp_variant (lbl, None) -> Some (printf "`%s" lbl doc)
+      | Pexp_construct (l, None) -> Some (longident ~is_constr:true l doc)
+      | Pexp_field (parent, lbl) ->
+          Option.map (printf ".%t" (longident lbl)) (nominal_exp doc parent)
+      | Pexp_send (parent, meth) ->
+          Option.map (printf "#%s" meth.txt) (nominal_exp doc parent)
+      (* String constants are syntactically too complex. For example, the
+         quotes conflict with the 'inline_code' style and they might contain
+         spaces. *)
+      | Pexp_constant { pconst_desc = Pconst_string _; _ } -> None
+      (* Char, integer and float constants are nominal. *)
+      | Pexp_constant { pconst_desc = Pconst_char c; _ } -> Some (msg "%C" c)
+      | Pexp_constant
+          {
+            pconst_desc = Pconst_integer (cst, suf) | Pconst_float (cst, suf);
+            _;
+          } ->
+          Some (msg "%s%t" cst (option char suf))
+      | _ -> None
+    in
+    nominal_exp empty t
+end
+
+let value_longident ppf l = Format_doc.compat Doc.value_longident ppf l
+let type_longident ppf l = Format_doc.compat Doc.type_longident ppf l
+
+let ident_of_name ppf i =
+  Format_doc.compat (Doc.ident_of_name ~kind:Other) ppf i
+
+let constr ppf l = Format_doc.compat Doc.constr ppf l
+let ident_of_name_loc ppf s = ident_of_name ppf s.txt
 
 type space_formatter = (unit, Format.formatter, unit) format
 
@@ -185,12 +243,16 @@ type construct =
   | `nil
   | `normal
   | `simple of Longident.t
-  | `tuple ]
+  | `tuple
+  | `btrue
+  | `bfalse ]
 
 let view_expr x =
   match x.pexp_desc with
-  | Pexp_construct ({ txt = Lident "()"; _ }, _) -> `tuple
-  | Pexp_construct ({ txt = Lident "[]"; _ }, _) -> `nil
+  | Pexp_construct ({ txt = Lident "()"; _ }, None) -> `tuple
+  | Pexp_construct ({ txt = Lident "true"; _ }, None) -> `btrue
+  | Pexp_construct ({ txt = Lident "false"; _ }, None) -> `bfalse
+  | Pexp_construct ({ txt = Lident "[]"; _ }, None) -> `nil
   | Pexp_construct ({ txt = Lident "::"; _ }, Some _) ->
       let rec loop exp acc =
         match exp with
@@ -216,7 +278,7 @@ let view_expr x =
   | _ -> `normal
 
 let is_simple_construct : construct -> bool = function
-  | `nil | `tuple | `list _ | `simple _ -> true
+  | `nil | `tuple | `list _ | `simple _ | `btrue | `bfalse -> true
   | `cons _ | `normal -> false
 
 let pp = fprintf
@@ -303,15 +365,10 @@ let paren :
     pp f ")")
   else fu f x
 
-let rec longident f = function
-  | Lident s -> protect_ident f s
-  | Ldot (y, s) -> protect_longident f longident y s
-  | Lapply (y, s) -> pp f "%a(%a)" longident y longident s
+let with_loc pr ppf x = pr ppf x.txt
+let value_longident_loc = with_loc value_longident
 
-let longident_loc f x = pp f "%a" longident x.txt
-
-let constant f c =
-  match c.pconst_desc with
+let constant_desc f = function
   | Pconst_char i -> pp f "%C" i
   | Pconst_string (i, _, None) -> pp f "%S" i
   | Pconst_string (i, _, Some delim) -> pp f "{%s|%s|%s}" delim i delim
@@ -321,6 +378,8 @@ let constant f c =
   | Pconst_float (i, None) -> paren (first_is '-' i) (fun f -> pp f "%s") f i
   | Pconst_float (i, Some m) ->
       paren (first_is '-' i) (fun f (i, m) -> pp f "%s%c" i m) f (i, m)
+
+let constant f const = constant_desc f const.pconst_desc
 
 (* trailing space*)
 let mutable_flag f = function Immutable -> () | Mutable -> pp f "mutable@;"
@@ -340,16 +399,9 @@ let direction_flag f = function
 let private_flag f = function Public -> () | Private -> pp f "private@ "
 let iter_loc f ctxt { txt; loc = _ } = f ctxt txt
 let constant_string f s = pp f "%S" s
-
-let tyvar ppf s =
-  if String.length s >= 2 && s.[1] = '\'' then
-    (* without the space, this would be parsed as
-       a character literal *)
-    Format.fprintf ppf "' %s" s
-  else Format.fprintf ppf "'%s" s
-
+let tyvar ppf v = Format_doc.compat Doc.tyvar ppf v
 let tyvar_loc f str = tyvar f str.txt
-let string_quot f x = pp f "`%s" x
+let string_quot f x = pp f "`%a" ident_of_name x
 
 (* c ['a,'b] *)
 let rec class_params_def ctxt f = function
@@ -359,8 +411,8 @@ let rec class_params_def ctxt f = function
 and type_with_label ctxt f (label, c) =
   match label with
   | Nolabel -> core_type1 ctxt f c (* otherwise parenthesize *)
-  | Labelled s -> pp f "%s:%a" s (core_type1 ctxt) c
-  | Optional s -> pp f "?%s:%a" s (core_type1 ctxt) c
+  | Labelled s -> pp f "%a:%a" ident_of_name s (core_type1 ctxt) c
+  | Optional s -> pp f "?%a:%a" ident_of_name s (core_type1 ctxt) c
 
 and core_type ctxt f x =
   if x.ptyp_attributes <> [] then
@@ -373,17 +425,14 @@ and core_type ctxt f x =
         pp f "@[<2>%a@;->@;%a@]" (* FIXME remove parens later *)
           (type_with_label ctxt) (l, ct1) (core_type ctxt) ct2
     | Ptyp_alias (ct, s) ->
-        pp f "@[<2>%a@;as@;%a@]" (core_type1 ctxt) ct tyvar_loc s
+        pp f "@[<2>%a@;as@;%a@]" (core_type1 ctxt) ct tyvar s.txt
     | Ptyp_poly ([], ct) -> core_type ctxt f ct
     | Ptyp_poly (sl, ct) ->
         pp f "@[<2>%a%a@]"
           (fun f l ->
-            pp f "%a"
-              (fun f l ->
-                match l with
-                | [] -> ()
-                | _ -> pp f "%a@;.@;" (list tyvar_loc ~sep:"@;") l)
-              l)
+            match l with
+            | [] -> ()
+            | _ -> pp f "%a@;.@;" (list tyvar_loc ~sep:"@;") l)
           sl (core_type ctxt) ct
     | _ -> pp f "@[<2>%a@]" (core_type1 ctxt) x
 
@@ -401,7 +450,7 @@ and core_type1 ctxt f x =
             | [] -> ()
             | [ x ] -> pp f "%a@;" (core_type1 ctxt) x
             | _ -> list ~first:"(" ~last:")@;" (core_type ctxt) ~sep:",@;" f l)
-          l longident_loc li
+          l (with_loc type_longident) li
     | Ptyp_variant (l, closed, low) ->
         let first_is_inherit =
           match l with
@@ -443,8 +492,8 @@ and core_type1 ctxt f x =
           match x.pof_desc with
           | Otag (l, ct) ->
               (* Cf #7200 *)
-              pp f "@[<hov2>%s: %a@ %a@ @]" l.txt (core_type ctxt) ct
-                (attributes ctxt) x.pof_attributes
+              pp f "@[<hov2>%a: %a@ %a@ @]" ident_of_name l.txt (core_type ctxt)
+                ct (attributes ctxt) x.pof_attributes
           | Oinherit ct -> pp f "@[<hov2>%a@ @]" (core_type ctxt) ct
         in
         let field_var f = function
@@ -454,26 +503,26 @@ and core_type1 ctxt f x =
         in
         pp f "@[<hov2><@ %a%a@ > @]"
           (list core_field_type ~sep:";")
-          l field_var o
-        (* Cf #7200 *)
+          l field_var o (* Cf #7200 *)
     | Ptyp_class (li, l) ->
         (*FIXME*)
         pp f "@[<hov2>%a#%a@]"
           (list (core_type ctxt) ~sep:"," ~first:"(" ~last:")")
-          l longident_loc li
-    | Ptyp_open (li, ct) ->
-        pp f "@[<hov2>%a.(%a)@]" longident_loc li (core_type ctxt) ct
+          l (with_loc type_longident) li
     | Ptyp_package (lid, cstrs) -> (
         let aux f (s, ct) =
-          pp f "type %a@ =@ %a" longident_loc s (core_type ctxt) ct
+          pp f "type %a@ =@ %a" (with_loc type_longident) s (core_type ctxt) ct
         in
         match cstrs with
-        | [] -> pp f "@[<hov2>(module@ %a)@]" longident_loc lid
+        | [] -> pp f "@[<hov2>(module@ %a)@]" (with_loc type_longident) lid
         | _ ->
-            pp f "@[<hov2>(module@ %a@ with@ %a)@]" longident_loc lid
-              (list aux ~sep:"@ and@ ") cstrs)
+            pp f "@[<hov2>(module@ %a@ with@ %a)@]" (with_loc type_longident)
+              lid (list aux ~sep:"@ and@ ") cstrs)
+    | Ptyp_open (li, ct) ->
+        pp f "@[<hov2>%a.(%a)@]" value_longident_loc li (core_type ctxt) ct
     | Ptyp_extension e -> extension ctxt f e
-    | _ -> paren true (core_type ctxt) f x
+    | Ptyp_arrow _ | Ptyp_alias _ | Ptyp_poly _ ->
+        paren true (core_type ctxt) f x
 
 (********************pattern********************)
 (* be cautious when use [pattern], [pattern1] is preferred *)
@@ -485,7 +534,7 @@ and pattern ctxt f x =
   else
     match x.ppat_desc with
     | Ppat_alias (p, s) ->
-        pp f "@[<2>%a@;as@;%a@]" (pattern ctxt) p protect_ident s.txt
+        pp f "@[<2>%a@;as@;%a@]" (pattern ctxt) p ident_of_name s.txt
     | _ -> pattern_or ctxt f x
 
 and pattern_or ctxt f x =
@@ -516,8 +565,9 @@ and pattern1 ctxt (f : Format.formatter) (x : pattern) : unit =
   else
     match x.ppat_desc with
     | Ppat_variant (l, Some p) ->
-        pp f "@[<2>`%s@;%a@]" l (simple_pattern ctxt) p
-    | Ppat_construct ({ txt = Lident ("()" | "[]"); _ }, _) ->
+        pp f "@[<2>`%a@;%a@]" ident_of_name l (simple_pattern ctxt) p
+    | Ppat_construct ({ txt = Lident ("()" | "[]" | "true" | "false"); _ }, _)
+      ->
         simple_pattern ctxt f x
     | Ppat_construct (({ txt; _ } as li), po) -> (
         if
@@ -527,34 +577,37 @@ and pattern1 ctxt (f : Format.formatter) (x : pattern) : unit =
         else
           match po with
           | Some ([], x) ->
-              pp f "%a@;%a" longident_loc li (simple_pattern ctxt) x
+              (* [true] and [false] are handled above *)
+              pp f "%a@;%a" value_longident_loc li (simple_pattern ctxt) x
           | Some (vl, x) ->
-              pp f "%a@ (type %a)@;%a" longident_loc li
-                (list ~sep:"@ " string_loc)
+              pp f "%a@ (type %a)@;%a" value_longident_loc li
+                (list ~sep:"@ " ident_of_name_loc)
                 vl (simple_pattern ctxt) x
-          | None -> pp f "%a" longident_loc li)
+          | None -> pp f "%a" value_longident_loc li)
     | _ -> simple_pattern ctxt f x
 
 and simple_pattern ctxt (f : Format.formatter) (x : pattern) : unit =
   if x.ppat_attributes <> [] then pattern ctxt f x
   else
     match x.ppat_desc with
-    | Ppat_construct ({ txt = Lident (("()" | "[]") as x); _ }, None) ->
+    | Ppat_construct
+        ({ txt = Lident (("()" | "[]" | "true" | "false") as x); _ }, None) ->
         pp f "%s" x
     | Ppat_any -> pp f "_"
-    | Ppat_var { txt; _ } -> protect_ident f txt
+    | Ppat_var { txt; _ } -> ident_of_name f txt
     | Ppat_array l -> pp f "@[<2>[|%a|]@]" (list (pattern1 ctxt) ~sep:";") l
     | Ppat_unpack { txt = None } -> pp f "(module@ _)@ "
     | Ppat_unpack { txt = Some s } -> pp f "(module@ %s)@ " s
-    | Ppat_type li -> pp f "#%a" longident_loc li
+    | Ppat_type li -> pp f "#%a" (with_loc type_longident) li
     | Ppat_record (l, closed) -> (
         let longident_x_pattern f (li, p) =
           match (li, p) with
           | ( { txt = Lident s; _ },
               { ppat_desc = Ppat_var { txt; _ }; ppat_attributes = []; _ } )
             when s = txt ->
-              pp f "@[<2>%a@]" longident_loc li
-          | _ -> pp f "@[<2>%a@;=@;%a@]" longident_loc li (pattern1 ctxt) p
+              pp f "@[<2>%a@]" value_longident_loc li
+          | _ ->
+              pp f "@[<2>%a@;=@;%a@]" value_longident_loc li (pattern1 ctxt) p
         in
         match closed with
         | Closed ->
@@ -564,21 +617,24 @@ and simple_pattern ctxt (f : Format.formatter) (x : pattern) : unit =
         pp f "@[<1>(%a)@]" (list ~sep:",@;" (pattern1 ctxt)) l (* level1*)
     | Ppat_constant c -> pp f "%a" constant c
     | Ppat_interval (c1, c2) -> pp f "%a..%a" constant c1 constant c2
-    | Ppat_variant (l, None) -> pp f "`%s" l
+    | Ppat_variant (l, None) -> pp f "`%a" ident_of_name l
     | Ppat_constraint (p, ct) ->
         pp f "@[<2>(%a@;:@;%a)@]" (pattern1 ctxt) p (core_type ctxt) ct
     | Ppat_lazy p -> pp f "@[<2>(lazy@;%a)@]" (simple_pattern ctxt) p
     | Ppat_exception p -> pp f "@[<2>exception@;%a@]" (pattern1 ctxt) p
+    | Ppat_effect (p1, p2) ->
+        pp f "@[<2>effect@;%a, @;%a@]" (pattern1 ctxt) p1 (pattern1 ctxt) p2
     | Ppat_extension e -> extension ctxt f e
     | Ppat_open (lid, p) ->
         let with_paren =
           match p.ppat_desc with
           | Ppat_array _ | Ppat_record _
-          | Ppat_construct ({ txt = Lident ("()" | "[]"); _ }, None) ->
+          | Ppat_construct
+              ({ txt = Lident ("()" | "[]" | "true" | "false"); _ }, None) ->
               false
           | _ -> true
         in
-        pp f "@[<2>%a.%a @]" longident_loc lid
+        pp f "@[<2>%a.%a @]" value_longident_loc lid
           (paren with_paren @@ pattern1 ctxt)
           p
     | _ -> paren true (pattern ctxt) f x
@@ -593,19 +649,20 @@ and label_exp ctxt f (l, opt, p) =
       | { ppat_desc = Ppat_var { txt; _ }; ppat_attributes = [] }
         when txt = rest -> (
           match opt with
-          | Some o -> pp f "?(%s=@;%a)@;" rest (expression ctxt) o
-          | None -> pp f "?%s@ " rest)
+          | Some o -> pp f "?(%a=@;%a)@;" ident_of_name rest (expression ctxt) o
+          | None -> pp f "?%a@ " ident_of_name rest)
       | _ -> (
           match opt with
           | Some o ->
-              pp f "?%s:(%a=@;%a)@;" rest (pattern1 ctxt) p (expression ctxt) o
-          | None -> pp f "?%s:%a@;" rest (simple_pattern ctxt) p))
+              pp f "?%a:(%a=@;%a)@;" ident_of_name rest (pattern1 ctxt) p
+                (expression ctxt) o
+          | None -> pp f "?%a:%a@;" ident_of_name rest (simple_pattern ctxt) p))
   | Labelled l -> (
       match p with
       | { ppat_desc = Ppat_var { txt; _ }; ppat_attributes = [] } when txt = l
         ->
-          pp f "~%s@;" l
-      | _ -> pp f "~%s:%a@;" l (simple_pattern ctxt) p)
+          pp f "~%a@;" ident_of_name l
+      | _ -> pp f "~%a:%a@;" ident_of_name l (simple_pattern ctxt) p)
 
 and sugar_expr ctxt f e =
   if e.pexp_attributes <> [] then false
@@ -619,7 +676,7 @@ and sugar_expr ctxt f e =
             indices rem_args =
           let print_path ppf = function
             | None -> ()
-            | Some m -> pp ppf ".%a" longident m
+            | Some m -> pp ppf ".%a" value_longident m
           in
           match (assign, rem_args) with
           | false, [] ->
@@ -658,9 +715,9 @@ and sugar_expr ctxt f e =
             | _ -> false)
         | (Lident s | Ldot (_, s)), a :: i :: rest when first_is '.' s ->
             (* extract operator:
-               assignment operators end with [right_bracket ^ "<-"],
-               access operators end with [right_bracket] directly
-            *)
+             assignment operators end with [right_bracket ^ "<-"],
+             access operators end with [right_bracket] directly
+          *)
             let multi_indices = String.contains s ';' in
             let i =
               match i.pexp_desc with
@@ -690,6 +747,35 @@ and sugar_expr ctxt f e =
         | _ -> false)
     | _ -> false
 
+and function_param ctxt f param =
+  match param.pparam_desc with
+  | Pparam_val (a, b, c) -> label_exp ctxt f (a, b, c)
+  | Pparam_newtype ty -> pp f "(type %a)@;" ident_of_name ty.txt
+
+and function_body ctxt f function_body =
+  match function_body with
+  | Pfunction_body body -> expression ctxt f body
+  | Pfunction_cases (cases, _, attrs) ->
+      pp f "@[<hv>function%a%a@]" (item_attributes ctxt) attrs (case_list ctxt)
+        cases
+
+and type_constraint ctxt f constraint_ =
+  match constraint_ with
+  | Pconstraint ty -> pp f ":@;%a" (core_type ctxt) ty
+  | Pcoerce (ty1, ty2) ->
+      pp f "%a:>@;%a"
+        (option ~first:":@;" (core_type ctxt))
+        ty1 (core_type ctxt) ty2
+
+and function_params_then_body ctxt f params constraint_ body ~delimiter =
+  pp f "%a%a%s@;%a"
+    (list (function_param ctxt) ~sep:"")
+    params
+    (option (type_constraint ctxt))
+    constraint_ delimiter
+    (function_body (under_functionrhs ctxt))
+    body
+
 and expression ctxt f x =
   if x.pexp_attributes <> [] then
     pp f "((%a)@,%a)" (expression ctxt)
@@ -708,7 +794,8 @@ and expression ctxt f x =
       when ctxt.semi ->
         paren true (expression reset_ctxt) f x
     | Pexp_newtype (lid, e) ->
-        pp f "@[<2>fun@;(type@;%s)@;->@;%a@]" lid.txt (expression ctxt) e
+        pp f "@[<2>fun@;(type@;%a)@;->@;%a@]" ident_of_name lid.txt
+          (expression ctxt) e
     | Pexp_function (params, c, body) -> (
         match (params, c) with
         (* Omit [fun] if there are no params. *)
@@ -768,7 +855,7 @@ and expression ctxt f x =
                   &&
                   match l with
                   (* See #7200: avoid turning (~- 1) into (- 1) which is
-                     parsed as an int literal *)
+                       parsed as an int literal *)
                   | [ (_, { pexp_desc = Pexp_constant _ }) ] -> false
                   | _ -> true
                 then String.sub s 1 (String.length s - 1)
@@ -785,19 +872,20 @@ and expression ctxt f x =
                 (fun f (e, l) ->
                   pp f "%a@ %a" (expression2 ctxt) e
                     (list (label_x_expression_param reset_ctxt))
-                    l
+                    l)
                   (* reset here only because [function,match,try,sequence]
-                     are lower priority *))
+                       are lower priority *)
                 (e, l))
     | Pexp_construct (li, Some eo) when not (is_simple_construct (view_expr x))
       -> (
         (* Not efficient FIXME*)
         match view_expr x with
         | `cons ls -> list (simple_expr ctxt) f ls ~sep:"@;::@;"
-        | `normal -> pp f "@[<2>%a@;%a@]" longident_loc li (simple_expr ctxt) eo
+        | `normal ->
+            pp f "@[<2>%a@;%a@]" (with_loc constr) li (simple_expr ctxt) eo
         | _ -> assert false)
     | Pexp_setfield (e1, li, e2) ->
-        pp f "@[<2>%a.%a@ <-@ %a@]" (simple_expr ctxt) e1 longident_loc li
+        pp f "@[<2>%a.%a@ <-@ %a@]" (simple_expr ctxt) e1 value_longident_loc li
           (simple_expr ctxt) e2
     | Pexp_ifthenelse (e1, e2, eo) ->
         (* @;@[<2>else@ %a@]@] *)
@@ -810,8 +898,7 @@ and expression ctxt f x =
             match eo with
             | Some x ->
                 pp f "@;@[<2>else@;%a@]" (expression (under_semi ctxt)) x
-            | None -> ()
-            (* pp f "()" *))
+            | None -> () (* pp f "()" *))
           eo
     | Pexp_sequence _ ->
         let rec sequence_helper acc = function
@@ -821,13 +908,13 @@ and expression ctxt f x =
         in
         let lst = sequence_helper [] x in
         pp f "@[<hv>%a@]" (list (expression (under_semi ctxt)) ~sep:";@;") lst
-    | Pexp_new li -> pp f "@[<hov2>new@ %a@]" longident_loc li
+    | Pexp_new li -> pp f "@[<hov2>new@ %a@]" (with_loc type_longident) li
     | Pexp_setinstvar (s, e) ->
-        pp f "@[<hov2>%s@ <-@ %a@]" s.txt (expression ctxt) e
+        pp f "@[<hov2>%a@ <-@ %a@]" ident_of_name s.txt (expression ctxt) e
     | Pexp_override l ->
         (* FIXME *)
         let string_x_expression f (s, e) =
-          pp f "@[<hov2>%s@ =@ %a@]" s.txt (expression ctxt) e
+          pp f "@[<hov2>%a@ =@ %a@]" ident_of_name s.txt (expression ctxt) e
         in
         pp f "@[<hov2>{<%a>}@]" (list string_x_expression ~sep:";") l
     | Pexp_letmodule (s, me, e) ->
@@ -850,7 +937,8 @@ and expression ctxt f x =
         pp f "@[<2>let open%s %a in@;%a@]"
           (override o.popen_override)
           (module_expr ctxt) o.popen_expr (expression ctxt) e
-    | Pexp_variant (l, Some eo) -> pp f "@[<2>`%s@;%a@]" l (simple_expr ctxt) eo
+    | Pexp_variant (l, Some eo) ->
+        pp f "@[<2>`%a@;%a@]" ident_of_name l (simple_expr ctxt) eo
     | Pexp_letop { let_; ands; body } ->
         pp f "@[<2>@[<v>%a@,%a@] in@;<1 -2>%a@]" (binding_op ctxt) let_
           (list ~sep:"@," (binding_op ctxt))
@@ -858,35 +946,6 @@ and expression ctxt f x =
     | Pexp_extension e -> extension ctxt f e
     | Pexp_unreachable -> pp f "."
     | _ -> expression1 ctxt f x
-
-and function_param ctxt f param =
-  match param.pparam_desc with
-  | Pparam_val (a, b, c) -> label_exp ctxt f (a, b, c)
-  | Pparam_newtype ty -> pp f "(type %a)@;" protect_ident ty.txt
-
-and function_body ctxt f function_body =
-  match function_body with
-  | Pfunction_body body -> expression ctxt f body
-  | Pfunction_cases (cases, _, attrs) ->
-      pp f "@[<hv>function%a%a@]" (item_attributes ctxt) attrs (case_list ctxt)
-        cases
-
-and type_constraint ctxt f constraint_ =
-  match constraint_ with
-  | Pconstraint ty -> pp f ":@;%a" (core_type ctxt) ty
-  | Pcoerce (ty1, ty2) ->
-      pp f "%a:>@;%a"
-        (option ~first:":@;" (core_type ctxt))
-        ty1 (core_type ctxt) ty2
-
-and function_params_then_body ctxt f params constraint_ body ~delimiter =
-  pp f "%a%a%s@;%a"
-    (list (function_param ctxt) ~sep:"")
-    params
-    (option (type_constraint ctxt))
-    constraint_ delimiter
-    (function_body (under_functionrhs ctxt))
-    body
 
 and expression1 ctxt f x =
   if x.pexp_attributes <> [] then expression ctxt f x
@@ -901,8 +960,9 @@ and expression2 ctxt f x =
   else
     match x.pexp_desc with
     | Pexp_field (e, li) ->
-        pp f "@[<hov2>%a.%a@]" (simple_expr ctxt) e longident_loc li
-    | Pexp_send (e, s) -> pp f "@[<hov2>%a#%s@]" (simple_expr ctxt) e s.txt
+        pp f "@[<hov2>%a.%a@]" (simple_expr ctxt) e value_longident_loc li
+    | Pexp_send (e, s) ->
+        pp f "@[<hov2>%a#%a@]" (simple_expr ctxt) e ident_of_name s.txt
     | _ -> simple_expr ctxt f x
 
 and simple_expr ctxt f x =
@@ -913,13 +973,15 @@ and simple_expr ctxt f x =
         match view_expr x with
         | `nil -> pp f "[]"
         | `tuple -> pp f "()"
+        | `btrue -> pp f "true"
+        | `bfalse -> pp f "false"
         | `list xs ->
             pp f "@[<hv0>[%a]@]"
               (list (expression (under_semi ctxt)) ~sep:";@;")
               xs
-        | `simple x -> longident f x
+        | `simple x -> constr f x
         | _ -> assert false)
-    | Pexp_ident li -> longident_loc f li
+    | Pexp_ident li -> value_longident_loc f li
     (* (match view_fixity_of_exp x with *)
     (* |`Normal -> longident_loc f li *)
     (* | `Prefix _ | `Infix _ -> pp f "( %a )" longident_loc li) *)
@@ -932,18 +994,18 @@ and simple_expr ctxt f x =
     | Pexp_coerce (e, cto1, ct) ->
         pp f "(%a%a :> %a)" (expression ctxt) e
           (option (core_type ctxt) ~first:" : " ~last:" ")
-          cto1
-          (* no sep hint*) (core_type ctxt)
-          ct
-    | Pexp_variant (l, None) -> pp f "`%s" l
+          cto1 (* no sep hint*)
+          (core_type ctxt) ct
+    | Pexp_variant (l, None) -> pp f "`%a" ident_of_name l
     | Pexp_record (l, eo) ->
         let longident_x_expression f (li, e) =
           match e with
           | { pexp_desc = Pexp_ident { txt; _ }; pexp_attributes = []; _ }
             when li.txt = txt ->
-              pp f "@[<hov2>%a@]" longident_loc li
+              pp f "@[<hov2>%a@]" value_longident_loc li
           | _ ->
-              pp f "@[<hov2>%a@;=@;%a@]" longident_loc li (simple_expr ctxt) e
+              pp f "@[<hov2>%a@;=@;%a@]" value_longident_loc li
+                (simple_expr ctxt) e
         in
         pp f "@[<hv0>@[<hv2>{@;%a%a@]@;}@]" (* "@[<hov2>{%a%a}@]" *)
           (option ~last:" with@;" (simple_expr ctxt))
@@ -1003,11 +1065,13 @@ and class_type_field ctxt f x =
       pp f "@[<2>inherit@ %a@]%a" (class_type ctxt) ct (item_attributes ctxt)
         x.pctf_attributes
   | Pctf_val (s, mf, vf, ct) ->
-      pp f "@[<2>val @ %a%a%s@ :@ %a@]%a" mutable_flag mf virtual_flag vf s.txt
-        (core_type ctxt) ct (item_attributes ctxt) x.pctf_attributes
+      pp f "@[<2>val @ %a%a%a@ :@ %a@]%a" mutable_flag mf virtual_flag vf
+        ident_of_name s.txt (core_type ctxt) ct (item_attributes ctxt)
+        x.pctf_attributes
   | Pctf_method (s, pf, vf, ct) ->
-      pp f "@[<2>method %a %a%s :@;%a@]%a" private_flag pf virtual_flag vf s.txt
-        (core_type ctxt) ct (item_attributes ctxt) x.pctf_attributes
+      pp f "@[<2>method %a %a%a :@;%a@]%a" private_flag pf virtual_flag vf
+        ident_of_name s.txt (core_type ctxt) ct (item_attributes ctxt)
+        x.pctf_attributes
   | Pctf_constraint (ct1, ct2) ->
       pp f "@[<2>constraint@ %a@ =@ %a@]%a" (core_type ctxt) ct1
         (core_type ctxt) ct2 (item_attributes ctxt) x.pctf_attributes
@@ -1037,7 +1101,7 @@ and class_type ctxt f x =
           match l with
           | [] -> ()
           | _ -> pp f "[%a]@ " (list (core_type ctxt) ~sep:",") l)
-        l longident_loc li (attributes ctxt) x.pcty_attributes
+        l (with_loc type_longident) li (attributes ctxt) x.pcty_attributes
   | Pcty_arrow (l, co, cl) ->
       pp f "@[<2>%a@;->@;%a@]" (* FIXME remove parens later *)
         (type_with_label ctxt) (l, co) (class_type ctxt) cl
@@ -1047,14 +1111,14 @@ and class_type ctxt f x =
   | Pcty_open (o, e) ->
       pp f "@[<2>let open%s %a in@;%a@]"
         (override o.popen_override)
-        longident_loc o.popen_expr (class_type ctxt) e
+        value_longident_loc o.popen_expr (class_type ctxt) e
 
 (* [class type a = object end] *)
 and class_type_declaration_list ctxt f l =
   let class_type_declaration kwd f x =
     let { pci_params = ls; pci_name = { txt; _ }; _ } = x in
-    pp f "@[<2>%s %a%a%s@ =@ %a@]%a" kwd virtual_flag x.pci_virt
-      (class_params_def ctxt) ls txt (class_type ctxt) x.pci_expr
+    pp f "@[<2>%s %a%a%a@ =@ %a@]%a" kwd virtual_flag x.pci_virt
+      (class_params_def ctxt) ls ident_of_name txt (class_type ctxt) x.pci_expr
       (item_attributes ctxt) x.pci_attributes
   in
   match l with
@@ -1072,16 +1136,19 @@ and class_field ctxt f x =
   | Pcf_inherit (ovf, ce, so) ->
       pp f "@[<2>inherit@ %s@ %a%a@]%a" (override ovf) (class_expr ctxt) ce
         (fun f so ->
-          match so with None -> () | Some s -> pp f "@ as %s" s.txt)
+          match so with
+          | None -> ()
+          | Some s -> pp f "@ as %a" ident_of_name s.txt)
         so (item_attributes ctxt) x.pcf_attributes
   | Pcf_val (s, mf, Cfk_concrete (ovf, e)) ->
-      pp f "@[<2>val%s %a%s =@;%a@]%a" (override ovf) mutable_flag mf s.txt
-        (expression ctxt) e (item_attributes ctxt) x.pcf_attributes
+      pp f "@[<2>val%s %a%a =@;%a@]%a" (override ovf) mutable_flag mf
+        ident_of_name s.txt (expression ctxt) e (item_attributes ctxt)
+        x.pcf_attributes
   | Pcf_method (s, pf, Cfk_virtual ct) ->
-      pp f "@[<2>method virtual %a %s :@;%a@]%a" private_flag pf s.txt
-        (core_type ctxt) ct (item_attributes ctxt) x.pcf_attributes
+      pp f "@[<2>method virtual %a %a :@;%a@]%a" private_flag pf ident_of_name
+        s.txt (core_type ctxt) ct (item_attributes ctxt) x.pcf_attributes
   | Pcf_val (s, mf, Cfk_virtual ct) ->
-      pp f "@[<2>val virtual %a%s :@ %a@]%a" mutable_flag mf s.txt
+      pp f "@[<2>val virtual %a%a :@ %a@]%a" mutable_flag mf ident_of_name s.txt
         (core_type ctxt) ct (item_attributes ctxt) x.pcf_attributes
   | Pcf_method (s, pf, Cfk_concrete (ovf, e)) ->
       let bind e =
@@ -1095,15 +1162,16 @@ and class_field ctxt f x =
                 ppat_attributes = [];
               };
             pvb_expr = e;
+            pvb_constraint = None;
             pvb_attributes = [];
             pvb_loc = Location.none;
-            pvb_constraint = None;
           }
       in
       pp f "@[<2>method%s %a%a@]%a" (override ovf) private_flag pf
         (fun f -> function
           | { pexp_desc = Pexp_poly (e, Some ct); pexp_attributes = []; _ } ->
-              pp f "%s :@;%a=@;%a" s.txt (core_type ctxt) ct (expression ctxt) e
+              pp f "%a :@;%a=@;%a" ident_of_name s.txt (core_type ctxt) ct
+                (expression ctxt) e
           | { pexp_desc = Pexp_poly (e, None); pexp_attributes = []; _ } ->
               bind e
           | _ -> bind e)
@@ -1152,14 +1220,14 @@ and class_expr ctxt f x =
         pp f "%a%a"
           (fun f l ->
             if l <> [] then pp f "[%a]@ " (list (core_type ctxt) ~sep:",") l)
-          l longident_loc li
+          l (with_loc type_longident) li
     | Pcl_constraint (ce, ct) ->
         pp f "(%a@ :@ %a)" (class_expr ctxt) ce (class_type ctxt) ct
     | Pcl_extension e -> extension ctxt f e
     | Pcl_open (o, e) ->
         pp f "@[<2>let open%s %a in@;%a@]"
           (override o.popen_override)
-          longident_loc o.popen_expr (class_expr ctxt) e
+          value_longident_loc o.popen_expr (class_expr ctxt) e
 
 and module_type ctxt f x =
   if x.pmty_attributes <> [] then
@@ -1169,15 +1237,15 @@ and module_type ctxt f x =
   else
     match x.pmty_desc with
     | Pmty_functor (Unit, mt2) ->
-        pp f "@[<hov2>functor () ->@ %a@]" (module_type ctxt) mt2
+        pp f "@[<hov2>() ->@ %a@]" (module_type ctxt) mt2
     | Pmty_functor (Named (s, mt1), mt2) -> (
         match s.txt with
         | None ->
             pp f "@[<hov2>%a@ ->@ %a@]" (module_type1 ctxt) mt1
               (module_type ctxt) mt2
         | Some name ->
-            pp f "@[<hov2>functor@ (%s@ :@ %a)@ ->@ %a@]" name
-              (module_type ctxt) mt1 (module_type ctxt) mt2)
+            pp f "@[<hov2>(%s@ :@ %a)@ ->@ %a@]" name (module_type ctxt) mt1
+              (module_type ctxt) mt2)
     | Pmty_with (mt, []) -> module_type ctxt f mt
     | Pmty_with (mt, l) ->
         pp f "@[<hov2>%a@ with@ %a@]" (module_type1 ctxt) mt
@@ -1187,35 +1255,32 @@ and module_type ctxt f x =
 
 and with_constraint ctxt f = function
   | Pwith_type (li, ({ ptype_params = ls; _ } as td)) ->
-      let ls = List.map fst ls in
-      pp f "type@ %a %a =@ %a"
-        (list (core_type ctxt) ~sep:"," ~first:"(" ~last:")")
-        ls longident_loc li (type_declaration ctxt) td
+      pp f "type@ %a %a =@ %a" (type_params ctxt) ls (with_loc type_longident)
+        li (type_declaration ctxt) td
   | Pwith_module (li, li2) ->
-      pp f "module %a =@ %a" longident_loc li longident_loc li2
+      pp f "module %a =@ %a" value_longident_loc li value_longident_loc li2
   | Pwith_modtype (li, mty) ->
-      pp f "module type %a =@ %a" longident_loc li (module_type ctxt) mty
+      pp f "module type %a =@ %a" (with_loc type_longident) li
+        (module_type ctxt) mty
   | Pwith_typesubst (li, ({ ptype_params = ls; _ } as td)) ->
-      let ls = List.map fst ls in
-      pp f "type@ %a %a :=@ %a"
-        (list (core_type ctxt) ~sep:"," ~first:"(" ~last:")")
-        ls longident_loc li (type_declaration ctxt) td
+      pp f "type@ %a %a :=@ %a" (type_params ctxt) ls (with_loc type_longident)
+        li (type_declaration ctxt) td
   | Pwith_modsubst (li, li2) ->
-      pp f "module %a :=@ %a" longident_loc li longident_loc li2
+      pp f "module %a :=@ %a" value_longident_loc li value_longident_loc li2
   | Pwith_modtypesubst (li, mty) ->
-      pp f "module type %a :=@ %a" longident_loc li (module_type ctxt) mty
+      pp f "module type %a :=@ %a" (with_loc type_longident) li
+        (module_type ctxt) mty
 
 and module_type1 ctxt f x =
   if x.pmty_attributes <> [] then module_type ctxt f x
   else
     match x.pmty_desc with
-    | Pmty_ident li -> pp f "%a" longident_loc li
-    | Pmty_alias li -> pp f "(module %a)" longident_loc li
+    | Pmty_ident li -> pp f "%a" (with_loc type_longident) li
+    | Pmty_alias li -> pp f "(module %a)" (with_loc type_longident) li
     | Pmty_signature s ->
         pp f "@[<hv0>@[<hv2>sig@ %a@]@ end@]" (* "@[<hov>sig@ %a@ end@]" *)
           (list (signature_item ctxt))
-          s
-        (* FIXME wrong indentation*)
+          s (* FIXME wrong indentation*)
     | Pmty_typeof me ->
         pp f "@[<hov2>module@ type@ of@ %a@]" (module_expr ctxt) me
     | Pmty_extension e -> extension ctxt f e
@@ -1233,16 +1298,16 @@ and signature_item ctxt f x : unit =
       type_def_list ctxt f (Recursive, false, l)
   | Psig_value vd ->
       let intro = if vd.pval_prim = [] then "val" else "external" in
-      pp f "@[<2>%s@ %a@ :@ %a@]%a" intro protect_ident vd.pval_name.txt
+      pp f "@[<2>%s@ %a@ :@ %a@]%a" intro ident_of_name vd.pval_name.txt
         (value_description ctxt) vd (item_attributes ctxt) vd.pval_attributes
   | Psig_typext te -> type_extension ctxt f te
   | Psig_exception ed -> exception_declaration ctxt f ed
   | Psig_class l -> (
       let class_description kwd f
           ({ pci_params = ls; pci_name = { txt; _ }; _ } as x) =
-        pp f "@[<2>%s %a%a%s@;:@;%a@]%a" kwd virtual_flag x.pci_virt
-          (class_params_def ctxt) ls txt (class_type ctxt) x.pci_expr
-          (item_attributes ctxt) x.pci_attributes
+        pp f "@[<2>%s %a%a%a@;:@;%a@]%a" kwd virtual_flag x.pci_virt
+          (class_params_def ctxt) ls ident_of_name txt (class_type ctxt)
+          x.pci_expr (item_attributes ctxt) x.pci_attributes
       in
       match l with
       | [] -> ()
@@ -1260,24 +1325,25 @@ and signature_item ctxt f x : unit =
        } as pmd) ->
       pp f "@[<hov>module@ %s@ =@ %a@]%a"
         (Option.value pmd.pmd_name.txt ~default:"_")
-        longident_loc alias (item_attributes ctxt) pmd.pmd_attributes
+        value_longident_loc alias (item_attributes ctxt) pmd.pmd_attributes
   | Psig_module pmd ->
       pp f "@[<hov>module@ %s@ :@ %a@]%a"
         (Option.value pmd.pmd_name.txt ~default:"_")
         (module_type ctxt) pmd.pmd_type (item_attributes ctxt)
         pmd.pmd_attributes
   | Psig_modsubst pms ->
-      pp f "@[<hov>module@ %s@ :=@ %a@]%a" pms.pms_name.txt longident_loc
+      pp f "@[<hov>module@ %s@ :=@ %a@]%a" pms.pms_name.txt value_longident_loc
         pms.pms_manifest (item_attributes ctxt) pms.pms_attributes
   | Psig_open od ->
       pp f "@[<hov2>open%s@ %a@]%a"
         (override od.popen_override)
-        longident_loc od.popen_expr (item_attributes ctxt) od.popen_attributes
+        value_longident_loc od.popen_expr (item_attributes ctxt)
+        od.popen_attributes
   | Psig_include incl ->
       pp f "@[<hov2>include@ %a@]%a" (module_type ctxt) incl.pincl_mod
         (item_attributes ctxt) incl.pincl_attributes
   | Psig_modtype { pmtd_name = s; pmtd_type = md; pmtd_attributes = attrs } ->
-      pp f "@[<hov2>module@ type@ %s%a@]%a" s.txt
+      pp f "@[<hov2>module@ type@ %a%a@]%a" ident_of_name s.txt
         (fun f md ->
           match md with
           | None -> ()
@@ -1329,7 +1395,7 @@ and module_expr ctxt f x =
           s
     | Pmod_constraint (me, mt) ->
         pp f "@[<hov2>(%a@ :@ %a)@]" (module_expr ctxt) me (module_type ctxt) mt
-    | Pmod_ident li -> pp f "%a" longident_loc li
+    | Pmod_ident li -> pp f "%a" value_longident_loc li
     | Pmod_functor (Unit, me) -> pp f "functor ()@;->@;%a" (module_expr ctxt) me
     | Pmod_functor (Named (s, mt), me) ->
         pp f "functor@ (%s@ :@ %a)@;->@;%a"
@@ -1364,7 +1430,7 @@ and payload ctxt f = function
       expression ctxt f e
 
 (* transform [f = fun g h -> ..] to [f g h = ... ] could be improved *)
-and binding ctxt f { pvb_pat = p; pvb_expr = x; _ } =
+and binding ctxt f { pvb_pat = p; pvb_expr = x; pvb_constraint = ct; _ } =
   (* .pvb_attributes have already been printed by the caller, #bindings *)
   let rec pp_print_pexp_function f x =
     if x.pexp_attributes <> [] then pp f "=@;%a" (expression ctxt) x
@@ -1373,75 +1439,29 @@ and binding ctxt f { pvb_pat = p; pvb_expr = x; _ } =
       | Pexp_function (params, c, body) ->
           function_params_then_body ctxt f params c body ~delimiter:"="
       | Pexp_newtype (str, e) ->
-          pp f "(type@ %s)@ %a" str.txt pp_print_pexp_function e
+          pp f "(type@ %a)@ %a" ident_of_name str.txt pp_print_pexp_function e
       | _ -> pp f "=@;%a" (expression ctxt) x
   in
-  let tyvars_str tyvars = List.map (fun v -> v.txt) tyvars in
-  let is_desugared_gadt p e =
-    let gadt_pattern =
+  match ct with
+  | Some (Pvc_constraint { locally_abstract_univars = []; typ }) ->
+      pp f "%a@;:@;%a@;=@;%a" (simple_pattern ctxt) p (core_type ctxt) typ
+        (expression ctxt) x
+  | Some (Pvc_constraint { locally_abstract_univars = vars; typ }) ->
+      pp f "%a@;: type@;%a.@;%a@;=@;%a" (simple_pattern ctxt) p
+        (list ident_of_name ~sep:"@;")
+        (List.map (fun x -> x.txt) vars)
+        (core_type ctxt) typ (expression ctxt) x
+  | Some (Pvc_coercion { ground = None; coercion }) ->
+      pp f "%a@;:>@;%a@;=@;%a" (simple_pattern ctxt) p (core_type ctxt) coercion
+        (expression ctxt) x
+  | Some (Pvc_coercion { ground = Some ground; coercion }) ->
+      pp f "%a@;:%a@;:>@;%a@;=@;%a" (simple_pattern ctxt) p (core_type ctxt)
+        ground (core_type ctxt) coercion (expression ctxt) x
+  | None -> (
       match p with
-      | {
-       ppat_desc =
-         Ppat_constraint
-           ( ({ ppat_desc = Ppat_var _ } as pat),
-             { ptyp_desc = Ptyp_poly (args_tyvars, rt) } );
-       ppat_attributes = [];
-      } ->
-          Some (pat, args_tyvars, rt)
-      | _ -> None
-    in
-    let rec gadt_exp tyvars e =
-      match e with
-      | { pexp_desc = Pexp_newtype (tyvar, e); pexp_attributes = [] } ->
-          gadt_exp (tyvar :: tyvars) e
-      | { pexp_desc = Pexp_constraint (e, ct); pexp_attributes = [] } ->
-          Some (List.rev tyvars, e, ct)
-      | _ -> None
-    in
-    let gadt_exp = gadt_exp [] e in
-    match (gadt_pattern, gadt_exp) with
-    | Some (p, pt_tyvars, pt_ct), Some (e_tyvars, e, e_ct)
-      when tyvars_str pt_tyvars = tyvars_str e_tyvars ->
-        let ety = varify_type_constructors e_tyvars e_ct in
-        if ety = pt_ct then Some (p, pt_tyvars, e_ct, e) else None
-    | _ -> None
-  in
-  if x.pexp_attributes <> [] then
-    match p with
-    | {
-     ppat_desc =
-       Ppat_constraint
-         ( ({ ppat_desc = Ppat_var _; _ } as pat),
-           ({ ptyp_desc = Ptyp_poly _; _ } as typ) );
-     ppat_attributes = [];
-     _;
-    } ->
-        pp f "%a@;: %a@;=@;%a" (simple_pattern ctxt) pat (core_type ctxt) typ
-          (expression ctxt) x
-    | _ -> pp f "%a@;=@;%a" (pattern ctxt) p (expression ctxt) x
-  else
-    match is_desugared_gadt p x with
-    | Some (p, [], ct, e) ->
-        pp f "%a@;: %a@;=@;%a" (simple_pattern ctxt) p (core_type ctxt) ct
-          (expression ctxt) e
-    | Some (p, tyvars, ct, e) ->
-        pp f "%a@;: type@;%a.@;%a@;=@;%a" (simple_pattern ctxt) p
-          (list pp_print_string ~sep:"@;")
-          (tyvars_str tyvars) (core_type ctxt) ct (expression ctxt) e
-    | None -> (
-        match p with
-        | { ppat_desc = Ppat_constraint (p, ty); ppat_attributes = [] } -> (
-            (* special case for the first*)
-            match ty with
-            | { ptyp_desc = Ptyp_poly _; ptyp_attributes = [] } ->
-                pp f "%a@;:@;%a@;=@;%a" (simple_pattern ctxt) p (core_type ctxt)
-                  ty (expression ctxt) x
-            | _ ->
-                pp f "(%a@;:@;%a)@;=@;%a" (simple_pattern ctxt) p
-                  (core_type ctxt) ty (expression ctxt) x)
-        | { ppat_desc = Ppat_var _; ppat_attributes = [] } ->
-            pp f "%a@ %a" (simple_pattern ctxt) p pp_print_pexp_function x
-        | _ -> pp f "%a@;=@;%a" (pattern ctxt) p (expression ctxt) x)
+      | { ppat_desc = Ppat_var _; ppat_attributes = [] } ->
+          pp f "%a@ %a" (simple_pattern ctxt) p pp_print_pexp_function x
+      | _ -> pp f "%a@;=@;%a" (pattern ctxt) p (expression ctxt) x)
 
 (* [in] is not printed *)
 and bindings ctxt f (rf, l) =
@@ -1515,7 +1535,7 @@ and structure_item ctxt f x =
         (module_expr ctxt) od.popen_expr (item_attributes ctxt)
         od.popen_attributes
   | Pstr_modtype { pmtd_name = s; pmtd_type = md; pmtd_attributes = attrs } ->
-      pp f "@[<hov2>module@ type@ %s%a@]%a" s.txt
+      pp f "@[<hov2>module@ type@ %a%a@]%a" ident_of_name s.txt
         (fun f md ->
           match md with
           | None -> ()
@@ -1543,8 +1563,8 @@ and structure_item ctxt f x =
       let class_declaration kwd f
           ({ pci_params = ls; pci_name = { txt; _ }; _ } as x) =
         let args, constr, cl = extract_class_args x.pci_expr in
-        pp f "@[<2>%s %a%a%s %a%a=@;%a@]%a" kwd virtual_flag x.pci_virt
-          (class_params_def ctxt) ls txt
+        pp f "@[<2>%s %a%a%a %a%a=@;%a@]%a" kwd virtual_flag x.pci_virt
+          (class_params_def ctxt) ls ident_of_name txt
           (list (label_exp ctxt))
           args (option class_constraint) constr (class_expr ctxt) cl
           (item_attributes ctxt) x.pci_attributes
@@ -1560,7 +1580,7 @@ and structure_item ctxt f x =
             xs)
   | Pstr_class_type l -> class_type_declaration_list ctxt f l
   | Pstr_primitive vd ->
-      pp f "@[<hov2>external@ %a@ :@ %a@]%a" protect_ident vd.pval_name.txt
+      pp f "@[<hov2>external@ %a@ :@ %a@]%a" ident_of_name vd.pval_name.txt
         (value_description ctxt) vd (item_attributes ctxt) vd.pval_attributes
   | Pstr_include incl ->
       pp f "@[<hov2>include@ %a@]%a" (module_expr ctxt) incl.pincl_mod
@@ -1615,8 +1635,8 @@ and type_def_list ctxt f (rf, exported, l) =
       else if exported then " ="
       else " :="
     in
-    pp f "@[<2>%s %a%a%s%s%a@]%a" kwd nonrec_flag rf (type_params ctxt)
-      x.ptype_params x.ptype_name.txt eq (type_declaration ctxt) x
+    pp f "@[<2>%s %a%a%a%s%a@]%a" kwd nonrec_flag rf (type_params ctxt)
+      x.ptype_params ident_of_name x.ptype_name.txt eq (type_declaration ctxt) x
       (item_attributes ctxt) x.ptype_attributes
   in
   match l with
@@ -1629,8 +1649,9 @@ and type_def_list ctxt f (rf, exported, l) =
 
 and record_declaration ctxt f lbls =
   let type_record_field f pld =
-    pp f "@[<2>%a%s:@;%a@;%a@]" mutable_flag pld.pld_mutable pld.pld_name.txt
-      (core_type ctxt) pld.pld_type (attributes ctxt) pld.pld_attributes
+    pp f "@[<2>%a%a:@;%a@;%a@]" mutable_flag pld.pld_mutable ident_of_name
+      pld.pld_name.txt (core_type ctxt) pld.pld_type (attributes ctxt)
+      pld.pld_attributes
   in
   pp f "{@\n%a}" (list type_record_field ~sep:";@\n") lbls
 
@@ -1688,7 +1709,7 @@ and type_extension ctxt f x =
       | [] -> ()
       | l ->
           pp f "%a@;" (list (type_param ctxt) ~first:"(" ~last:")" ~sep:",") l)
-    x.ptyext_params longident_loc x.ptyext_path private_flag
+    x.ptyext_params (with_loc type_longident) x.ptyext_path private_flag
     x.ptyext_private (* Cf: #7200 *)
     (list ~sep:"" extension_constructor)
     x.ptyext_constructors (item_attributes ctxt) x.ptyext_attributes
@@ -1728,7 +1749,7 @@ and extension_constructor ctxt f x =
       constructor_declaration ctxt f
         (x.pext_name.txt, v, l, r, x.pext_attributes)
   | Pext_rebind li ->
-      pp f "%s@;=@;%a%a" x.pext_name.txt longident_loc li (attributes ctxt)
+      pp f "%s@;=@;%a%a" x.pext_name.txt (with_loc constr) li (attributes ctxt)
         x.pext_attributes
 
 and case_list ctxt f l : unit =
@@ -1751,18 +1772,18 @@ and label_x_expression_param ctxt f (l, e) =
   match l with
   | Nolabel -> expression2 ctxt f e (* level 2*)
   | Optional str ->
-      if Some str = simple_name then pp f "?%s" str
-      else pp f "?%s:%a" str (simple_expr ctxt) e
+      if Some str = simple_name then pp f "?%a" ident_of_name str
+      else pp f "?%a:%a" ident_of_name str (simple_expr ctxt) e
   | Labelled lbl ->
-      if Some lbl = simple_name then pp f "~%s" lbl
-      else pp f "~%s:%a" lbl (simple_expr ctxt) e
+      if Some lbl = simple_name then pp f "~%a" ident_of_name lbl
+      else pp f "~%a:%a" ident_of_name lbl (simple_expr ctxt) e
 
 and directive_argument f x =
   match x.pdira_desc with
   | Pdir_string s -> pp f "@ %S" s
   | Pdir_int (n, None) -> pp f "@ %s" n
   | Pdir_int (n, Some m) -> pp f "@ %s%c" n m
-  | Pdir_ident li -> pp f "@ %a" longident li
+  | Pdir_ident li -> pp f "@ %a" value_longident li
   | Pdir_bool b -> pp f "@ %s" (string_of_bool b)
 
 let toplevel_phrase f x =
@@ -1800,15 +1821,18 @@ let core_type = core_type reset_ctxt
 let pattern = pattern reset_ctxt
 let signature = signature reset_ctxt
 let structure = structure reset_ctxt
-let class_expr = class_expr reset_ctxt
-let class_field = class_field reset_ctxt
-let class_type = class_type reset_ctxt
-let class_signature = class_signature reset_ctxt
-let class_type_field = class_type_field reset_ctxt
 let module_expr = module_expr reset_ctxt
 let module_type = module_type reset_ctxt
-let signature_item = signature_item reset_ctxt
+let class_field = class_field reset_ctxt
+let class_type_field = class_type_field reset_ctxt
+let class_expr = class_expr reset_ctxt
+let class_type = class_type reset_ctxt
 let structure_item = structure_item reset_ctxt
-let type_declaration = type_declaration reset_ctxt
+let signature_item = signature_item reset_ctxt
 let binding = binding reset_ctxt
 let payload = payload reset_ctxt
+let longident = value_longident
+
+(* Added for ppxlib *)
+let class_signature = class_signature reset_ctxt
+let type_declaration = type_declaration reset_ctxt


### PR DESCRIPTION
Our local copy of pprintast for 5.3 was patched from the 5.2 version rather than simply copied from the compiler's own.

This updates our `pprintast` copy and adds a short comment documenting the update process.