### PR TITLE
Fix Ast_builder's `value_binding` to generate the correct `pvb_constraint`

### DIFF
--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -30,6 +30,7 @@ astlib/migrate_500_414.ml
 
 # Currently our expect-test lexer is too strict for our expect tests to
 # work well with ocamlformat
+test/ast_builder_value_binding/test.ml
 test/base/test.ml
 test/base/test_510.ml
 test/code_path/test.ml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 unreleased
 ----------
 
+- Make Ast_builder's default `value_binding` constructor generate the proper
+  `pvb_constraint` from the pattern and expression arguments.
+  (#<PR_NUMBER>, @NathanReb)
 - Fix pprintast to output correct syntax from `Ppat_constraint (pat, Ptyp_poly ...)`
   nodes until they are completely dropped. (#588, @NathanReb)
 

--- a/stdppx/stdppx.ml
+++ b/stdppx/stdppx.ml
@@ -275,6 +275,12 @@ module List = struct
 
   (* reorders arguments to improve type inference *)
   let iter list ~f = iter list ~f
+
+  let rec equal ~eq l1 l2 =
+    match (l1, l2) with
+    | [], [] -> true
+    | [], _ :: _ | _ :: _, [] -> false
+    | a1 :: l1, a2 :: l2 -> eq a1 a2 && equal ~eq l1 l2
 end
 
 module Option = struct

--- a/test/ast_builder_value_binding/dune
+++ b/test/ast_builder_value_binding/dune
@@ -1,0 +1,12 @@
+(rule
+ (package ppxlib)
+ (alias runtest)
+ (deps
+  (:test test.ml)
+  (package ppxlib))
+ (action
+  (chdir
+   %{project_root}
+   (progn
+    (run expect-test %{test})
+    (diff? %{test} %{test}.corrected)))))

--- a/test/ast_builder_value_binding/dune
+++ b/test/ast_builder_value_binding/dune
@@ -1,6 +1,10 @@
 (rule
  (package ppxlib)
  (alias runtest)
+ ; #install_printer is not working on older compilers for some reason
+ ; This is fine as this does not need to be tested on older compilers anyway
+ (enabled_if
+  (>= %{ocaml_version} 5.1))
  (deps
   (:test test.ml)
   (package ppxlib))

--- a/test/ast_builder_value_binding/test.ml
+++ b/test/ast_builder_value_binding/test.ml
@@ -1,0 +1,198 @@
+open Ppxlib
+
+(* This file contains tests to ensure that [Ast_builder.value_binding] properly
+   translates the given [pattern] and [expression] pair into the correct
+   [pattern], [expression] and [value_constraint] triple. *)
+
+
+(* ------- Test Setup -------- *)
+
+#install_printer Pp_ast.Default.structure_item;;
+#install_printer Pp_ast.Default.expression;;
+#install_printer Pp_ast.Default.pattern;;
+
+let loc = Location.none
+[%%ignore]
+
+(* --------- Simple case, no translation --------- *)
+
+let pat = [%pat? f]
+let expr = [%expr fun x -> x + 1]
+[%%ignore]
+
+let vb =
+  let open Ast_builder.Default in
+  pstr_value ~loc Nonrecursive [value_binding ~pat ~expr ~loc]
+
+[%%expect{|
+val vb : structure_item =
+  Pstr_value
+    ( Nonrecursive
+    , [ { pvb_pat = Ppat_var "f"
+        ; pvb_expr =
+            Pexp_function
+              ( [ { pparam_loc = __loc
+                  ; pparam_desc = Pparam_val ( Nolabel, None, Ppat_var "x")
+                  }
+                ]
+              , None
+              , Pfunction_body
+                  (Pexp_apply
+                     ( Pexp_ident (Lident "+")
+                     , [ ( Nolabel, Pexp_ident (Lident "x"))
+                       ; ( Nolabel
+                         , Pexp_constant (Pconst_integer ( "1", None))
+                         )
+                       ]
+                     ))
+              )
+        ; pvb_constraint = None
+        ; pvb_attributes = __attrs
+        ; pvb_loc = __loc
+        }
+      ]
+    )
+|}]
+
+(* As expected here, the [pvb_constraint] field is none, the pattern and
+   expression are used as is. *)
+
+(* --------- No var Ppat_constraint to pvb_constraint --------- *)
+
+let pat = [%pat? (x : int)]
+let expr = [%expr 12]
+[%%ignore]
+
+let vb =
+  let open Ast_builder.Default in
+  pstr_value ~loc Nonrecursive [value_binding ~pat ~expr ~loc]
+
+[%%expect{|
+val vb : structure_item =
+  Pstr_value
+    ( Nonrecursive
+    , [ { pvb_pat = Ppat_var "x"
+        ; pvb_expr = Pexp_constant (Pconst_integer ( "12", None))
+        ; pvb_constraint =
+            Some
+              (Pvc_constraint
+                 { locally_abstract_univars = []
+                 ; typ = Ptyp_constr ( Lident "int", [])
+                 })
+        ; pvb_attributes = __attrs
+        ; pvb_loc = __loc
+        }
+      ]
+    )
+|}]
+
+(* --------- poly Ppat_constraint to pvb_constraint --------- *)
+
+let pat =
+  Ast_builder.Default.ppat_constraint ~loc
+    [%pat? f]
+    (Ast_builder.Default.ptyp_poly ~loc
+       [ Loc.make ~loc "a" ]
+       [%type: 'a -> unit])
+
+let expr = [%expr fun x -> unit]
+
+[%%ignore]
+
+let vb =
+  let open Ast_builder.Default in
+  pstr_value ~loc Nonrecursive [value_binding ~pat ~expr ~loc]
+
+[%%expect{|
+val vb : structure_item =
+  Pstr_value
+    ( Nonrecursive
+    , [ { pvb_pat = Ppat_var "f"
+        ; pvb_expr =
+            Pexp_function
+              ( [ { pparam_loc = __loc
+                  ; pparam_desc = Pparam_val ( Nolabel, None, Ppat_var "x")
+                  }
+                ]
+              , None
+              , Pfunction_body (Pexp_ident (Lident "unit"))
+              )
+        ; pvb_constraint =
+            Some
+              (Pvc_constraint
+                 { locally_abstract_univars = []
+                 ; typ =
+                     Ptyp_poly
+                       ( [ "a"]
+                       , Ptyp_arrow
+                           ( Nolabel
+                           , Ptyp_var "a"
+                           , Ptyp_constr ( Lident "unit", [])
+                           )
+                       )
+                 })
+        ; pvb_attributes = __attrs
+        ; pvb_loc = __loc
+        }
+      ]
+    )
+|}]
+
+(* --------- desugared locally abstract univars to pvb_constraint --------- *)
+
+let pat =
+  Ast_builder.Default.ppat_constraint ~loc
+    [%pat? f]
+    (Ast_builder.Default.ptyp_poly ~loc
+       [ Loc.make ~loc "a" ]
+       [%type: 'a -> unit])
+
+let expr = [%expr fun (type a) -> (fun _ -> unit : a -> unit)]
+
+[%%ignore]
+
+let vb =
+  let open Ast_builder.Default in
+  pstr_value ~loc Nonrecursive [value_binding ~pat ~expr ~loc]
+
+[%%expect{|
+val vb : structure_item =
+  Pstr_value
+    ( Nonrecursive
+    , [ { pvb_pat = Ppat_var "f"
+        ; pvb_expr =
+            Pexp_function
+              ( [ { pparam_loc = __loc
+                  ; pparam_desc = Pparam_val ( Nolabel, None, Ppat_any)
+                  }
+                ]
+              , None
+              , Pfunction_body (Pexp_ident (Lident "unit"))
+              )
+        ; pvb_constraint =
+            Some
+              (Pvc_constraint
+                 { locally_abstract_univars = [ "a"]
+                 ; typ =
+                     Ptyp_arrow
+                       ( Nolabel
+                       , Ptyp_constr ( Lident "a", [])
+                       , Ptyp_constr ( Lident "unit", [])
+                       )
+                 })
+        ; pvb_attributes = __attrs
+        ; pvb_loc = __loc
+        }
+      ]
+    )
+|}]
+
+(* As expected here, the matching constraint from the pattern and expression or
+   recombined into a single value constraint with locally abstract univars set
+   correctly. *)
+
+(* --------- coercion to pvb_constraint --------- *)
+
+(*TODO*)
+[%%expect{|
+|}]

--- a/test/pprintast/oldschool-constraints/pprint_ppat_constraint.ml
+++ b/test/pprintast/oldschool-constraints/pprint_ppat_constraint.ml
@@ -12,8 +12,23 @@ let ast =
            [%type: 'a -> unit])
     in
     let expr = [%expr fun _ -> ()] in
+    (* It is important that this is either built using [Latest.value_binding]
+       or assembled manually as [Ast_builder.Defaut.value_binding] will
+       generate a pvb_constraint, entirely defeatin the test's purpose. *)
     [ Ast_builder.Default.Latest.value_binding ~loc ~pat ~expr () ]
   in
   Ast_builder.Default.pstr_value ~loc Nonrecursive vbs
 
-let () = Format.printf "%a\n" Pprintast.structure_item ast
+let print_source () = Format.printf "%a\n" Pprintast.structure_item ast
+let print_ast () = Format.printf "%a\n" Pp_ast.Default.structure_item ast
+
+let () =
+  match Sys.argv with
+  | [| _exec |] -> print_source ()
+  | [| _exec; _flag |] ->
+      print_ast ();
+      Format.printf "------- PRINTED AS -------\n";
+      print_source ()
+  | _ ->
+      Printf.eprintf "Invalid usage!";
+      exit 1

--- a/test/pprintast/oldschool-constraints/pprint_pvb_constraint.ml
+++ b/test/pprintast/oldschool-constraints/pprint_pvb_constraint.ml
@@ -20,4 +20,16 @@ let ast =
   in
   Ast_builder.Default.pstr_value ~loc Nonrecursive vbs
 
-let () = Format.printf "%a\n" Pprintast.structure_item ast
+let print_source () = Format.printf "%a\n" Pprintast.structure_item ast
+let print_ast () = Format.printf "%a\n" Pp_ast.Default.structure_item ast
+
+let () =
+  match Sys.argv with
+  | [| _exec |] -> print_source ()
+  | [| _exec; _flag |] ->
+      print_ast ();
+      Format.printf "------- PRINTED AS -------\n";
+      print_source ()
+  | _ ->
+      Printf.eprintf "Invalid usage!";
+      exit 1

--- a/test/pprintast/oldschool-constraints/run.t
+++ b/test/pprintast/oldschool-constraints/run.t
@@ -5,10 +5,72 @@ constraint in the pvb_constraint field of the value_binding while
 pprint_ppat_constraint encodes it in the pvb_pat field, i.e. the legacy way.
 
 
-  $ ./pprint_pvb_constraint.exe
+  $ ./pprint_pvb_constraint.exe --with-ast
+  Pstr_value
+    ( Nonrecursive
+    , [ { pvb_pat = Ppat_var "f"
+        ; pvb_expr =
+            Pexp_function
+              ( [ { pparam_loc = __loc
+                  ; pparam_desc = Pparam_val ( Nolabel, None, Ppat_any)
+                  }
+                ]
+              , None
+              , Pfunction_body (Pexp_construct ( Lident "()", None))
+              )
+        ; pvb_constraint =
+            Some
+              (Pvc_constraint
+                 { locally_abstract_univars = []
+                 ; typ =
+                     Ptyp_poly
+                       ( [ "a"]
+                       , Ptyp_arrow
+                           ( Nolabel
+                           , Ptyp_var "a"
+                           , Ptyp_constr ( Lident "unit", [])
+                           )
+                       )
+                 })
+        ; pvb_attributes = __attrs
+        ; pvb_loc = __loc
+        }
+      ]
+    )
+  ------- PRINTED AS -------
   let f : 'a . 'a -> unit = fun _ -> ()
 
-  $ ./pprint_ppat_constraint.exe
+  $ ./pprint_ppat_constraint.exe --with-ast
+  Pstr_value
+    ( Nonrecursive
+    , [ { pvb_pat =
+            Ppat_constraint
+              ( Ppat_var "f"
+              , Ptyp_poly
+                  ( [ "a"]
+                  , Ptyp_arrow
+                      ( Nolabel
+                      , Ptyp_var "a"
+                      , Ptyp_constr ( Lident "unit", [])
+                      )
+                  )
+              )
+        ; pvb_expr =
+            Pexp_function
+              ( [ { pparam_loc = __loc
+                  ; pparam_desc = Pparam_val ( Nolabel, None, Ppat_any)
+                  }
+                ]
+              , None
+              , Pfunction_body (Pexp_construct ( Lident "()", None))
+              )
+        ; pvb_constraint = None
+        ; pvb_attributes = __attrs
+        ; pvb_loc = __loc
+        }
+      ]
+    )
+  ------- PRINTED AS -------
   let f : 'a . 'a -> unit = fun _ -> ()
 
 The legacy gets printed the same way as the pvb_constraint version to allow both


### PR DESCRIPTION
I'd like to add some basic tests for this before we merge but it's basically a copy of the code that's handling the same conversion in the 5.0 -> 5.1 migration.