### PR TITLE
Expose Lexer.comments in the Parse module

### DIFF
--- a/ast/import.ml
+++ b/ast/import.ml
@@ -211,4 +211,6 @@ module Parse = struct
   let core_type lexbuf = core_type lexbuf |> Of_ocaml.copy_core_type
   let expression lexbuf = expression lexbuf |> Of_ocaml.copy_expression
   let pattern lexbuf = pattern lexbuf |> Of_ocaml.copy_pattern
+
+  let comments_in_last_parse = comments_in_last_parse
 end

--- a/astlib/parse.ml
+++ b/astlib/parse.ml
@@ -1,1 +1,3 @@
 include Ocaml_common.Parse
+
+let comments_in_last_parse = Ocaml_common.Lexer.comments

--- a/astlib/parse.mli
+++ b/astlib/parse.mli
@@ -20,3 +20,6 @@ val expression : Lexing.lexbuf -> Parsetree.expression
 
 val pattern : Lexing.lexbuf -> Parsetree.pattern
 (** Parse a pattern *)
+
+val comments_in_last_parse : unit -> (string * Location.t) list
+(** Get the comments from the last parse *)


### PR DESCRIPTION
This PR exposes a way to get the comments when parsing things, using the existing function `Lexer.comments`. I renamed it to try and make it clearer that this was mutable state that gets reset every time you parse things.

Testing: have tested in the context of the internal feature I'm writing. I'm relying on CI for testing stability across versions.