### PR TITLE
Expose type equality of `Location.Error.t` between Astlib and Ppxlib.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@ unreleased
 - Allow users to derive code from module bindings and module declarations
   (#576, @patricoferris)
 
+- Expose `Ppxlib.Location.Error.t = Astlib.Location.Error.t` (#593, @ceastlund)
+
 0.36.1 (2025-07-10)
 -------------------
 

--- a/src/location.mli
+++ b/src/location.mli
@@ -59,7 +59,7 @@ module Error : sig
   (** For a detailed explanation on error reporting, refer to the
       {{!"good-practices".handling_errors} relevant} part of the tutorial.*)
 
-  type t
+  type t = Astlib.Location.Error.t
 
   val make : loc:location -> string -> sub:(location * string) list -> t
 


### PR DESCRIPTION
This provides access to some slightly lower level accessors.