### PR TITLE
Add `@@@ppxlib.inline.end`, deprecate `@@@deriving.end`

### DIFF
--- a/src/code_matcher.ml
+++ b/src/code_matcher.ml
@@ -3,13 +3,25 @@ open! Import
 module Format = Stdlib.Format
 module Filename = Stdlib.Filename
 
-(* TODO: make the "deriving." depend on the matching attribute name. *)
+let allow_deriving_end = ref false
+
+(* TODO: make the "deriving." or other prefix depend on the matching attribute name. *)
 let end_marker_sig =
-  Attribute.Floating.declare "deriving.end" Signature_item
+  Attribute.Floating.declare "ppxlib.inline.end" Signature_item
     Ast_pattern.(pstr nil)
     ()
 
 let end_marker_str =
+  Attribute.Floating.declare "ppxlib.inline.end" Structure_item
+    Ast_pattern.(pstr nil)
+    ()
+
+let deprecated_end_marker_sig =
+  Attribute.Floating.declare "deriving.end" Signature_item
+    Ast_pattern.(pstr nil)
+    ()
+
+let deprecated_end_marker_str =
   Attribute.Floating.declare "deriving.end" Structure_item
     Ast_pattern.(pstr nil)
     ()
@@ -24,6 +36,7 @@ module Make (M : sig
 
   val get_loc : t -> Location.t
   val end_marker : (t, unit) Attribute.Floating.t
+  val deprecated_end_marker : (t, unit) Attribute.Floating.t
 
   module Transform (T : T1) : sig
     val apply :
@@ -51,10 +64,27 @@ struct
               [] )
       | x :: l -> (
           match Attribute.Floating.convert_res [ M.end_marker ] x with
-          | Ok None -> loop (x :: acc) l
           | Ok (Some ()) -> Ok (List.rev acc, (M.get_loc x).loc_start)
           | Error e -> Error e
-          | exception Failure _ -> loop (x :: acc) l)
+          | (exception Failure _) | Ok None -> (
+              match
+                Attribute.Floating.convert_res [ M.deprecated_end_marker ] x
+              with
+              | Ok (Some ()) ->
+                  if !allow_deriving_end then
+                    Ok (List.rev acc, (M.get_loc x).loc_start)
+                  else
+                    Error
+                      ( Location.Error.createf ~loc:(M.get_loc x)
+                          "ppxlib: [@@@@@@%s] is deprecated, please use \
+                           [@@@@@@%s]. If you need the deprecated attribute \
+                           temporarily, pass [-allow-deriving-end] to the ppx \
+                           driver)."
+                          (Attribute.Floating.name M.deprecated_end_marker)
+                          (Attribute.Floating.name M.end_marker),
+                        [] )
+              | Error e -> Error e
+              | (exception Failure _) | Ok None -> loop (x :: acc) l))
     in
     loop [] l
 
@@ -170,6 +200,7 @@ module Str = Make (struct
 
   let get_loc x = x.pstr_loc
   let end_marker = end_marker_str
+  let deprecated_end_marker = deprecated_end_marker_str
 
   module Transform (T : T1) = struct
     let apply o = o#structure_item
@@ -188,6 +219,7 @@ module Sig = Make (struct
 
   let get_loc x = x.psig_loc
   let end_marker = end_marker_sig
+  let deprecated_end_marker = deprecated_end_marker_sig
 
   module Transform (T : T1) = struct
     let apply o = o#signature_item

--- a/src/code_matcher.mli
+++ b/src/code_matcher.mli
@@ -39,3 +39,8 @@ val match_signature :
   signature ->
   unit
 (** Same for signatures *)
+
+val allow_deriving_end : bool ref
+(** The legacy attribute [@@@deriving.end] is disabled by default, and
+    superseded by [@@@ppxlib.inline.end]. It can be enabled by setting
+    [allow_deriving_end := true]. See [-allow-deriving-end] in [Driver]. *)

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -1339,6 +1339,9 @@ let shared_args =
     ( "-raise-embedded-errors",
       Arg.Set raise_embedded_errors_flag,
       " Raise the first embedded error found in the processed AST" );
+    ( "-allow-deriving-end",
+      Arg.Set Code_matcher.allow_deriving_end,
+      " Allow the use of [@@@deriving.end] (which is deprecated)." );
   ]
 
 let () =

--- a/test/deriving/inline/example/ppx_deriving_example.ml
+++ b/test/deriving/inline/example/ppx_deriving_example.ml
@@ -13,4 +13,4 @@ include struct
     [%foo]
 end [@@ocaml.doc "@inline"]
 
-[@@@deriving.end]
+[@@@inline.end]

--- a/test/driver/run_as_ppx_rewriter/run.t
+++ b/test/driver/run_as_ppx_rewriter/run.t
@@ -64,6 +64,7 @@ The only possible usage is [extra_args] <infile> <outfile>...
     -cookie NAME=EXPR           Set the cookie NAME to EXPR
     --cookie                    Same as -cookie
     -raise-embedded-errors      Raise the first embedded error found in the processed AST
+    -allow-deriving-end         Allow the use of [@@@deriving.end] (which is deprecated).
     -help                       Display this list of options
     --help                      Display this list of options
   [2]
@@ -86,5 +87,6 @@ The only exception is consulting help
     -cookie NAME=EXPR           Set the cookie NAME to EXPR
     --cookie                    Same as -cookie
     -raise-embedded-errors      Raise the first embedded error found in the processed AST
+    -allow-deriving-end         Allow the use of [@@@deriving.end] (which is deprecated).
     -help                       Display this list of options
     --help                      Display this list of options


### PR DESCRIPTION
Replace `deriving.end` with `inline.end` so the attribute makes more sense in the context of, e.g., `@@expand_inline`. Deprecate the old name for the attribute, with a command-line flag to allow it.