### PR TITLE
Fix broken links in quick_intro.mld

### DIFF
--- a/doc/quick_intro.mld
+++ b/doc/quick_intro.mld
@@ -12,7 +12,7 @@ may be of interest to everyone.
 
 OCaml doesn't have a macro system, that is, there is no official part of the
 OCaml language that will be executed at compile time in order to generate or
-alter the source code. However, OCaml does have an official part of its syntax dedicated to this: {{:https://v3.ocaml.org/manual/extensionnodes.html}extension nodes} and {{:https://v2.ocaml.org/manual/attributes.html}attributes}; both of them introduced in OCaml 4.02. The preprocessing itself, though, is left to external programs,
+alter the source code. However, OCaml does have an official part of its syntax dedicated to this: {{:https://ocaml.org/manual/extensionnodes.html}extension nodes} and {{:https://ocaml.org/manual/attributes.html}attributes}; both of them introduced in OCaml 4.02. The preprocessing itself, though, is left to external programs,
 written by the community and specialised for their own tasks. However, without a
 unification framework, the following issues arise:
 


### PR DESCRIPTION
Links where broken redirected to https://ocaml.org because v3.ocaml.org is not a valid domain any more. Links now point to the current manual.