### PR TITLE
Add remove functions for migration metadata

### DIFF
--- a/astlib/astlib.ml
+++ b/astlib/astlib.ml
@@ -90,6 +90,8 @@ module Compiler_pprintast = struct
   (*IF_NOT_AT_LEAST 414 let module_expr _fmt _t = raise Unavailable *)
 end
 
+module Clean = Clean
+
 let init_error_reporting_style_using_env_vars () =
   Ocaml_common.Compmisc.read_clflags_from_env ()
 (** Adjust the reporting style of error messages to the environment variables OCAML_COLOR and OCAML_ERROR_STYLE. *)

--- a/astlib/clean.ml
+++ b/astlib/clean.ml
@@ -1,0 +1,19 @@
+let remove_ppxlib_migration_from_ast_mapper =
+  let should_keep_attribute (a : Parsetree.attribute) =
+    not (Stdlib0.String.is_prefix ~prefix:"ppxlib.migration" a.attr_name.txt)
+  in
+  let mapper =
+    {
+      Ast_mapper.default_mapper with
+      attributes = (fun _ -> List.filter should_keep_attribute);
+    }
+  in
+  mapper
+
+let remove_migration_attributes_from_str =
+  remove_ppxlib_migration_from_ast_mapper.structure
+    remove_ppxlib_migration_from_ast_mapper
+
+let remove_migration_attributes_from_sig =
+  remove_ppxlib_migration_from_ast_mapper.signature
+    remove_ppxlib_migration_from_ast_mapper

--- a/astlib/clean.mli
+++ b/astlib/clean.mli
@@ -1,0 +1,10 @@
+val remove_migration_attributes_from_str :
+  Parsetree.structure -> Parsetree.structure
+(** [remove_migration_attributes_from_str str] removes any left-over metadata
+    that be in the parsetree after a migration. Most users will not have to
+    worry about applying this function.*)
+
+val remove_migration_attributes_from_sig :
+  Parsetree.signature -> Parsetree.signature
+(** The same as {! remove_migration_attributes_from_str} except for
+    {! Parsetree.signature}. *)

--- a/astlib/stdlib0.ml
+++ b/astlib/stdlib0.ml
@@ -5,3 +5,14 @@ end
 module Option = struct
   let map f o = match o with None -> None | Some v -> Some (f v)
 end
+
+module String = struct
+  let is_prefix t ~prefix =
+    let rec is_prefix_from t ~prefix ~pos ~len =
+      pos >= len
+      || Char.equal (String.get t pos) (String.get prefix pos)
+         && is_prefix_from t ~prefix ~pos:(pos + 1) ~len
+    in
+    String.length t >= String.length prefix
+    && is_prefix_from t ~prefix ~pos:0 ~len:(String.length prefix)
+end

--- a/src/clean.ml
+++ b/src/clean.ml
@@ -1,0 +1,15 @@
+open! Import
+
+let remove_migration_attributes =
+  object
+    inherit Ast_traverse.map
+
+    method! attributes vs =
+      match vs with
+      | [] -> []
+      | vs ->
+          let should_keep_attribute a =
+            not (String.is_prefix ~prefix:"ppxlib.migration" a.attr_name.txt)
+          in
+          List.filter ~f:should_keep_attribute vs
+  end

--- a/src/clean.mli
+++ b/src/clean.mli
@@ -1,0 +1,6 @@
+(** Clean the AST.
+
+    This module provides functions to help clean the AST *)
+
+val remove_migration_attributes : Ast_traverse.map
+(** A map that removes any leftover migration metadata in the AST. *)

--- a/src/ppxlib.ml
+++ b/src/ppxlib.ml
@@ -48,6 +48,7 @@ module Ast_io = Utils.Ast_io.Read_bin
 
 module Attribute = Attribute
 module Reserved_namespaces = Name.Reserved_namespaces
+module Clean = Clean
 
 (** {2 Common helper functions} *)
 

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -310,7 +310,9 @@ let print_as_compiler_source ppf ast =
   match (ast : Intf_or_impl.t) with
   | Intf sg ->
       let sg = Ppxlib_to_compiler.copy_signature sg in
-      Astlib.Compiler_pprintast.signature ppf sg
+      Astlib.Compiler_pprintast.signature ppf
+        (Astlib.Clean.remove_migration_attributes_from_sig sg)
   | Impl st ->
       let st = Ppxlib_to_compiler.copy_structure st in
-      Astlib.Compiler_pprintast.structure ppf st
+      Astlib.Compiler_pprintast.structure ppf
+        (Astlib.Clean.remove_migration_attributes_from_str st)

--- a/test/migrations/driver.ml
+++ b/test/migrations/driver.ml
@@ -1,0 +1,36 @@
+open Ppxlib
+
+module B = Ast_builder.Make (struct
+  let loc = Location.none
+end)
+
+let add_function =
+  let param v = B.pparam_val Nolabel None (B.ppat_var (B.Located.mk v)) in
+  let body =
+    B.pexp_function
+      [ param "b" ]
+      None
+      (Pfunction_body
+         (B.pexp_apply
+            (B.pexp_ident (B.Located.mk (Lident "+")))
+            [
+              (Nolabel, B.pexp_ident (B.Located.lident "a"));
+              (Nolabel, B.pexp_ident (B.Located.lident "b"));
+            ]))
+  in
+  let func = B.pexp_function [ param "a" ] None (Pfunction_body body) in
+  B.pstr_value Nonrecursive
+    [ B.value_binding ~pat:(B.ppat_var (B.Located.mk "f")) ~expr:func ]
+
+let generative_functor =
+  let empty_struct = B.pmod_structure [] in
+  B.pstr_module
+    (B.module_binding ~name:(B.Located.mk (Some "F"))
+       ~expr:(B.pmod_apply (B.pmod_ident (B.Located.lident "F")) empty_struct))
+
+let () =
+  Driver.register_transformation
+    ~impl:(fun impl -> add_function :: generative_functor :: impl)
+    "migrators"
+
+let () = Driver.standalone ()

--- a/test/migrations/dune
+++ b/test/migrations/dune
@@ -1,0 +1,9 @@
+(executable
+ (name driver)
+ (modules driver)
+ (libraries ppxlib))
+
+(cram
+ (enabled_if
+  (< %{ocaml_version} "5.2.0"))
+ (deps driver.exe))

--- a/test/migrations/run.t
+++ b/test/migrations/run.t
@@ -1,0 +1,22 @@
+Ppxlib applies migrations to the AST. In some cases, especially when applying
+downward migrations, extra information must be encoded in the AST in order to
+be able to properly re-encode the AST when migrating back up.
+
+This means that sometimes the extra information is left in the AST especially
+when printing the code as source of the current compiler (where the current
+compiler is less than the internal AST version).
+
+Therefore we must clean the produced AST to remove ppxlib.migration attributes.
+
+  $ touch file.ml
+  $ ./driver.exe file.ml
+  let f a = fun b -> a + b
+  module F = (F)(struct  end)
+
+Now we ensure no attributes are left in the AST after we force a downard
+migration using the --use-compiler-pp flag.
+
+  $ ./driver.exe --use-compiler-pp file.ml
+  let f a b = a + b
+  module F = (F)(struct  end)
+


### PR DESCRIPTION
Functions to help with #597. It is not quite clear to me when/if we should default to calling these except perhaps for the `use_compiler_pp` option.

The main reason for that is that the output of the ppx might be consumed by another ppx like tool (for example ppxlib-pp-ast) which makes use of the internal Ast_io function for re-reading the ppxlib output. Crucially, these functions then re-migrate the code to the internal AST at which point it will _need_ those attributes saved in the original ppxlib output.