### PR TITLE
Remove myself (pitag-ha) as a GH code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ceastlund @NathanReb @panglesd @patricoferris @pitag-ha
+* @ceastlund @NathanReb @panglesd @patricoferris


### PR DESCRIPTION
Heya, as I'm not active on ppxlib anymore, I'm removing myself as a GH code owner, so that I won't automatically be added as a reviewer by GH anymore. I think this is the only place where I was listed as a maintainer. If there are other places, please let me know.

Btw, IMO, we should edit CODE_OF_CONDUCT.md to ask folks to reach out to you, @NathanReb and @patricoferris instead of @panglesd, @ceastlund  and me in the very unlikely event that there's a code of conduct violation to report. Does that sound good to you?