### PR TITLE
Fixes for dune package management CI

### DIFF
--- a/test/driver/exception_handling/run.t
+++ b/test/driver/exception_handling/run.t
@@ -121,6 +121,7 @@ when the -embed-errors flag is not passed
   File "impl.ml", line 3, characters 0-47:
   Error: A raised located error
   [1]
+
  when the -embed-errors flag is passed 
   $ ./deriver.exe -embed-errors impl.ml
   let x = 1 + 1.


### PR DESCRIPTION
It seems that some change has been introduced in the dune released for dune package management that requires a space between the cram-like tests. Regardless, it is a change that I think makes the test more readable and hopefully will help get our CI green :)