### PR TITLE
Bump sexplib0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -17,8 +17,7 @@
   (ocaml (and (and (>= 4.08.0) (< 5.7.0))))
   (ocaml-compiler-libs (>= v0.11.0))
   (ppx_derivers (>= 1.0))
-  (sexplib0 (>= v0.12))
-  (sexplib0 (and :with-test (>= "v0.15"))) ; Printexc.register_printer in sexplib0 changed
+  (sexplib0 (>= "v0.15"))
   (ocamlfind :with-test)
   (re (and :with-test (>= 1.9.0)))
   (cinaps (and :with-test (>= v0.12.1)))

--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -24,8 +24,7 @@ depends: [
   "ocaml" {>= "4.08.0" & < "5.7.0"}
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ppx_derivers" {>= "1.0"}
-  "sexplib0" {>= "v0.12"}
-  "sexplib0" {with-test & >= "v0.15"}
+  "sexplib0" {>= "v0.15"}
   "ocamlfind" {with-test}
   "re" {with-test & >= "1.9.0"}
   "cinaps" {with-test & >= "v0.12.1"}


### PR DESCRIPTION
Our OCaml lower-bound is already 4.08.

With newer versions of dune, we are getting the following warning.

```
File "dune-project", line 21, characters 2-42:
21 |   (sexplib0 (and :with-test (>= "v0.15"))) ; Printexc.register_printer in sexplib0 changed
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Warning: Duplicate dependency on package (sexplib0 (and :with-test (>=
v0.15))) in 'depends' field. If you want to specify multiple constraints,
combine them using (and ...).
Hint: To disable this warning, add the following to your dune-project file:
(warnings (duplicate_deps disabled))
```

We could do as it says (and be forced to bump our `dune lang` to `3.18`). But actually, we can safely bump our own "normal" (i.e. not with-test) dependency of sexplib0 all the way to `v0.15` as our lower-bound on ocaml is 4.08.