### PR TITLE
remove stdlib-shims

### DIFF
--- a/ast/dune
+++ b/ast/dune
@@ -5,7 +5,7 @@
 (library
  (name ppxlib_ast)
  (public_name ppxlib.ast)
- (libraries astlib stdlib-shims)
+ (libraries astlib)
  (flags
   (:standard -safe-string)
   -w

--- a/dune-project
+++ b/dune-project
@@ -19,7 +19,6 @@
   (ppx_derivers (>= 1.0))
   (sexplib0 (>= v0.12))
   (sexplib0 (and :with-test (>= "v0.15"))) ; Printexc.register_printer in sexplib0 changed
-  stdlib-shims
   (ocamlfind :with-test)
   (re (and :with-test (>= 1.9.0)))
   (cinaps (and :with-test (>= v0.12.1)))

--- a/metaquot_lifters/dune
+++ b/metaquot_lifters/dune
@@ -3,4 +3,4 @@
  (public_name ppxlib.metaquot_lifters)
  (flags
   (:standard -safe-string))
- (libraries ppxlib ppxlib_traverse_builtins stdppx stdlib-shims))
+ (libraries ppxlib ppxlib_traverse_builtins stdppx))

--- a/ppxlib.opam
+++ b/ppxlib.opam
@@ -26,7 +26,6 @@ depends: [
   "ppx_derivers" {>= "1.0"}
   "sexplib0" {>= "v0.12"}
   "sexplib0" {with-test & >= "v0.15"}
-  "stdlib-shims"
   "ocamlfind" {with-test}
   "re" {with-test & >= "1.9.0"}
   "cinaps" {with-test & >= "v0.12.1"}

--- a/src/dune
+++ b/src/dune
@@ -9,7 +9,6 @@
   ppx_derivers
   ppxlib_traverse_builtins
   stdppx
-  stdlib-shims
   sexplib0
   compiler-libs.common)
  (flags

--- a/src/gen/dune
+++ b/src/gen/dune
@@ -2,4 +2,4 @@
  (names gen_ast_pattern gen_ast_builder)
  (flags
   (:standard -safe-string))
- (libraries ppxlib_ast astlib ppxlib_traverse_builtins stdppx stdlib-shims))
+ (libraries ppxlib_ast astlib ppxlib_traverse_builtins stdppx))

--- a/stdppx/dune
+++ b/stdppx/dune
@@ -1,6 +1,6 @@
 (library
  (name stdppx)
  (public_name ppxlib.stdppx)
- (libraries sexplib0 stdlib-shims)
+ (libraries sexplib0)
  (flags
   (:standard -safe-string)))

--- a/traverse/dune
+++ b/traverse/dune
@@ -4,6 +4,6 @@
  (kind ppx_deriver)
  (flags
   (:standard -safe-string))
- (libraries ppxlib ppxlib_ast ppxlib_traverse_builtins stdppx stdlib-shims)
+ (libraries ppxlib ppxlib_ast ppxlib_traverse_builtins stdppx)
  (preprocess
   (pps ppxlib_metaquot)))


### PR DESCRIPTION
stdlib-shims is only needed for OCaml <= 4.07, but the minimum version supported by ppxlib is already 4.08.

Tested on a 4.08.1 and a 5.4.1 switch.