### PR TITLE
Fix `Ast_builder.Default.pexp_apply` duplicating attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 unreleased
 ----------
 
+- Fix a bug in `Ast_builder.Default.pexp_apply` where it would duplicate
+  attributes and mess up the locations. (#643. @Skepfyr)
+
 0.38.0
 ------
 

--- a/src/ast_builder.ml
+++ b/src/ast_builder.ml
@@ -300,8 +300,8 @@ module Default = struct
   let pexp_apply ~loc e el =
     match (e, el) with
     | _, [] -> e
-    | { pexp_desc = Pexp_apply (e, args); pexp_attributes = []; _ }, _ ->
-        { e with pexp_desc = Pexp_apply (e, args @ el) }
+    | { pexp_desc = Pexp_apply (func, args); pexp_attributes = []; _ }, _ ->
+        { e with pexp_desc = Pexp_apply (func, args @ el) }
     | _ -> pexp_apply ~loc e el
 
   let eapply ~loc e el =

--- a/test/ast_builder_pexp_apply/dune
+++ b/test/ast_builder_pexp_apply/dune
@@ -1,0 +1,16 @@
+(rule
+ (package ppxlib)
+ (alias runtest)
+ ; #install_printer is not working on older compilers for some reason
+ ; This is fine as this does not need to be tested on older compilers anyway
+ (enabled_if
+  (>= %{ocaml_version} 5.1))
+ (deps
+  (:test test.ml)
+  (package ppxlib))
+ (action
+  (chdir
+   %{project_root}
+   (progn
+    (run expect-test %{test})
+    (diff? %{test} %{test}.corrected)))))

--- a/test/ast_builder_pexp_apply/test.ml
+++ b/test/ast_builder_pexp_apply/test.ml
@@ -12,5 +12,5 @@ let _ =
   Pprintast.string_of_expression expr
 
 [%%expect{|
-- : string = "((((f)[@attr once]) x y)[@attr once])"
+- : string = "((f)[@attr once]) x y"
 |}]

--- a/test/ast_builder_pexp_apply/test.ml
+++ b/test/ast_builder_pexp_apply/test.ml
@@ -1,0 +1,16 @@
+open Ppxlib
+
+let loc = Location.none
+[%%ignore]
+
+(* Testing attribute propagation. *)
+let _ =
+  let expr =
+    Ast_builder.Default.pexp_apply ~loc [%expr (f [@attr once]) x]
+      [ (Nolabel, [%expr y]) ]
+  in
+  Pprintast.string_of_expression expr
+
+[%%expect{|
+- : string = "((((f)[@attr once]) x y)[@attr once])"
+|}]


### PR DESCRIPTION
Fix a simple bug in pexp_apply where it would use the wrong expression as the base meaning it would duplicate attributes and get the locations wrong.