### PR TITLE
Remove extra copy_module_type from pmty_with migration from 504 to 503

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ unreleased
 
 - Add support for OCaml 5.6 primitive aliases (#642, @NathanReb)
 
+- Remove reduntant module type copy from migrate_504_503, preventing
+  exponential blowup with many "with" constraints. (#644, @smuenzel)
+
 0.38.0
 ------
 

--- a/astlib/migrate_504_503.ml
+++ b/astlib/migrate_504_503.ml
@@ -800,7 +800,7 @@ and copy_module_type_desc_with_loc ~loc :
       in
       if contains_bivariant then
         Encoding_504.To_503.encode_bivariant_pmty_with ~loc mty constraints
-      else Ast_503.Parsetree.Pmty_with (copy_module_type x0, constraints)
+      else Ast_503.Parsetree.Pmty_with (mty, constraints)
   | Ast_504.Parsetree.Pmty_typeof x0 ->
       Ast_503.Parsetree.Pmty_typeof (copy_module_expr x0)
   | Ast_504.Parsetree.Pmty_extension x0 ->


### PR DESCRIPTION
In `astlib/migrate_504_503.ml`, when migrating `Pmty_with`, the module type is copied twice. 

This can be especially bad with many nested `with` constraints, such as https://github.com/janestreet/base/blob/259754a4a8601a1c59a9dcf2baf008e2a90d54fd/src/import0.ml#L5-L42, seemingly leading to a double copying at every constraint.

This error was found with claude code.